### PR TITLE
Make install(1) commands override-able

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ PREFIX ?= /usr/local
 MANPREFIX ?= $(PREFIX)/share/man
 STRIP ?= strip
 PKG_CONFIG ?= pkg-config
+INSTALL ?= install
 
 CFLAGS ?= -O3
 CFLAGS += -Wall -Wextra -Wno-unused-parameter
@@ -32,10 +33,10 @@ debug: $(SRC)
 	$(CC) -DDEBUGMODE -g $(CFLAGS) $(LDFLAGS) -o $(BIN) $^ $(LDLIBS)
 
 install: all
-	install -m 0755 -d $(DESTDIR)$(PREFIX)/bin
-	install -m 0755 $(BIN) $(PLAYER) $(DESTDIR)$(PREFIX)/bin
-	install -m 0755 -d $(DESTDIR)$(MANPREFIX)/man1
-	install -m 0644 $(BIN).1 $(DESTDIR)$(MANPREFIX)/man1
+	$(INSTALL) -m 0755 -d $(DESTDIR)$(PREFIX)/bin
+	$(INSTALL) -m 0755 $(BIN) $(PLAYER) $(DESTDIR)$(PREFIX)/bin
+	$(INSTALL) -m 0755 -d $(DESTDIR)$(MANPREFIX)/man1
+	$(INSTALL) -m 0644 $(BIN).1 $(DESTDIR)$(MANPREFIX)/man1
 
 uninstall:
 	$(RM) $(DESTDIR)$(PREFIX)/bin/$(BIN)


### PR DESCRIPTION
Hello,

I'm reviewing a package submission for `nnn` on Fedora and one thing that goes against our packaging policy is the install step. This is a trivial patch to solve that and maintain the same behavior by default.

https://bugzilla.redhat.com/show_bug.cgi?id=1548761

Dridi