### PR TITLE
Makefile: use libncurses instead of libncursesw on Darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,11 @@ PREFIX = /usr/local
 MANPREFIX = $(PREFIX)/share/man
 
 CFLAGS += -O3 -march=native -Wall -Wextra -Wno-unused-parameter
-LDLIBS = -lncursesw
+ifeq ($(shell uname), Darwin)
+  LDLIBS = -lncurses
+else
+  LDLIBS = -lncursesw
+endif
 
 DISTFILES = nnn.c config.def.h nnn.1 Makefile README.md LICENSE
 LOCALCONFIG = config.h

--- a/Makefile.generic
+++ b/Makefile.generic
@@ -4,7 +4,11 @@ PREFIX = /usr/local
 MANPREFIX = $(PREFIX)/share/man
 
 CFLAGS += -O2 -Wall -Wextra -Wno-unused-parameter
-LDLIBS = -lncursesw
+ifeq ($(shell uname), Darwin)
+  LDLIBS = -lncurses
+else
+  LDLIBS = -lncursesw
+endif
 
 DISTFILES = nnn.c config.def.h nnn.1 Makefile README.md LICENSE
 LOCALCONFIG = config.h


### PR DESCRIPTION
macOS 10.12.4 and many earlier versions have libncurses 5.4 with wide character support, but not libncursesw.