### PR TITLE
fixed compile error in OpenBSD

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -78,12 +78,12 @@
 #endif
 #include <locale.h>
 #include <pwd.h>
+#include <stdio.h>
 #include <readline/history.h>
 #include <readline/readline.h>
 #include <regex.h>
 #include <signal.h>
 #include <stdarg.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>


### PR DESCRIPTION
Just tried to Compile `nnn` on OpenBSD (6.4). the following diff fixes the problem. Hope it helps!

```sh
$ uname -a
OpenBSD openbsd.localhost 6.4 GENERIC.MP#626 amd64
$ gmake
cc  -Wall -Wextra -Wno-unused-parameter -O3   -o nnn src/nnn.c -lreadline -lncurses
In file included from src/nnn.c:81:
In file included from /usr/include/readline/history.h:34:
/usr/include/readline/rltypedefs.h:65:36: error: unknown type name 'FILE'
typedef int rl_getc_func_t PARAMS((FILE *));
                                   ^
In file included from src/nnn.c:82:
/usr/include/readline/readline.h:400:28: error: unknown type name 'FILE'
extern int rl_getc PARAMS((FILE *));
                           ^
/usr/include/readline/readline.h:516:8: error: unknown type name 'FILE'
extern FILE *rl_instream;
       ^
/usr/include/readline/readline.h:517:8: error: unknown type name 'FILE'
extern FILE *rl_outstream;
       ^
/usr/include/readline/readline.h:779:3: error: unknown type name 'FILE'
  FILE *inf;
  ^
/usr/include/readline/readline.h:780:3: error: unknown type name 'FILE'
  FILE *outf;
  ^
6 errors generated.
gmake: *** [Makefile:36: nnn] Error 1
```