### PR TITLE
Added mouse support

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -871,6 +871,7 @@ static bool initcurses(void)
 	nonl();
 	//intrflush(stdscr, FALSE);
 	keypad(stdscr, TRUE);
+	mousemask(BUTTON1_CLICKED | BUTTON1_DOUBLE_CLICKED, NULL);
 	curs_set(FALSE); /* Hide cursor */
 	start_color();
 	use_default_colors();
@@ -3034,6 +3035,7 @@ static void browse(char *ipath)
 	bool dir_changed = FALSE;
 	struct stat sb;
 	char *path, *lastdir, *lastname, *dir, *tmp;
+	MEVENT event;
 
 	atexit(dentfree);
 
@@ -3131,6 +3133,35 @@ nochange:
 
 			setdirwatch();
 			goto begin;
+		case SEL_CLICK:
+			if (getmouse(&event) != OK)
+				break;
+			// Handle clicking on a context at the top:
+			if (event.y == 0) {
+				int ctx = (event.x - 1)/2;
+				if (event.x == 1 + 2*ctx && 0 <= ctx && ctx < CTX_MAX) {
+					r = ctx;
+					goto switch_context;
+				}
+				break;
+			}
+			// Handle clicking on a file:
+			if (2 <= event.y && event.y < LINES - 2) {
+				r = 0;
+				if (cur-(LINES-4)/2 > 0)
+					r = cur-(LINES-4)/2;
+				if (ndents >= LINES-4 && ndents - (LINES-4) < r)
+					r = ndents - (LINES-4);
+				r += event.y - 2;
+				if (r >= ndents)
+					break;
+				cur = r;
+				// Single click just selects, double click also opens
+				if (event.bstate != BUTTON1_DOUBLE_CLICKED)
+					break;
+			} else {
+				break;
+			}
 		case SEL_NAV_IN: // fallthrough
 		case SEL_GOIN:
 			/* Cannot descend in empty directories */
@@ -3342,6 +3373,7 @@ nochange:
 			case '3': // fallthrough
 			case '4':
 				r = fd - '1'; /* Save the next context id */
+switch_context:
 				if (cfg.curctx == r) {
 					if (sel != SEL_CYCLE)
 						continue;

--- a/src/nnn.h
+++ b/src/nnn.h
@@ -102,6 +102,7 @@ enum action {
 	SEL_QUITCTX,
 	SEL_QUITCD,
 	SEL_QUIT,
+	SEL_CLICK,
 };
 
 /* Associate a pressed key to an action */
@@ -256,4 +257,5 @@ static struct key bindings[] = {
 	/* Quit */
 	{ 'Q',            SEL_QUIT },
 	{ CONTROL('Q'),   SEL_QUIT },
+	{ KEY_MOUSE,      SEL_CLICK },
 };


### PR DESCRIPTION
This change adds mouse support for:
- Click on a context number to go to that context
- Click on a file or folder's line to move the cursor to that file
- Double click on a file or folder's line to open it