### PR TITLE
Replace single dot with source for fish shell

### DIFF
--- a/scripts/quitcd/quitcd.fish
+++ b/scripts/quitcd/quitcd.fish
@@ -4,7 +4,7 @@ function n --description 'support nnn quit and change directory'
         nnn $argv
 
         if test -e $NNN_TMPFILE
-                . $NNN_TMPFILE
+                source $NNN_TMPFILE
                 rm $NNN_TMPFILE
         end
 end


### PR DESCRIPTION
Single dot has been deprecated and can cause issues with users on newer version: https://github.com/fish-shell/fish-shell/issues/310