### PR TITLE
.travis.yml: bring back -Werror

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,6 @@ matrix:
     - os: osx
       compiler: clang
 script:
+  - export CFLAGS=-Werror
   - make clean
   - make


### PR DESCRIPTION
Convert warnings to errors on CI, or they'll go unnoticed.