### PR TITLE
Test on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: c
+matrix:
+  include:
+    # Access more recent gcc and clang via a Trusty image
+    - os: linux
+      dist: trusty
+      compiler: gcc
+    - os: linux
+      dist: trusty
+      compiler: clang
+    - os: osx
+      compiler: gcc
+    - os: osx
+      compiler: clang
+script:
+  - make CFLAGS='-Werror'
+  - make CFLAGS='-Wall -Wextra -Werror'

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,7 @@ VERSION = 0.6
 PREFIX = /usr/local
 MANPREFIX = $(PREFIX)/man
 
-#CPPFLAGS = -DDEBUG
-#CFLAGS = -g
-CFLAGS = -O3 -march=native
+CFLAGS += -O3 -march=native
 LDLIBS = -lcurses
 
 DISTFILES = nnn.c config.def.h nnn.1 Makefile README.md LICENSE
@@ -21,8 +19,8 @@ $(LOCALCONFIG): config.def.h
 $(SRC): $(LOCALCONFIG)
 
 $(BIN): $(SRC)
-	$(CC) $(CFLAGS) -o $@ $(SRC) $(LDFLAGS) $(LDLIBS)
-	strip $(BIN)
+	$(CC) $(CFLAGS) $(CPPFLAGS) -o $@ $^ $(LDFLAGS) $(LDLIBS)
+	strip $@
 
 install: all
 	mkdir -p $(DESTDIR)$(PREFIX)/bin


### PR DESCRIPTION
This PR sets up Travis testing on Ubuntu Trusty and macOS, with gcc and clang on both platforms. Warnings are turned into errors. See https://travis-ci.org/zmwangx/nnn/builds/218196438 for instance.

Notes:
1. I'm using the Trusty image because the Precise image comes with GCC 4.6.3, and the error messages are just abysmal.
2. Travis's macOS infrastructure is not big enough to handle its demand in real time, so there are crazy backlogs on workdays that IIRC are usually only cleared past midnight (in the U.S.). See https://www.traviscistatus.com/.