### PR TITLE
Added a user-script to send selected files using kde-connect.

### DIFF
--- a/user-scripts/kdeconnect
+++ b/user-scripts/kdeconnect
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Description: Send the selected files to your Android device using kdeconnect-cli. You must have installed and configured kdeconnect both on the Android device and on the PC.
+#
+# Shell: Bash
+# Author: juacq97
+
+id=$(kdeconnect-cli -a --id-only | awk '{print $1}')
+if [ $(find ~/.nnncp) ]
+then
+    kdeconnect-cli -d $id --share $(cat ~/.nnncp)
+# If you want a system notification, uncomment the next 3 lines.
+#    notify-send -a "Kdeconnect" "Sending $(cat ~/.nnncp)"
+#else
+#    notify-send -a "Kdeconnect" "No file selected"
+fi


### PR DESCRIPTION
The script uses `kdeconnect-cli` to send the files to the linked device.
Uses the `.nnncp` file to `cat` the selected files.
You can get system notifications using `notify-send`. This is disabled
by default.