### PR TITLE
Fix backspace rendering and error handling.

### DIFF
--- a/nnn.c
+++ b/nnn.c
@@ -1077,8 +1077,13 @@ filterentries(char *path)
 
 			wcstombs(ln, wln, REGEX_MAX);
 			ndents = total;
-			if (matches(pln) == -1)
-				continue;
+			char *tmppln = pln;
+			if (strcmp(pln, "") == 0) {
+				tmppln=".*"; //otherwise setfilter will fail for the empty string.
+			}
+			if (matches(tmppln) == -1) {
+				goto end;
+			}
 			redraw(path);
 			printprompt(ln);
 			continue;


### PR DESCRIPTION
@jarun - can you please review this change:

```
Fixes the following issues:
- When in filter mode, hitting backspace on the first character renders
  the backspace character on the screen along with the first character
  instead of just the search prompt (i.e. '/').
  For example, hitting backspace 3 times on the search string 'abc'
  produces this sequence:
     /abc
     /ab
     /a
     /a^?
- Go to the 'end' label if matches() fails (via regcomp()) when hitting
  backspace.
```