### PR TITLE
Minor tweaks on quitcd.bash

### DIFF
--- a/scripts/quitcd/quitcd.bash
+++ b/scripts/quitcd/quitcd.bash
@@ -6,6 +6,6 @@ n()
 
         if [ -f $NNN_TMPFILE ]; then
                 . $NNN_TMPFILE
-                rm $NNN_TMPFILE
+                rm -f $NNN_TMPFILE > /dev/null
         fi
 }


### PR DESCRIPTION
Hello,
on MacOS 10.13.3 (and I think any BSD system) rm ask for confirmation before deleting ```/tmp/nnn```, and when it's done print out the name of the deleted file.
It's pretty annoying.

This PR makes no difference on Debian/Ubuntu.