### PR TITLE
Fix zsh path autocompletion

### DIFF
--- a/scripts/auto-completion/zsh/_nnn
+++ b/scripts/auto-completion/zsh/_nnn
@@ -17,6 +17,6 @@ args=(
     '(-p)-p[specify custom nlay]:path to nlay'
     '(-S)-S[start in disk usage analyzer mode]'
     '(-v)-v[show program version and exit]'
-    '*: :_guard "^-*" keyword'
+    '*:filename:_files'
 )
 _arguments -S -s $args


### PR DESCRIPTION
I'm not sure what that _guard function was supposed to do, but autocompletion of the path argument wasn't working with that. With this change the autocompletion is working both for options and a path.