### PR TITLE
Make yes/no prompts have the "y/N" structure.

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3812,7 +3812,7 @@ nochange:
 
 			/* Confirm if app is CLI or GUI */
 			if (sel == SEL_OPENWITH) {
-				r = get_input("cli mode? [y/Y]");
+				r = get_input("cli mode? [y/N]");
 				(r == 'y' || r == 'Y') ? (r = F_CLI)
 						       : (r = F_NOWAIT | F_NOTRACE | F_MULTI);
 			}

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -594,7 +594,7 @@ static void xdelay(void)
 
 static char confirm_force(void)
 {
-	int r = get_input("use force? [y/Y]");
+	int r = get_input("use force? [y/N]");
 
 	if (r == 'y' || r == 'Y')
 		return 'f'; /* forceful */
@@ -3769,7 +3769,7 @@ nochange:
 		{
 			switch (sel) {
 			case SEL_ARCHIVE:
-				r = get_input("archive selection (else current)? [y/Y]");
+				r = get_input("archive selection (else current)? [y/N]");
 				if (r == 'y' || r == 'Y') {
 					if (!cpsafe()) {
 						presel = MSGWAIT;
@@ -3866,7 +3866,7 @@ nochange:
 			if (faccessat(fd, tmp, F_OK, AT_SYMLINK_NOFOLLOW) != -1) {
 				if (sel == SEL_RENAME) {
 					/* Overwrite file with same name? */
-					r = get_input("overwrite? [y/Y]");
+					r = get_input("overwrite? [y/N]");
 					if (r != 'y' && r != 'Y') {
 						close(fd);
 						break;


### PR DESCRIPTION
`nnn` yes / no prompts have currently the structure of "y/Y". E.g. :
```
r = get_input("overwrite? [y/Y]");
if (r != 'y' && r != 'Y') {
// do the stuff
```

This is non-intuitive (to me at least), as imo usually:
- the "/" is understood as xor, while here the 2 choices separated by the slash are the same
- the capital letter usually marks default that gets triggered upon hitting enter.

And thus "y/Y" can be understood as (this is how I understood it at first, and what triggered this PR), type "y" for yes and "Y" for no (default choice).

This PR changes this to
"y/N"
instead to make it more aligned with the intuition above.

With the PR, the logic is however not fully explicit any more (== does not list all the keys required for making the yes), but I do not think this is worse problem than the potential ambiguity above.