### PR TITLE
Lookup xdg-open in PATH on non-Apple platforms

### DIFF
--- a/nnn.c
+++ b/nnn.c
@@ -260,7 +260,7 @@ static char * const utils[] = {
 #ifdef __APPLE__
 	"/usr/bin/open",
 #else
-	"/usr/bin/xdg-open",
+	"xdg-open",
 #endif
 	"nlay",
 	"atool"


### PR DESCRIPTION
On FreeBSD (and other *BSD), xdg-open is installed in /usr/local/bin/, not /usr/bin/. Remove hardcoded path prefix and rely on PATH lookup by execlp() instead.