### PR TITLE
Show hidden files by default when env NNN_SHOW_HIDDEN is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Common use cases:
 - to list all matches starting with the filter expression, start the expression with a `^` (caret) symbol
 - type `\.mkv` to list all MKV files
 
-If `nnn` is invoked as root the default filter will also match hidden files.
+If `nnn` is invoked as root or the environment variable `NNN_SHOW_HIDDEN` is set the default filter will also match hidden files.
 
 #### Navigate-as-you-type mode
 

--- a/nnn.1
+++ b/nnn.1
@@ -264,6 +264,10 @@ names in the shell.
 .Bd -literal
     export NNN_SCRIPT=/usr/local/bin/script.sh
 .Ed
+\fBNNN_SHOW_HIDDEN:\fR show hidden files.
+.Bd -literal
+    export NNN_SHOW_HIDDEN=1
+.Ed
 .Sh KNOWN ISSUES
 If you are using urxvt you might have to set backspacekey to DEC.
 .Sh AUTHORS

--- a/nnn.c
+++ b/nnn.c
@@ -2026,6 +2026,9 @@ show_help(char *path)
 	if (getenv("NNN_SCRIPT"))
 		dprintf(fd, "NNN_SCRIPT: %s\n", getenv("NNN_SCRIPT"));
 
+	if (getenv("NNN_SHOW_HIDDEN"))
+		dprintf(fd, "NNN_SHOW_HIDDEN: %s\n", getenv("NNN_SHOW_HIDDEN"));
+
 	dprintf(fd, "\nVolume: %s of ", coolsize(get_fs_free(path)));
 	dprintf(fd, "%s free\n\n", coolsize(get_fs_capacity(path)));
 
@@ -3370,7 +3373,7 @@ main(int argc, char *argv[])
 	/* Increase current open file descriptor limit */
 	open_max = max_openfds();
 
-	if (getuid() == 0)
+	if (getuid() == 0 || getenv("NNN_SHOW_HIDDEN"))
 		cfg.showhidden = 1;
 	initfilter(cfg.showhidden, &ifilter);
 


### PR DESCRIPTION
This allows users to opt-in into showing hidden files _by default_ by setting environment variable `NNN_SHOW_HIDDEN`.