### PR TITLE
Use standard date formats.

### DIFF
--- a/nnn.c
+++ b/nnn.c
@@ -1319,7 +1319,7 @@ printent_long(struct entry *ent, int sel, uint namecols)
 {
 	static char buf[18], *pname;
 
-	strftime(buf, 18, "%d-%m-%Y %H:%M", localtime(&ent->t));
+	strftime(buf, 18, "%Y-%m-%d %H:%M", localtime(&ent->t));
 	pname = unescape(ent->name, namecols);
 
 	/* Directories are always shown on top */
@@ -1573,15 +1573,15 @@ show_stats(char *fpath, char *fname, struct stat *sb)
 		sb->st_mode & 7, perms, sb->st_uid, (getpwuid(sb->st_uid))->pw_name, sb->st_gid, (getgrgid(sb->st_gid))->gr_name);
 
 	/* Show last access time */
-	strftime(g_buf, 40, "%a %d-%b-%Y %T %z,%Z", localtime(&sb->st_atime));
+	strftime(g_buf, 40, "%a %b %d %T %Z %Y", localtime(&sb->st_atime));
 	dprintf(fd, "\n\n  Access: %s", g_buf);
 
 	/* Show last modification time */
-	strftime(g_buf, 40, "%a %d-%b-%Y %T %z,%Z", localtime(&sb->st_mtime));
+	strftime(g_buf, 40, "%a %b %d %T %Z %Y", localtime(&sb->st_mtime));
 	dprintf(fd, "\n  Modify: %s", g_buf);
 
 	/* Show last status change time */
-	strftime(g_buf, 40, "%a %d-%b-%Y %T %z,%Z", localtime(&sb->st_ctime));
+	strftime(g_buf, 40, "%a %b %d %T %Z %Y", localtime(&sb->st_ctime));
 	dprintf(fd, "\n  Change: %s", g_buf);
 
 	if (S_ISREG(sb->st_mode)) {


### PR DESCRIPTION
- For standard view, use ISO 8601 date format.
- For detailed view (i.e. stat), use default Linux date
  format. Also, remove GMT offset to avoid confusion in
  determining source of offset when reading alongside
  the local time zone.