### PR TITLE
Honour CPPFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,10 @@ all: $(BIN) $(PLAYER)
 $(SRC): nnn.h
 
 $(BIN): $(SRC)
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 debug: $(SRC)
-	$(CC) -DDEBUGMODE -g $(CFLAGS) $(LDFLAGS) -o $(BIN) $^ $(LDLIBS)
+	$(CC) -DDEBUGMODE -g $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(BIN) $^ $(LDLIBS)
 
 install: all
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(PREFIX)/bin


### PR DESCRIPTION
Preprocessor flags are passed in CPPFLAGS.
Debian uses it to pass hardening options (-D_FORTIFY_SOURCE)
to the compiler.