### PR TITLE
Makefile portability tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,10 @@ all: $(BIN)
 $(SRC): src/nnn.h
 
 $(BIN): $(SRC)
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 debug: $(SRC)
-	$(CC) -DDEBUGMODE -g $(CFLAGS) $(LDFLAGS) -o $(BIN) $^ $(LDLIBS)
+	$(CC) -DDEBUGMODE -g $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(BIN) $^ $(LDLIBS)
 
 install: all
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(PREFIX)/bin


### PR DESCRIPTION
Very similar to https://github.com/jarun/bcal/pull/25

Note regarding curses: the BSD (& macOS) built in curses generally support all you need hence **n**curses is not actually needed. pkgsrc can detect the correct curses to use and I’ve used `{CFLAGS,LDLIBS}_CURSES` in the environment to pass those on.

The package itself needs to go through review first; I’ll PR Makefile when it’s live.