### PR TITLE
Correct name checking for NEW and RENAME

### DIFF
--- a/nnn.c
+++ b/nnn.c
@@ -2673,7 +2673,7 @@ nochange:
 				break;
 
 			/* Allow only relative, same dir paths */
-			if (tmp[0] == '/' || basename(tmp) != tmp) {
+			if (tmp[0] == '/' || xstrcmp(basename(tmp), tmp) != 0) {
 				printmsg(STR_INPUT);
 				goto nochange;
 			}
@@ -2726,7 +2726,7 @@ nochange:
 				break;
 
 			/* Allow only relative, same dir paths */
-			if (tmp[0] == '/' || basename(tmp) != tmp) {
+			if (tmp[0] == '/' || xstrcmp(basename(tmp), tmp) != 0) {
 				printmsg(STR_INPUT);
 				goto nochange;
 			}


### PR DESCRIPTION
According to the [man page](https://man.openbsd.org/man3/basename.3):

```
CAVEATS
     basename() returns a pointer to internal static storage space that will
     be overwritten by subsequent calls.

     Other vendor implementations of basename() may modify the contents of the
     string passed to basename(); this should be taken into account when
     writing code which calls this function if portability is desired.
```

So pointers will point to different memory areas, thus we should rely on string comparison.

This is a proposed fix for #50 