### PR TITLE
Adding scrolloff option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ else
 	LDLIBS_CURSES ?= -lncurses
 endif
 
-CFLAGS += -Wall -Wextra -Wno-unused-parameter
+CFLAGS += -Wall -Wextra -Wno-unused-parameter -Wno-format-truncation
 CFLAGS += $(CFLAGS_OPTIMIZATION)
 CFLAGS += $(CFLAGS_CURSES)
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ else
 	LDLIBS_CURSES ?= -lncurses
 endif
 
-CFLAGS += -Wall -Wextra -Wno-unused-parameter -Wno-format-truncation
+CFLAGS += -Wall -Wextra -Wno-unused-parameter
 CFLAGS += $(CFLAGS_OPTIMIZATION)
 CFLAGS += $(CFLAGS_CURSES)
 

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3170,9 +3170,9 @@ nochange:
 				// Single click just selects, double click also opens
 				if (event.bstate != BUTTON1_DOUBLE_CLICKED)
 					break;
-				// fallthrough
+				// fallthrough to select the file
 			} else
-				goto nochange;
+				goto nochange; // fallthrough
 		case SEL_NAV_IN: // fallthrough
 		case SEL_GOIN:
 			/* Cannot descend in empty directories */

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -2017,8 +2017,8 @@ static char *coolsize(off_t size)
 {
 	static const char * const U = "BKMGTPEZY";
 	static char size_buf[12]; /* Buffer to hold human readable size */
-	static off_t rem;
-	static int i;
+	off_t rem;
+	int i;
 
 	rem = i = 0;
 
@@ -2065,19 +2065,21 @@ static char *coolsize(off_t size)
 	}
 
 	if (i > 0 && i < 6)
-		snprintf(size_buf, 12, "%lu.%0*lu%c", (ulong)size, i, (ulong)rem, U[i]);
+		snprintf(size_buf, 12, "%lu.%0*lu%c", size, i, rem, U[i]);
 	else
-		snprintf(size_buf, 12, "%lu%c", (ulong)size, U[i]);
+		snprintf(size_buf, 12, "%lu%c", size, U[i]);
 
 	return size_buf;
 }
 
-static char *get_file_sym(mode_t mode)
+static void printent(const struct entry *ent, int sel, uint namecols)
 {
-	static char ind[2];
+	const char *pname = unescape(ent->name, namecols);
+	const char cp = (ent->flags & FILE_COPIED) ? '+' : ' ';
+	char ind[2];
+	mode_t mode = ent->mode;
 
-	ind[0] = '\0';
-	ind[1] = '\0';
+	ind[0] = ind[1] = '\0';
 
 	switch (mode & S_IFMT) {
 	case S_IFREG:
@@ -2104,18 +2106,10 @@ static char *get_file_sym(mode_t mode)
 		break;
 	}
 
-	return ind;
-}
-
-static void printent(const struct entry *ent, int sel, uint namecols)
-{
-	const char *pname = unescape(ent->name, namecols);
-	const char cp = (ent->flags & FILE_COPIED) ? '+' : ' ';
-
 	/* Directories are always shown on top */
 	resetdircolor(ent->flags);
 
-	printw("%s%c%s%s\n", CURSYM(sel), cp, pname, get_file_sym(ent->mode));
+	printw("%s%c%s%s\n", CURSYM(sel), cp, pname, ind);
 }
 
 static void printent_long(const struct entry *ent, int sel, uint namecols)

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3107,7 +3107,6 @@ begin:
 
 	while (1) {
 		redraw(path);
-        onscreen = xlines - 4;
 nochange:
 		/* Exit if parent has exited */
 		if (getppid() == 1)
@@ -3277,6 +3276,7 @@ nochange:
 			break;
 		case SEL_PGDN: // fallthrough
 		case SEL_CTRL_D:
+			onscreen = xlines - 4;
 			r = sel == SEL_PGDN ? onscreen - 1 : onscreen >> 1;
 			curscroll = MIN(ndents - onscreen, curscroll + r);
 			cur = (curscroll == ndents - onscreen) ? cur + r :
@@ -3285,6 +3285,7 @@ nochange:
 			break;
 		case SEL_PGUP: // fallthrough
 		case SEL_CTRL_U:
+			onscreen = xlines - 4;
 			r = sel == SEL_PGUP ? onscreen - 1 : onscreen >> 1;
 			curscroll = MAX(0, curscroll - r);
 			cur = (curscroll == 0) ? cur - r :

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -2895,8 +2895,8 @@ static void redraw(char *path)
 	xcols = COLS;
 
 	int ncols = (xcols <= PATH_MAX) ? xcols : PATH_MAX;
-	int lastln = xlines;
-	int scrolloff = MIN(SCROLLOFF, (xlines-4)>>1);
+	int lastln = xlines, onscreen = xlines - 4;
+	int scrolloff = MIN(SCROLLOFF, onscreen >> 1);
 	int i, attrs;
 	char buf[12];
 	char c;
@@ -2906,12 +2906,12 @@ static void redraw(char *path)
 	/* Clear screen */
 	erase();
 
-	if (ndents <= xlines - 4)
+	if (ndents <= onscreen)
 		curscroll = 0;
 	else if (cur < curscroll + scrolloff)
 		curscroll = MAX(0, cur - scrolloff);
-	else if (cur > curscroll + (xlines - 4) - scrolloff - 1)
-		curscroll = MIN(ndents - (xlines - 4), cur - (xlines - 4) + scrolloff + 1);
+	else if (cur > curscroll + onscreen - scrolloff - 1)
+		curscroll = MIN(ndents - onscreen, cur - onscreen + scrolloff + 1);
 
 #ifdef DIR_LIMITED_COPY
 	if (cfg.copymode)
@@ -2978,7 +2978,7 @@ static void redraw(char *path)
 	}
 
 	/* Print listing */
-	for (i = curscroll; i < ndents && i < curscroll + (xlines - 4); ++i) {
+	for (i = curscroll; i < ndents && i < curscroll + onscreen; ++i) {
 		printptr(&dents[i], i == cur, ncols);
 	}
 
@@ -3170,7 +3170,6 @@ nochange:
 				// Single click just selects, double click also opens
 				if (event.bstate != BUTTON1_DOUBLE_CLICKED)
 					break;
-				// fallthrough to select the file
 			} else
 				goto nochange; // fallthrough
 		case SEL_NAV_IN: // fallthrough

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3170,7 +3170,7 @@ nochange:
 				// Single click just selects, double click also opens
 				if (event.bstate != BUTTON1_DOUBLE_CLICKED)
 					break;
-                // fallthrough
+				// fallthrough
 			} else
 				goto nochange;
 		case SEL_NAV_IN: // fallthrough

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -2070,9 +2070,9 @@ static char *coolsize(off_t size)
 	}
 
 	if (i > 0 && i < 6)
-		snprintf(size_buf, 12, "%lu.%0*lu%c", size, i, rem, U[i]);
+		snprintf(size_buf, 12, "%lu.%0*lu%c", (long)size, i, (long)rem, U[i]);
 	else
-		snprintf(size_buf, 12, "%lu%c", size, U[i]);
+		snprintf(size_buf, 12, "%lu%c", (long)size, U[i]);
 
 	return size_buf;
 }

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3275,21 +3275,21 @@ nochange:
 				/* Roll over, set cursor to last entry */
 				cur = ndents - 1;
 			break;
-		case SEL_PGDN:
-			if (cur < ndents - 1)
-				cur += MIN((xlines - 4), ndents - 1 - cur);
-			break;
-		case SEL_PGUP:
-			if (cur > 0)
-				cur -= MIN((xlines - 4), cur);
-			break;
+		case SEL_PGDN: // fallthrough
 		case SEL_CTRL_D:
-			if (cur < ndents - 1)
-				cur += MIN((xlines - 4) / 2, ndents - 1 - cur);
+			r = sel == SEL_PGDN ? (xlines - 4) - 1 : (xlines - 4) / 2;
+			curscroll = MIN(ndents - (xlines - 4), curscroll + r);
+			cur = (curscroll == ndents - (xlines - 4)) ? cur + r :
+				curscroll + MIN(SCROLLOFF, (xlines - 4) >> 1);
+			cur = MIN(ndents - 1, cur);
 			break;
+		case SEL_PGUP: // fallthrough
 		case SEL_CTRL_U:
-			if (cur > 0)
-				cur -= MIN((xlines - 4) / 2, cur);
+			r = sel == SEL_PGUP ? (xlines - 4) - 1 : (xlines - 4) / 2;
+			curscroll = MAX(0, curscroll - r);
+			cur = (curscroll == 0) ? cur - r :
+				curscroll + (xlines - 4) - MIN(SCROLLOFF, (xlines - 4) >> 1) - 1;
+			cur = MAX(0, cur);
 			break;
 		case SEL_HOME:
 			cur = 0;

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -2070,9 +2070,9 @@ static char *coolsize(off_t size)
 	}
 
 	if (i > 0 && i < 6)
-		snprintf(size_buf, 12, "%lu.%0*lu%c", (long)size, i, (long)rem, U[i]);
+		snprintf(size_buf, 12, "%lu.%0*lu%c", (ulong)size, i, (ulong)rem, U[i]);
 	else
-		snprintf(size_buf, 12, "%lu%c", (long)size, U[i]);
+		snprintf(size_buf, 12, "%lu%c", (ulong)size, U[i]);
 
 	return size_buf;
 }

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3158,9 +3158,10 @@ nochange:
 			// Handle clicking on a file:
 			if (2 <= event.y && event.y < xlines - 2) {
 				// Get index of the first file listed on-screen:
-				r = MIN(MAX(0, cur-((xlines-4)>>1)), ndents-(xlines-4));
+				r = MAX(0, MIN(cur-((xlines-4)>>1), ndents-(xlines-4)));
 				// Add the mouse click position to get the clicked file:
 				r += event.y - 2;
+                printf("CLICKED: %d", r);
 
 				if (r >= ndents)
 					goto nochange;

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3161,7 +3161,6 @@ nochange:
 				r = MAX(0, MIN(cur-((xlines-4)>>1), ndents-(xlines-4)));
 				// Add the mouse click position to get the clicked file:
 				r += event.y - 2;
-                printf("CLICKED: %d", r);
 
 				if (r >= ndents)
 					goto nochange;

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3170,8 +3170,9 @@ nochange:
 				// Single click just selects, double click also opens
 				if (event.bstate != BUTTON1_DOUBLE_CLICKED)
 					break;
+                // fallthrough
 			} else
-				goto nochange; // fallthrough
+				goto nochange;
 		case SEL_NAV_IN: // fallthrough
 		case SEL_GOIN:
 			/* Cannot descend in empty directories */

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3029,7 +3029,7 @@ static void browse(char *ipath)
 	char mark[PATH_MAX] __attribute__ ((aligned));
 	char rundir[PATH_MAX] __attribute__ ((aligned));
 	char runfile[NAME_MAX + 1] __attribute__ ((aligned));
-	int r = -1, fd, presel, ncp = 0, copystartid = 0, copyendid = 0;
+	int r = -1, fd, presel, ncp = 0, copystartid = 0, copyendid = 0, onscreen;
 	enum action sel;
 	bool dir_changed = FALSE;
 	struct stat sb;
@@ -3107,6 +3107,7 @@ begin:
 
 	while (1) {
 		redraw(path);
+        onscreen = xlines - 4;
 nochange:
 		/* Exit if parent has exited */
 		if (getppid() == 1)
@@ -3139,7 +3140,7 @@ nochange:
 			// Handle clicking on a context at the top:
 			if (event.y == 0) {
 				// Get context from: "[1 2 3 4]..."
-				r = event.x/2;
+				r = event.x >> 1;
 
 				if (event.x != 1 + (r << 1))
 					goto nochange; // The character after the context number
@@ -3276,18 +3277,18 @@ nochange:
 			break;
 		case SEL_PGDN: // fallthrough
 		case SEL_CTRL_D:
-			r = sel == SEL_PGDN ? (xlines - 4) - 1 : (xlines - 4) / 2;
-			curscroll = MIN(ndents - (xlines - 4), curscroll + r);
-			cur = (curscroll == ndents - (xlines - 4)) ? cur + r :
-				curscroll + MIN(SCROLLOFF, (xlines - 4) >> 1);
+			r = sel == SEL_PGDN ? onscreen - 1 : onscreen >> 1;
+			curscroll = MIN(ndents - onscreen, curscroll + r);
+			cur = (curscroll == ndents - onscreen) ? cur + r :
+				curscroll + MIN(SCROLLOFF, onscreen >> 1);
 			cur = MIN(ndents - 1, cur);
 			break;
 		case SEL_PGUP: // fallthrough
 		case SEL_CTRL_U:
-			r = sel == SEL_PGUP ? (xlines - 4) - 1 : (xlines - 4) / 2;
+			r = sel == SEL_PGUP ? onscreen - 1 : onscreen >> 1;
 			curscroll = MAX(0, curscroll - r);
 			cur = (curscroll == 0) ? cur - r :
-				curscroll + (xlines - 4) - MIN(SCROLLOFF, (xlines - 4) >> 1) - 1;
+				curscroll + onscreen - MIN(SCROLLOFF, onscreen >> 1) - 1;
 			cur = MAX(0, cur);
 			break;
 		case SEL_HOME:

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -109,6 +109,8 @@
 #define LEN(x) (sizeof(x) / sizeof(*(x)))
 #undef MIN
 #define MIN(x, y) ((x) < (y) ? (x) : (y))
+#undef MAX
+#define MAX(x, y) ((x) > (y) ? (x) : (y))
 #define ISODD(x) ((x) & 1)
 #define ISBLANK(x) ((x) == ' ' || (x) == '\t')
 #define TOUPPER(ch) \
@@ -3155,15 +3157,15 @@ nochange:
 
 			// Handle clicking on a file:
 			if (2 <= event.y && event.y < xlines - 2) {
-				r = event.y - 2;
+				// Get index of the first file listed on-screen:
+				r = MIN(MAX(0, cur-((xlines-4)>>1)), ndents-(xlines-4));
+				// Add the mouse click position to get the clicked file:
+				r += event.y - 2;
 
 				if (r >= ndents)
 					goto nochange;
 
-				if (ndents > (xlines - 4) && cur >= ((xlines - 4) >> 1))
-					cur -= ((xlines - 4) >> 1) - r;
-				else
-					cur = r;
+				cur = r;
 
 				// Single click just selects, double click also opens
 				if (event.bstate != BUTTON1_DOUBLE_CLICKED)


### PR DESCRIPTION
In the style of vim's `scrolloff` option, this change makes it so nnn will keep the active item a minimum of `SCROLLOFF` lines from the top and bottom of the screen, instead of always at the center. (The old behavior can be replicated by setting `SCROLLOFF` to a large number like 9999) This means the scroll position is tracked separately from the current item, which has the added benefit of simplifying the mouse click and line-rendering logic a bit.