### PR TITLE
Add definition of PATH_MAX on GNU/Hurd

### DIFF
--- a/nnn.c
+++ b/nnn.c
@@ -13,6 +13,9 @@
 #include <fcntl.h>
 #include <grp.h>
 #include <limits.h>
+#ifdef __gnu_hurd__
+#define PATH_MAX 4096
+#endif
 #include <locale.h>
 #include <pwd.h>
 #include <regex.h>


### PR DESCRIPTION
MAX_PATH is not defined in some platforms, most notably GNU/Hurd. Therefore, I define it here to some constant.