### PR TITLE
Fix warning of implicit declaration of function 'strcasestr'

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -29,6 +29,9 @@
  */
 
 #ifdef __linux__
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
 #if defined(__arm__) || defined(__i386__)
 #define _FILE_OFFSET_BITS 64 /* Support large files on 32-bit */
 #endif


### PR DESCRIPTION
According to manpage of strcasestr [1], the macro function needs to be added.

[1] https://linux.die.net/man/3/strcasestr

Signed-off-by: SZ Lin (林上智) <szlin@debian.org>