### PR TITLE
Map BS (8) and DEL (127) key codes to SEL_BACK as well

### DIFF
--- a/nnn.h
+++ b/nnn.h
@@ -102,6 +102,8 @@ static struct assoc assocs[] = {
 static struct key bindings[] = {
 	/* Back */
 	{ KEY_BACKSPACE,  SEL_BACK,      "",     "" },
+	{ 8 /* BS */,     SEL_BACK,      "",     "" },
+	{ 127 /* DEL */,  SEL_BACK,      "",     "" },
 	{ KEY_LEFT,       SEL_BACK,      "",     "" },
 	{ 'h',            SEL_BACK,      "",     "" },
 	{ CONTROL('H'),   SEL_BACK,      "",     "" },


### PR DESCRIPTION
On some systems backspace key is producing the BS (8) code and on some others DEL (127). KEY_BACKSPACE is mapped to 263 which doesn't seem to work everywhere. I think there's no harm in supporting all these options out of the box.