### PR TITLE
Use temporary file name to avoid race condition

### DIFF
--- a/scripts/quitcd/quitcd.bash
+++ b/scripts/quitcd/quitcd.bash
@@ -1,4 +1,4 @@
-export NNN_TMPFILE="/tmp/nnn"
+export NNN_TMPFILE="$(mktemp -u nnn.XXXXXXXX)"
 
 n()
 {

--- a/scripts/quitcd/quitcd.bash
+++ b/scripts/quitcd/quitcd.bash
@@ -1,7 +1,7 @@
-export NNN_TMPFILE="$(mktemp -u nnn.XXXXXXXX)"
-
 n()
 {
+        export NNN_TMPFILE="$(mktemp -u nnn.XXXXXXXX)"
+
         nnn "$@"
 
         if [ -f $NNN_TMPFILE ]; then


### PR DESCRIPTION
In quitcd.bash, use mktemp to make a filename, rather than hardcoding '/tmp/nnn'.