### PR TITLE
Clarify the difference between copy and select

### DIFF
--- a/nnn.1
+++ b/nnn.1
@@ -103,7 +103,7 @@ Toggle selection mode
 .It Ic Y
 Select all entries in dir
 .It Ic Space, ^K
-Copy entry absolute path
+Select entry and copy absolute path
 .It Ic y
 Show selection list
 .It Ic P
@@ -254,17 +254,17 @@ In case of only one match and it's a directory, `nnn` auto selects the directory
 The absolute path of a single file can be copied to clipboard by pressing \fI^K\fR if
 NNN_COPIER is set (see ENVIRONMENT section below).
 .Pp
-To copy multiple file paths the selection mode should be enabled using \fI^Y\fR.
+To select multiple files the selection mode should be enabled using \fI^Y\fR.
 In this mode it's possible to
 .Pp
 (1) cherry-pick individual files one by one by pressing <kbd>^K</kbd> on each entry (works across directories and contexts); or,
 .br
 (2) navigate to another file in the same directory to select a range of files.
 .Pp
-Pressing \fI^Y\fR again copies the paths and exits the selection mode. The files in the list can now
-be copied, moved or removed using respective keyboard shortcuts.
+Pressing \fI^Y\fR again saves the selection to the list and exits the selection mode.
+The files in the list can now be copied, moved or removed using respective keyboard shortcuts.
 .Pp
-To list the file paths copied to memory press \fIy\fR.
+To list the selected files press \fIy\fR.
 .Sh ENVIRONMENT
 The SHELL, EDITOR (VISUAL, if defined) and PAGER environment variables take precedence
 when dealing with the !, e and p commands respectively. A single combination to arguments is supported for SHELL and PAGER.

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3493,7 +3493,8 @@ nochange:
 				if (copier)
 					spawn(copier, NULL, NULL, NULL, F_NOTRACE);
 			}
-			printmsg(newpath);
+			mvprintw(LINES - 1, 0, "selected %s%s\n",
+				(!cfg.copymode&&copier) ? "and copied " : "" , newpath);
 			goto nochange;
 		case SEL_COPYMUL:
 			cfg.copymode ^= 1;
@@ -3543,7 +3544,7 @@ nochange:
 								 dents[r].name, newpath)))
 							goto nochange;
 
-					mvprintw(LINES - 1, 0, "%d files copied\n",
+					mvprintw(LINES - 1, 0, "%d files selected\n",
 						 copyendid - copystartid + 1);
 				}
 			}
@@ -3554,7 +3555,7 @@ nochange:
 					spawn(copier, NULL, NULL, NULL, F_NOTRACE);
 
 				if (ncp) /* Some files cherry picked */
-					mvprintw(LINES - 1, 0, "%d files copied\n", ncp);
+					mvprintw(LINES - 1, 0, "%d files selected\n", ncp);
 			} else
 				printmsg("selection off");
 			goto nochange;


### PR DESCRIPTION
The intermixed use of 'copied' and 'selected' is quite confusing to me. This pull request trys to make things more clear. For example the displayed message 'x files copied' looks like files had been copied although they only got added to the selection list. Additionally it is now shown if the file got selected/copied when cherry-picking with <kbd>^K</kbd>.