### PR TITLE
include sys/types.h for non-glibc linux builds

### DIFF
--- a/nnn.c
+++ b/nnn.c
@@ -23,6 +23,9 @@
 #endif
 #include <sys/inotify.h>
 #define LINUX_INOTIFY
+#if !defined(__GLIBC__)
+#include <sys/types.h>
+#endif
 #endif
 #include <sys/resource.h>
 #include <sys/stat.h>


### PR DESCRIPTION
Fixes builds on musl-based systems.

resolves #45 