### PR TITLE
nlay: use more portable shebang for bash.

### DIFF
--- a/nlay
+++ b/nlay
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # #############################################################################
 # nlay: a customizable script to play files in different apps by file type


### PR DESCRIPTION
Should make it able to run on more distros like `NixOS`, `OpenBSD` and whoever doesn't have /bin/bash really.