### PR TITLE
OpenBSD compatibility support

### DIFF
--- a/nnn.c
+++ b/nnn.c
@@ -2893,7 +2893,7 @@ main(int argc, char *argv[])
 	}
 
 	gtimeout.tv_sec = 0;
-	gtimeout.tv_nsec = 50; /* 50 ns delay */
+	gtimeout.tv_nsec = 0;
 #endif
 
 	/* Parse bookmarks string, if available */

--- a/nnn.c
+++ b/nnn.c
@@ -2122,7 +2122,11 @@ begin:
 		inotify_wd = inotify_add_watch(inotify_fd, path, INOTIFY_MASK);
 #elif defined(BSD_KQUEUE)
 	if (event_fd == -1) {
+#if defined(O_EVTONLY)
 		event_fd = open(path, O_EVTONLY);
+#else
+		event_fd = open(path, O_RDONLY);
+#endif
 		if (event_fd >= 0)
 		    EV_SET(&events_to_monitor[0], event_fd, EVFILT_VNODE, EV_ADD | EV_CLEAR, KQUEUE_FFLAGS, 0, path);
 	}


### PR DESCRIPTION
This one fixes 2 things:

1. Compilation on OpenBSD (checked **6.1**) as there's no `O_EVTONLY` there
2. Indefinite blocking using `kevent()`, which results in nnn's freeze