### PR TITLE
Removing external vidir dependency by replicating vidir's behavior internally

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "0 0 * * 0"
+          cron: "0 0 * * 6"
           filters:
             branches:
               only:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,4 +10,6 @@ CheckOptions:
     value:           '_t'
   - key:             fuchsia-restrict-system-includes.Includes
     value:           '*,-stdint.h,-stdbool.h'
+  - key:             readability-function-size.StatementThreshold
+    value:           '850'
 ...

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ else
 	LDLIBS_CURSES ?= -lncurses
 endif
 
-CFLAGS += -Wall -Wextra -Wno-unused-parameter
+CFLAGS += -Wall -Wextra -Wno-unused-parameter -Wno-format-truncation
 CFLAGS += $(CFLAGS_OPTIMIZATION)
 CFLAGS += $(CFLAGS_CURSES)
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ else
 	LDLIBS_CURSES ?= -lncurses
 endif
 
-CFLAGS += -Wall -Wextra -Wno-unused-parameter -Wno-format-truncation
+CFLAGS += -Wall -Wextra -Wno-unused-parameter
 CFLAGS += $(CFLAGS_OPTIMIZATION)
 CFLAGS += $(CFLAGS_CURSES)
 

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ DISTFILES = src nnn.1 Makefile README.md LICENSE
 SRC = src/nnn.c
 BIN = nnn
 
-all: $(BIN)
+all:
 
 $(SRC): src/nnn.h
 

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ DISTFILES = src nnn.1 Makefile README.md LICENSE
 SRC = src/nnn.c
 BIN = nnn
 
-all:
+all: $(BIN)
 
 $(SRC): src/nnn.h
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 <p align="center"><i>3 modes of nnn (light with filter, detail, du analyzer) with memory usage. Click for a demo video.</i></a></p>
 
-`nnn` is smooth... like butter. It's one of the fastest and most lightweight file managers, thanks to a [highly optimized](https://github.com/jarun/nnn/wiki/performance-factors) code. And yet, it doesn't lack in features!
+`nnn` is smooth... like butter. It's one of the fastest and most lightweight file managers, thanks to a **[highly optimized](https://github.com/jarun/nnn/wiki/performance-factors)** code. And yet, it doesn't lack in features!
 
 It runs on Linux, macOS, Raspberry Pi, BSD, Cygwin, Linux subsystem for Windows and Termux on Android.
 
@@ -129,6 +129,8 @@ It runs on Linux, macOS, Raspberry Pi, BSD, Cygwin, Linux subsystem for Windows 
 
 #### Utility dependencies
 
+The following table is a complete list. Some of the utilities may be installed by default (e.g. desktop opener, file, coreutils, findutils) and some may not be required by all users (e.g. sshfs, vlock, advcpmv).
+
 | Dependency | Operation |
 | --- | --- |
 | xdg-open (Linux), open(1) (macOS), cygstart (Cygwin) | desktop opener |
@@ -136,7 +138,6 @@ It runs on Linux, macOS, Raspberry Pi, BSD, Cygwin, Linux subsystem for Windows 
 | trash-cli | trash files (default: delete) |
 | mediainfo / exiftool | multimedia file details |
 | atool / patool ([integration](https://github.com/jarun/nnn/wiki/hacking-nnn#integrate-patool)) | create, list and extract archives |
-| fzy | app launcher, subtree search |
 | vidir (from moreutils) | batch rename dir entries |
 | sshfs, fusermount(3) | mount, unmount remote over SSHFS |
 | vlock (Linux), bashlock (macOS), lock(1) (BSD) | terminal locker |

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@
 
 `nnn` works seamlessly with your DE and favourite GUI utilities. It runs on Linux, macOS, Raspberry Pi, BSD, Cygwin, Linux subsystem for Windows and Termux on Android.
 
-Have as many scripts as you want to extend the power of `nnn`! Pick from the available [plugins](https://github.com/jarun/nnn/tree/master/plugins) or add your own.
+Have as many scripts as you want to extend the power of `nnn`! Pick from the available plugins or add your own.
 
-[Quickstart](#quickstart) and see how `nnn` simplifies long desktop sessions. When you are ready for more, start [hacking `nnn`](https://github.com/jarun/nnn/wiki/hacking-nnn).
+**[Quickstart](#quickstart)** and see how `nnn` simplifies long desktop sessions.
 
 *Love smart and efficient utilities? Explore [my repositories](https://github.com/jarun?tab=repositories). Buy me a cup of coffee if they help you.*
 
@@ -198,7 +198,7 @@ Option completion scripts for Bash, Fish and Zsh can be found in respective subd
 6. Don't memorize keys. Arrows, <kbd>/</kbd> and <kbd>q</kbd> suffice. Press <kbd>?</kbd> for help on keyboard shortcuts anytime.
 
 - For additional functionality [setup plugins](#plugins).
-- Visit the wiki page [hacking `nnn`](https://github.com/jarun/nnn/wiki/hacking-nnn) for many more specific use cases.
+- When you are ready for more, start [hacking `nnn`](https://github.com/jarun/nnn/wiki/hacking-nnn).
 - To set `nnn` as the default file manager, follow these [instructions](https://github.com/jarun/nnn/wiki/nnn-as-default-file-manager).
 
 #### USAGE

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ It runs on Linux, macOS, Raspberry Pi, BSD, Cygwin, Linux subsystem for Windows 
   - FreeDesktop compliant trash (needs trash-cli)
   - Plugin repository
   - SSHFS mounts (needs sshfs)
-  - Batch rename (needs vidir)
+  - Batch rename
   - Show copy, move progress on Linux (needs avdcpmv)
   - Per-context directory color (default: blue)
   - Spawn a shell in the current directory
@@ -139,7 +139,6 @@ The following table is a complete list. Some of the utilities may be installed b
 | trash-cli | trash files (default: delete) |
 | mediainfo / exiftool | multimedia file details |
 | atool / patool ([integration](https://github.com/jarun/nnn/wiki/hacking-nnn#integrate-patool)) | create, list and extract archives |
-| vidir (from moreutils) | batch rename dir entries |
 | sshfs, fusermount(3) | mount, unmount remote over SSHFS |
 | vlock (Linux), bashlock (macOS), lock(1) (BSD) | terminal locker |
 | advcpmv (Linux) ([integration](https://github.com/jarun/nnn/wiki/hacking-nnn#show-cp-mv-progress)) | copy, move progress |

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ It runs on Linux, macOS, Raspberry Pi, BSD, Cygwin, Linux subsystem for Windows 
   - Detailed file information
   - Media information (needs mediainfo/exiftool)
 - Convenience
+  - Mouse support
   - Create, rename files and directories
   - Select files across dirs; all/range selection
   - Copy, move, delete, archive, link selection

--- a/README.md
+++ b/README.md
@@ -335,7 +335,6 @@ The following indicators are used in the detail view:
 | --- | --- |
 | `NNN_BMS='d:~/Documents;D:~/Docs archive/'` | specify bookmarks (max 10) |
 | `NNN_OPENER=mimeopen` | custom file opener |
-| `NNN_OPENER_DETACH=1` | do not block when invoking file opener |
 | `NNN_CONTEXT_COLORS='1234'` | specify per context color [default: '4444' (all blue)] |
 | `NNN_IDLE_TIMEOUT=300` | idle seconds before locking terminal [default: disabled] |
 | `NNN_COPIER='/absolute/path/to/copier'` | system clipboard copier script [default: none] |

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 It runs on Linux, macOS, Raspberry Pi, BSD, Cygwin, Linux subsystem for Windows and Termux on Android.
 
-`nnn` works seamlessly with DEs and GUI utilities. Several plugins are available to extend its power. New plugins can be added easily.
+`nnn` works seamlessly with DEs and GUI utilities. Several **[plugins](https://github.com/jarun/nnn/tree/master/plugins)** are available to extend its power. New plugins can be added easily.
 
 **[Quickstart](#quickstart)** and see how `nnn` simplifies long desktop sessions.
 
@@ -78,8 +78,8 @@ It runs on Linux, macOS, Raspberry Pi, BSD, Cygwin, Linux subsystem for Windows 
   - Disk usage analyzer (block/apparent)
   - File picker, (neo)vim plugin
 - Navigation
-  - *Navigate-as-you-type* with auto-select dir, *wild load*
-  - 4 contexts (_aka_ tabs _aka_ workspaces)
+  - *Navigate-as-you-type* with dir auto-select, *wild load*
+  - 4 contexts (_aka_ tabs/workspaces)
   - Bookmarks; pin and visit a directory
   - Familiar, easy shortcuts (arrows, <kbd>~</kbd>, <kbd>-</kbd>, <kbd>@</kbd>)
 - Sorting
@@ -93,19 +93,19 @@ It runs on Linux, macOS, Raspberry Pi, BSD, Cygwin, Linux subsystem for Windows 
 - Mimes
   - Open with desktop opener or specify a custom app
   - Create, list, extract archive (needs (p)atool)
-  - Open all text files in EDITOR (optional)
+  - Option to open all text files in EDITOR
 - Information
-  - Detailed file information (stat and file)
+  - Detailed file information
   - Media information (needs mediainfo/exiftool)
 - Convenience
   - Create, rename files and directories
   - Select files across dirs; all/range selection
   - Copy, move, delete, archive, link selection
   - FreeDesktop compliant trash (needs trash-cli)
-  - Show copy, move progress on Linux (needs avdcpmv)
   - Plugin repository
   - SSHFS mounts (needs sshfs)
   - Batch rename (needs vidir)
+  - Show copy, move progress on Linux (needs avdcpmv)
   - Per-context directory color (default: blue)
   - Spawn a shell in the current directory
   - Launch applications, run a command
@@ -195,10 +195,9 @@ Option completion scripts for Bash, Fish and Zsh can be found in respective subd
 2. Configure [cd on quit](https://github.com/jarun/nnn/wiki/hacking-nnn#cd-on-quit).
 3. Optionally open all text files in `$EDITOR` (fallback vi): `export NNN_USE_EDITOR=1`
 4. Run `n`.
-5. To enable the GUI app launcher with a fuzzy drop-down selection menu [`nlaunch`](https://github.com/jarun/nnn/tree/master/scripts/nlaunch), drop it somewhere in your `$PATH`.
-6. Don't memorize keys. Arrows, <kbd>/</kbd> and <kbd>q</kbd> suffice. Press <kbd>?</kbd> for help on keyboard shortcuts anytime.
+5. For additional functionality [setup plugins](https://github.com/jarun/nnn/tree/master/plugins#installing-plugins) and the GUI app launcher [`nlaunch`](https://github.com/jarun/nnn/tree/master/scripts/nlaunch).
 
-- For additional functionality [setup plugins](#plugins).
+- Don't memorize keys. Arrows, <kbd>/</kbd> and <kbd>q</kbd> suffice. Press <kbd>?</kbd> for help on keyboard shortcuts anytime.
 - When you are ready for more, start [hacking `nnn`](https://github.com/jarun/nnn/wiki/hacking-nnn).
 - To set `nnn` as the default file manager, follow these [instructions](https://github.com/jarun/nnn/wiki/nnn-as-default-file-manager).
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Option completion scripts for Bash, Fish and Zsh can be found in respective subd
 2. Configure [cd on quit](https://github.com/jarun/nnn/wiki/hacking-nnn#cd-on-quit).
 3. Optionally open all text files in `$EDITOR` (fallback vi): `export NNN_USE_EDITOR=1`
 4. Run `n`.
-5. For additional functionality [setup plugins](https://github.com/jarun/nnn/tree/master/plugins#installing-plugins) and the GUI app launcher [`nlaunch`](https://github.com/jarun/nnn/tree/master/scripts/nlaunch).
+5. For additional functionality [install plugins](https://github.com/jarun/nnn/tree/master/plugins#installing-plugins) and the GUI app launcher [`nlaunch`](https://github.com/jarun/nnn/tree/master/scripts/nlaunch).
 
 - Don't memorize keys. Arrows, <kbd>/</kbd> and <kbd>q</kbd> suffice. Press <kbd>?</kbd> for help on keyboard shortcuts anytime.
 - When you are ready for more, start [hacking `nnn`](https://github.com/jarun/nnn/wiki/hacking-nnn).
@@ -416,9 +416,7 @@ To lookup keyboard shortcuts at runtime, press <kbd>?</kbd>.
 
 #### PLUGINS
 
-To extend the capabilities of `nnn`, plugins are introduced. Plugins are scripts which `nnn` can communicate with and trigger. This mechanism fits perfectly with the fundamental design to keep the core file manager lean and fast, by delegating repetitive (but not necessarily file manager-specific) tasks to the plugins.
-
-Copy the [plugins](https://github.com/jarun/nnn/tree/master/plugins) of your interest to `~/.config/nnn/plugins`.
+To extend the capabilities of `nnn`, [plugins](https://github.com/jarun/nnn/tree/master/plugins) are introduced. Plugins are scripts which `nnn` can communicate with and trigger. This mechanism fits perfectly with the fundamental design to keep the core file manager lean and fast, by delegating repetitive (but not necessarily file manager-specific) tasks to the plugins.
 
 Use the pick plugin shortcut to visit the plugin directory and execute a plugin. Repeating the same shortcut cancels the operation and puts you back in the original directory.
 

--- a/README.md
+++ b/README.md
@@ -233,6 +233,40 @@ optional args:
 
 Press <kbd>?</kbd> in `nnn` to see the list anytime.
 
+```
+ NAVIGATION
+          ↑ k  Up          PgUp ^U  Scroll up
+          ↓ j  Down        PgDn ^D  Scroll down
+          ← h  Parent dir  ~ ` @ -  HOME, /, start, last
+        ↵ → l  Open file/dir     .  Toggle show hidden
+    Home g ^A  First entry    G ^E  Last entry
+            /  Filter       Ins ^T  Toggle nav-as-you-type
+            b  Pin current dir  ^B  Go to pinned dir
+       Tab ^I  Next context      d  Toggle detail view
+         , ^/  Leader key  N LeadN  Context N
+          Esc  Exit prompt      ^L  Redraw/clear prompt
+           ^G  Quit and cd       q  Quit context
+         Q ^Q  Quit              ?  Help, config
+ FILES
+           ^O  Open with...      n  Create new/link
+            D  File details     ^R  Rename entry
+     ⎵ ^K / Y  Select entry/all  r  Batch rename
+         K ^Y  Toggle selection  y  List selection
+            P  Copy selection    X  Delete selection
+            V  Move selection   ^X  Delete entry
+            f  Create archive  m M  Brief/full mediainfo
+           ^F  Extract archive   F  List archive
+            e  Edit in EDITOR    p  Open in PAGER
+ ORDER TOGGLES
+           ^J  Disk usage        S  Apparent du
+           ^W  Random  s  Size   t  Time modified
+ MISC
+         ! ^]  Spawn SHELL       C  Execute entry
+         R ^V  Pick plugin       L  Lock terminal
+            c  SSHFS mount       u  Unmount
+           ^P  Prompt  ^N  Note  =  Launcher
+```
+
 Note: Help & settings, file details, media info and archive listing are shown in the PAGER. Use the PAGER-specific keys in these screens.
 
 #### Leader key

--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ Have as many scripts as you want to extend the power of `nnn`! Pick from the ava
 - [Troubleshooting](#troubleshooting)
   - [Tmux configuration](#tmux-configuration)
   - [BSD terminal issue](#bsd-terminal-issue)
-  - [Restrict file open](#restrict-file-open)
-  - [Restrict 0-byte files](#restrict-0-byte-files)
+  - [100% CPU usage](#100-cpu-usage)
 - [Why fork?](#why-fork)
 - [Mentions](#mentions)
 - [Developers](#developers)
@@ -345,7 +344,7 @@ The following indicators are used in the detail view:
 | `NNN_USE_EDITOR=1` | open text files in `$EDITOR` (`$VISUAL`, if defined; fallback vi) |
 | `NNN_NO_AUTOSELECT=1` | do not auto-select matching dir in _nav-as-you-type_ mode |
 | `NNN_RESTRICT_NAV_OPEN=1` | open files on <kbd> ↵</kbd>, not <kbd>→</kbd> or <kbd>l</kbd> |
-| `NNN_RESTRICT_0B=1` | do not open 0-byte files |
+| `NNN_RESTRICT_0B=1` | disable 0-byte file open; see [#187](https://github.com/jarun/nnn/issues/187), use _edit_ or _open with_ |
 | `NNN_TRASH=1` | trash files to the desktop Trash [default: delete] |
 | `NNN_OPS_PROG=1` | show copy, move progress on Linux |
 
@@ -404,23 +403,9 @@ TLDR: Use the keybind <kbd>K</kbd> to toggle selection if you are having issues 
 
 By default in OpenBSD & FreeBSD (and probably on macOS as well), `stty` maps <kbd>^Y</kbd> to `DSUSP`. This means that typing <kbd>^Y</kbd> will suspend `nnn` as if you typed <kbd>^Z</kbd> (you can bring `nnn` back to the foreground by issuing `fg`) instead of entering multi-selection mode. You can check this with `stty -a`. If it includes the text `dsusp = ^Y`, issuing `stty dsusp undef` will disable this `DSUSP` and let `nnn` receive the <kbd>^Y</kbd> instead.
 
-##### Restrict file open
-
-In order to disable opening files on accidental navigation key (<kbd>→</kbd> or <kbd>l</kbd>) press:
-
-    export NNN_RESTRICT_NAV_OPEN=1
-
-Use <kbd>Enter</kbd> to open these files.
-
-##### Restrict 0-byte files
-
-Restrict opening 0-byte files due to [unexpected behaviour](https://github.com/jarun/nnn/issues/187); use _edit_ or _open with_ to open the file.
-
-    export NNN_RESTRICT_0B=1
-
 ##### 100% CPU usage
 
-There is a known issue where if you close the terminal directly with `nnn` waiting for a spawned process to exit, a deadlock occurs and `nnn` uses 100% CPU. Please see issue [#225](https://github.com/jarun/nnn/issues/225) for more details. Make sure you quit the spawned process before closing the terminal. It's not a problem if there is no spawned process.
+There is a known issue where if you close the terminal directly with `nnn` waiting for a spawned process to exit, a deadlock occurs and `nnn` uses 100% CPU. Please see issue [#225](https://github.com/jarun/nnn/issues/225) for more details. Make sure you quit the spawned process before closing the terminal. It's not a problem if there is no spawned process (`nnn` isn't blocked) as `nnn` checks if the parent process has exited.
 
 #### WHY FORK?
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ It runs on Linux, macOS, Raspberry Pi, BSD, Cygwin, Linux subsystem for Windows 
 - Search
   - Instant filtering with *search-as-you-type*
   - Regex and substring match
-  - Subtree search (needs fzy)
+  - Subtree search to open or edit files (using plugin)
 - Mimes
   - Open with desktop opener or specify a custom app
   - Create, list, extract archive (needs (p)atool)
@@ -136,7 +136,7 @@ It runs on Linux, macOS, Raspberry Pi, BSD, Cygwin, Linux subsystem for Windows 
 | trash-cli | trash files (default: delete) |
 | mediainfo / exiftool | multimedia file details |
 | atool / patool ([integration](https://github.com/jarun/nnn/wiki/hacking-nnn#integrate-patool)) | create, list and extract archives |
-| fzy | app launcher with drop-down menu |
+| fzy | app launcher, subtree search |
 | vidir (from moreutils) | batch rename dir entries |
 | sshfs, fusermount(3) | mount, unmount remote over SSHFS |
 | vlock (Linux), bashlock (macOS), lock(1) (BSD) | terminal locker |
@@ -194,7 +194,7 @@ Option completion scripts for Bash, Fish and Zsh can be found in respective subd
 2. Configure [cd on quit](https://github.com/jarun/nnn/wiki/hacking-nnn#cd-on-quit).
 3. Optionally open all text files in `$EDITOR` (fallback vi): `export NNN_USE_EDITOR=1`
 4. Run `n`.
-5. To use `nnn` as a GUI app launcher with fuzzy selection menu, drop [`nlaunch`](https://github.com/jarun/nnn/blob/master/scripts/nlaunch/nlaunch) somewhere in your `$PATH`. Note that the launcher requires fzy.
+5. To enable the GUI app launcher with a fuzzy drop-down selection menu [`nlaunch`](https://github.com/jarun/nnn/tree/master/scripts/nlaunch), drop it somewhere in your `$PATH`.
 6. Don't memorize keys. Arrows, <kbd>/</kbd> and <kbd>q</kbd> suffice. Press <kbd>?</kbd> for help on keyboard shortcuts anytime.
 
 - For additional functionality [setup plugins](#plugins).

--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ There is a known issue where if you close the terminal directly with `nnn` **_wa
 
 `nnn` was initially forked from [noice](http://git.2f30.org/noice/) but is significantly [different](https://github.com/jarun/nnn/wiki/nnn-vs.-noice) today. I chose to fork because:
 - one can argue my approach deviates from the goal of the original project -  keep the utility `suckless`. `noice` was rudimentary. In my opinion evolution is the taste of time.
-- I would like to have a bit of control on what features are added in the name of desktop integration. A feature-bloat is the last thing in my mind. Check out [nnn design considerations](https://github.com/jarun/nnn/wiki/nnn-design-considerations) for more details.
+- I would like to have a bit of control on what features are added in the name of desktop integration. A feature-bloat is the last thing in my mind. Check out the [design considerations](https://github.com/jarun/nnn/wiki/design-considerations) for more details.
 
 Trivia: The name `nnn` stands for _Noice is Not Noice, a noicer fork..._.
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@
 
 <p align="center"><i>3 modes of nnn (light with filter, detail, du analyzer) with memory usage. Click for a demo video.</i></a></p>
 
-`nnn` is one of the fastest and most lightweight file managers (`~55KB` binary, `~3.5MB` resident memory usage, [highly optimized](https://github.com/jarun/nnn/wiki/performance-factors) code). And yet, it doesn't lack in features!
+`nnn` is smooth... like butter. It's one of the fastest and most lightweight file managers, thanks to a [highly optimized](https://github.com/jarun/nnn/wiki/performance-factors) code. And yet, it doesn't lack in features!
 
-`nnn` works seamlessly with your DE and favourite GUI utilities. It runs on Linux, macOS, Raspberry Pi, BSD, Cygwin, Linux subsystem for Windows and Termux on Android.
+It runs on Linux, macOS, Raspberry Pi, BSD, Cygwin, Linux subsystem for Windows and Termux on Android.
 
-Have as many scripts as you want to extend the power of `nnn`! Pick from the available plugins or add your own.
+`nnn` works seamlessly with DEs and GUI utilities. Several plugins are available to extend its power. New plugins can be added easily.
 
 **[Quickstart](#quickstart)** and see how `nnn` simplifies long desktop sessions.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 <p align="center"><i>3 modes of nnn (light with filter, detail, du analyzer) with memory usage. Click for a demo video.</i></a></p>
 
-`nnn` is smooth... like butter. It's one of the fastest and most lightweight file managers, thanks to a **[highly optimized](https://github.com/jarun/nnn/wiki/performance-factors)** code. And yet, it doesn't lack in features!
+`nnn` is smooth... like butter. It's one of the fastest and most lightweight file managers, thanks to a **[highly optimized](https://github.com/jarun/nnn/wiki/performance)** code. And yet, it doesn't lack in features!
 
 It runs on Linux, macOS, Raspberry Pi, BSD, Cygwin, Linux subsystem for Windows and Termux on Android.
 

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ By default in OpenBSD & FreeBSD (and probably on macOS as well), `stty` maps <kb
 
 ##### 100% CPU usage
 
-There is a known issue where if you close the terminal directly with `nnn` waiting for a spawned process to exit, a deadlock occurs and `nnn` uses 100% CPU. Please see issue [#225](https://github.com/jarun/nnn/issues/225) for more details. Make sure you quit the spawned process before closing the terminal. It's not a problem if there is no spawned process (`nnn` isn't blocked) as `nnn` checks if the parent process has exited.
+There is a known issue where if you close the terminal directly with `nnn` **_waiting for a spawned process_**, a deadlock occurs and `nnn` uses 100% CPU. Please see issue [#225](https://github.com/jarun/nnn/issues/225) for more details. Make sure you quit the spawned process before closing the terminal. It's not a problem if there is no spawned process (`nnn` isn't blocked) as `nnn` checks if the parent process has exited.
 
 #### WHY FORK?
 

--- a/README.md
+++ b/README.md
@@ -418,6 +418,10 @@ Restrict opening 0-byte files due to [unexpected behaviour](https://github.com/j
 
     export NNN_RESTRICT_0B=1
 
+##### 100% CPU usage
+
+There is a known issue where if you close the terminal directly with `nnn` waiting for a spawned process to exit, a deadlock occurs and `nnn` uses 100% CPU. Please see issue [#225](https://github.com/jarun/nnn/issues/225) for more details. Make sure you quit the spawned process before closing the terminal. It's not a problem if there is no spawned process.
+
 #### WHY FORK?
 
 `nnn` was initially forked from [noice](http://git.2f30.org/noice/) but is significantly [different](https://github.com/jarun/nnn/wiki/nnn-vs.-noice) today. I chose to fork because:

--- a/nnn.1
+++ b/nnn.1
@@ -154,11 +154,6 @@ when dealing with the !, e and p commands respectively. A single combination to 
     export NNN_OPENER=mimeopen
 .Ed
 .Pp
-\fBNNN_OPENER_DETACH:\fR do not block when invoking file opener.
-.Bd -literal
-    export NNN_OPENER_DETACH=1
-.Ed
-.Pp
 \fBNNN_CONTEXT_COLORS:\fR string of color codes for each context, e.g.:
 .Bd -literal
     export NNN_CONTEXT_COLORS='1234'

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -21,9 +21,9 @@
 
 #### Installing plugins
 
-Download the `getplugs` plugin and execute it to get all the plugins. You can run it again later to update the plugins.
+Download the `getplugs` plugin and execute it anywhere to get all the plugins installed to `~/.config/nnn/plugins`. You can run it again later to update the plugins.
 
-Note that `getplugs` also downloads the launcher `nlaunch` which you have to drop somewhere in your `$PATH` manually.
+**NOTE:** `getplugs` also downloads the launcher `nlaunch` and tries to place it at `/usr/local/bin/` using `sudo`. If it fails you have to place `nlauch` manually somewhere in your `$PATH`.
 
 #### File access from plugins
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -13,6 +13,7 @@
 | nmount | sh | pmount | Toggle mount status of a device as normal user |
 | nwal | sh | nitrogen | Set the selected image as wallpaper using nitrogen |
 | pastebin | sh | [pastebinit](https://launchpad.net/pastebinit) | Paste contents of current (text) file to paste.ubuntu.com |
+| pdfview | sh | pdftotext, `$PAGER` | View current PDF file |
 | picker | sh | nnn | Pick files and pipe the newline-separated list to another utility |
 | pywal | sh | pywal | Set selected image as wallpaper, change terminal color scheme |
 | sxiv | sh | sxiv | Browse images in a dir in sxiv, set wallpaper, copy path ([config](https://wiki.archlinux.org/index.php/Sxiv#Assigning_keyboard_shortcuts))|

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -19,6 +19,12 @@
 | transfer | sh | curl | Upload current file to transfer.sh |
 | upgrade | sh | wget | Upgrade to latest nnn version manually on Debian 9 Stretch |
 
+#### Installing plugins
+
+Download the `getplugs` plugin and execute it to get all the plugins. You can run it again later to update the plugins.
+
+Note that `getplugs` also downloads the launcher `nlaunch` which you have to drop somewhere in your `$PATH` manually.
+
 #### File access from plugins
 
 Plugins can access:

--- a/plugins/getplugs
+++ b/plugins/getplugs
@@ -10,5 +10,5 @@ cd ~/.config/nnn/plugins
 wget -nv --show-progress https://github.com/jarun/nnn/archive/master.tar.gz
 tar -xf master.tar.gz
 cp -vf nnn-master/plugins/* .
-cp -vf nnn-master/scripts/nlaunch/nlaunch .
+sudo mv -vf nnn-master/scripts/nlaunch/nlaunch /usr/local/bin/
 rm -rf nnn-master/ master.tar.gz README.md

--- a/plugins/getplugs
+++ b/plugins/getplugs
@@ -5,7 +5,10 @@
 # Shell: POSIX compliant
 # Author: Arun Prakash Jana
 
+mkdir -p ~/.config/nnn/plugins
+cd ~/.config/nnn/plugins
 wget -nv --show-progress https://github.com/jarun/nnn/archive/master.tar.gz
 tar -xf master.tar.gz
 cp -vf nnn-master/plugins/* .
+cp -vf nnn-master/scripts/nlaunch/nlaunch .
 rm -rf nnn-master/ master.tar.gz README.md

--- a/plugins/nmount
+++ b/plugins/nmount
@@ -1,7 +1,8 @@
 #!/usr/bin/env sh
 
 # Description: Toggle mount status of a device using pmount
-#              If the device is mounted, it will be unmounted and vice versa.
+#              If the device is not mounted, it will be mounted.
+#              If the device is mounted, it will be unmounted and powered down.
 #
 # Shell: POSIX compliant
 # Author: Arun Prakash Jana
@@ -19,7 +20,10 @@ echo
 
 if grep -qs "$dev " /proc/mounts; then
     pumount "$dev"
-    echo $dev unmounted.
+    if [ "$?" -eq "0" ]; then
+        udisksctl power-off -b /dev/"$dev"
+        echo $dev ejected.
+    fi
 else
     pmount "$dev"
     echo "$dev" mounted to "$(lsblk -n /dev/"$dev" | rev | cut -d' ' -f1 | rev)".

--- a/plugins/nmount
+++ b/plugins/nmount
@@ -12,22 +12,24 @@ echo
 echo -n "device (e.g. sdc2): "
 read dev
 
-if [ -z "$dev" ]; then
-    exit 1
-fi
-
-echo
-
-if grep -qs "$dev " /proc/mounts; then
-    sync
-    pumount "$dev"
-    if [ "$?" -eq "0" ]; then
-        udisksctl power-off -b /dev/"$dev"
-        echo $dev ejected.
+while ! [ -z "$dev" ]
+do
+    if grep -qs "$dev " /proc/mounts; then
+        sync
+        pumount "$dev"
+        if [ "$?" -eq "0" ]; then
+            echo "$dev" unmounted.
+            udisksctl power-off -b /dev/"$dev"
+            if [ "$?" -eq "0" ]; then
+                echo "$dev" ejected.
+            fi
+        fi
+    else
+        pmount "$dev"
+        echo "$dev" mounted to "$(lsblk -n /dev/"$dev" | rev | cut -d' ' -f1 | rev)".
     fi
-else
-    pmount "$dev"
-    echo "$dev" mounted to "$(lsblk -n /dev/"$dev" | rev | cut -d' ' -f1 | rev)".
-fi
 
-read dummy
+    echo
+    echo -n "next device: "
+    read dev
+done

--- a/plugins/nmount
+++ b/plugins/nmount
@@ -19,6 +19,7 @@ fi
 echo
 
 if grep -qs "$dev " /proc/mounts; then
+    sync
     pumount "$dev"
     if [ "$?" -eq "0" ]; then
         udisksctl power-off -b /dev/"$dev"

--- a/plugins/pdfview
+++ b/plugins/pdfview
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+# Description: View a PDF file in pager
+#
+# Shell: POSIX compliant
+# Author: Arun Prakash Jana
+
+if ! [ -z "$1" ]; then
+    if [ $(head -c 4 "$1") = "%PDF" ]; then
+        pdftotext -nopgbrk -layout "$1" - | sed 's/\xe2\x80\x8b//g' | $PAGER
+    fi
+fi

--- a/scripts/nlaunch/README.md
+++ b/scripts/nlaunch/README.md
@@ -1,4 +1,4 @@
-`nlaunch` is an independent POSIX-compliant GUI application launcher shell script.
+`nlaunch` is an independent POSIX-compliant GUI application launcher shell script. To use it with `nnn` you need to mark the file executable and drop it somewhere in your `$PATH`.
 
 It requires [`fzy`](https://github.com/jhawthorn/fzy) to show a fuzzy drop-down menu.
 

--- a/scripts/nlaunch/README.md
+++ b/scripts/nlaunch/README.md
@@ -1,1 +1,5 @@
 `nlaunch` is an independent POSIX-compliant GUI application launcher shell script. Its only dependency is `fzy`. It's possible to set a keyboard shortcut to open `nlaunch` in a terminal and use it as the regular launcher.
+
+To use `nlaunch` as an independent launcher add a keybind to open `nlaunch` in a terminal e.g.
+
+    xfce4-terminal -e nlaunch

--- a/scripts/nlaunch/README.md
+++ b/scripts/nlaunch/README.md
@@ -1,0 +1,1 @@
+`nlaunch` is an independent POSIX-compliant GUI application launcher shell script. Its only dependency is `fzy`. It's possible to set a keyboard shortcut to open `nlaunch` in a terminal and use it as the regular launcher.

--- a/scripts/nlaunch/README.md
+++ b/scripts/nlaunch/README.md
@@ -1,4 +1,6 @@
-`nlaunch` is an independent POSIX-compliant GUI application launcher shell script. Its only dependency is `fzy`. It's possible to set a keyboard shortcut to open `nlaunch` in a terminal and use it as the regular launcher.
+`nlaunch` is an independent POSIX-compliant GUI application launcher shell script.
+
+It requires [`fzy`](https://github.com/jhawthorn/fzy) to show a fuzzy drop-down menu.
 
 To use `nlaunch` as an independent launcher add a keybind to open `nlaunch` in a terminal e.g.
 

--- a/scripts/nlaunch/nlaunch
+++ b/scripts/nlaunch/nlaunch
@@ -6,6 +6,9 @@
 #
 #              Requires fzy.
 #
+#              Usage: nlaunch [delay]
+#                     delay is in seconds, if omitted nlaunch waits for 1 sec
+#
 # Shell: POSIX compliant
 # Author: Arun Prakash Jana
 
@@ -17,4 +20,10 @@ get_selection() {
 
 if selection=$( get_selection ); then
     setsid "$selection" 2>/dev/null 1>/dev/null &
+
+    if ! [ -z "$1" ]; then
+        sleep "$1"
+    else
+        sleep 1
+    fi
 fi

--- a/scripts/nlaunch/nlaunch
+++ b/scripts/nlaunch/nlaunch
@@ -16,5 +16,5 @@ get_selection() {
 }
 
 if selection=$( get_selection ); then
-    "$selection" 2>/dev/null 1>/dev/null &
+    setsid "$selection" 2>/dev/null 1>/dev/null &
 fi

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3170,9 +3170,9 @@ nochange:
 				// Single click just selects, double click also opens
 				if (event.bstate != BUTTON1_DOUBLE_CLICKED)
 					break;
-				// fallthrough
+				// fallthrough to select the file
 			} else
-				goto nochange;
+				goto nochange; // fallthrough
 		case SEL_NAV_IN: // fallthrough
 		case SEL_GOIN:
 			/* Cannot descend in empty directories */

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -2017,8 +2017,8 @@ static char *coolsize(off_t size)
 {
 	static const char * const U = "BKMGTPEZY";
 	static char size_buf[12]; /* Buffer to hold human readable size */
-	static off_t rem;
-	static int i;
+	off_t rem;
+	int i;
 
 	rem = i = 0;
 
@@ -2065,19 +2065,21 @@ static char *coolsize(off_t size)
 	}
 
 	if (i > 0 && i < 6)
-		snprintf(size_buf, 12, "%lu.%0*lu%c", (ulong)size, i, (ulong)rem, U[i]);
+		snprintf(size_buf, 12, "%lu.%0*lu%c", size, i, rem, U[i]);
 	else
-		snprintf(size_buf, 12, "%lu%c", (ulong)size, U[i]);
+		snprintf(size_buf, 12, "%lu%c", size, U[i]);
 
 	return size_buf;
 }
 
-static char *get_file_sym(mode_t mode)
+static void printent(const struct entry *ent, int sel, uint namecols)
 {
-	static char ind[2];
+	const char *pname = unescape(ent->name, namecols);
+	const char cp = (ent->flags & FILE_COPIED) ? '+' : ' ';
+	char ind[2];
+	mode_t mode = ent->mode;
 
-	ind[0] = '\0';
-	ind[1] = '\0';
+	ind[0] = ind[1] = '\0';
 
 	switch (mode & S_IFMT) {
 	case S_IFREG:
@@ -2104,18 +2106,10 @@ static char *get_file_sym(mode_t mode)
 		break;
 	}
 
-	return ind;
-}
-
-static void printent(const struct entry *ent, int sel, uint namecols)
-{
-	const char *pname = unescape(ent->name, namecols);
-	const char cp = (ent->flags & FILE_COPIED) ? '+' : ' ';
-
 	/* Directories are always shown on top */
 	resetdircolor(ent->flags);
 
-	printw("%s%c%s%s\n", CURSYM(sel), cp, pname, get_file_sym(ent->mode));
+	printw("%s%c%s%s\n", CURSYM(sel), cp, pname, ind);
 }
 
 static void printent_long(const struct entry *ent, int sel, uint namecols)

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -1023,10 +1023,8 @@ static int spawn(char *file, char *arg1, char *arg2, const char *dir, uchar flag
 		retstatus = join(pid, flag);
 
 		DPRINTF_D(pid);
-		if (flag & F_NORMAL) {
-			nonl();
-			noecho();
-		}
+		if (flag & F_NORMAL)
+			refresh();
 
 		free(cmd);
 	}

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3107,7 +3107,6 @@ begin:
 
 	while (1) {
 		redraw(path);
-        onscreen = xlines - 4;
 nochange:
 		/* Exit if parent has exited */
 		if (getppid() == 1)
@@ -3277,6 +3276,7 @@ nochange:
 			break;
 		case SEL_PGDN: // fallthrough
 		case SEL_CTRL_D:
+			onscreen = xlines - 4;
 			r = sel == SEL_PGDN ? onscreen - 1 : onscreen >> 1;
 			curscroll = MIN(ndents - onscreen, curscroll + r);
 			cur = (curscroll == ndents - onscreen) ? cur + r :
@@ -3285,6 +3285,7 @@ nochange:
 			break;
 		case SEL_PGUP: // fallthrough
 		case SEL_CTRL_U:
+			onscreen = xlines - 4;
 			r = sel == SEL_PGUP ? onscreen - 1 : onscreen >> 1;
 			curscroll = MAX(0, curscroll - r);
 			cur = (curscroll == 0) ? cur - r :

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -2895,8 +2895,8 @@ static void redraw(char *path)
 	xcols = COLS;
 
 	int ncols = (xcols <= PATH_MAX) ? xcols : PATH_MAX;
-	int lastln = xlines;
-	int scrolloff = MIN(SCROLLOFF, (xlines-4)>>1);
+	int lastln = xlines, onscreen = xlines - 4;
+	int scrolloff = MIN(SCROLLOFF, onscreen >> 1);
 	int i, attrs;
 	char buf[12];
 	char c;
@@ -2906,12 +2906,12 @@ static void redraw(char *path)
 	/* Clear screen */
 	erase();
 
-	if (ndents <= xlines - 4)
+	if (ndents <= onscreen)
 		curscroll = 0;
 	else if (cur < curscroll + scrolloff)
 		curscroll = MAX(0, cur - scrolloff);
-	else if (cur > curscroll + (xlines - 4) - scrolloff - 1)
-		curscroll = MIN(ndents - (xlines - 4), cur - (xlines - 4) + scrolloff + 1);
+	else if (cur > curscroll + onscreen - scrolloff - 1)
+		curscroll = MIN(ndents - onscreen, cur - onscreen + scrolloff + 1);
 
 #ifdef DIR_LIMITED_COPY
 	if (cfg.copymode)
@@ -2978,7 +2978,7 @@ static void redraw(char *path)
 	}
 
 	/* Print listing */
-	for (i = curscroll; i < ndents && i < curscroll + (xlines - 4); ++i) {
+	for (i = curscroll; i < ndents && i < curscroll + onscreen; ++i) {
 		printptr(&dents[i], i == cur, ncols);
 	}
 
@@ -3170,7 +3170,6 @@ nochange:
 				// Single click just selects, double click also opens
 				if (event.bstate != BUTTON1_DOUBLE_CLICKED)
 					break;
-				// fallthrough to select the file
 			} else
 				goto nochange; // fallthrough
 		case SEL_NAV_IN: // fallthrough

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -731,6 +731,12 @@ static char *xbasename(char *path)
 	return base ? base + 1 : path;
 }
 
+static int create_tmp_file()
+{
+	xstrlcpy(g_tmpfpath + g_tmpfplen - 1, messages[STR_TMPFILE], TMP_LEN_MAX - g_tmpfplen);
+	return mkstemp(g_tmpfpath);
+}
+
 /* Writes buflen char(s) from buf to a file */
 static void writecp(const char *buf, const size_t buflen)
 {
@@ -792,9 +798,7 @@ static void showcplist(void)
 	if (!copybufpos)
 		return;
 
-	xstrlcpy(g_tmpfpath + g_tmpfplen - 1, messages[STR_TMPFILE], TMP_LEN_MAX - g_tmpfplen);
-
-	fd = mkstemp(g_tmpfpath);
+	fd = create_tmp_file();
 	if (fd == -1) {
 		DPRINTF_S("mkstemp failed!");
 		return;
@@ -2312,9 +2316,7 @@ static bool show_stats(const char *fpath, const char *fname, const struct stat *
 	size_t r;
 	FILE *fp;
 
-	xstrlcpy(g_tmpfpath + g_tmpfplen - 1, messages[STR_TMPFILE], TMP_LEN_MAX - g_tmpfplen);
-
-	fd = mkstemp(g_tmpfpath);
+	fd = create_tmp_file();
 	if (fd == -1)
 		return FALSE;
 
@@ -2567,9 +2569,7 @@ static bool show_help(const char *path)
 	          "cc  SSHFS mount       u  Unmount\n"
 		 "b^P  Prompt  ^N  Note  =  Launcher\n"};
 
-	xstrlcpy(g_tmpfpath + g_tmpfplen - 1, messages[STR_TMPFILE], TMP_LEN_MAX - g_tmpfplen);
-
-	fd = mkstemp(g_tmpfpath);
+	fd = create_tmp_file();
 	if (fd == -1)
 		return FALSE;
 

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3136,6 +3136,7 @@ nochange:
 		case SEL_CLICK:
 			if (getmouse(&event) != OK)
 				break;
+
 			// Handle clicking on a context at the top:
 			if (event.y == 0) {
 				// Get context from: "[1 2 3 4]..."
@@ -3155,6 +3156,7 @@ nochange:
 				}
 				break;
 			}
+
 			// Handle clicking on a file:
 			if (2 <= event.y && event.y < LINES - 2) {
 				r = 0;
@@ -3168,10 +3170,9 @@ nochange:
 				cur = r;
 				// Single click just selects, double click also opens
 				if (event.bstate != BUTTON1_DOUBLE_CLICKED)
-					break;
-			} else {
+					break; // fallthrough
+			} else
 				break;
-			}
 		case SEL_NAV_IN: // fallthrough
 		case SEL_GOIN:
 			/* Cannot descend in empty directories */

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3170,7 +3170,7 @@ nochange:
 				// Single click just selects, double click also opens
 				if (event.bstate != BUTTON1_DOUBLE_CLICKED)
 					break;
-                // fallthrough
+				// fallthrough
 			} else
 				goto nochange;
 		case SEL_NAV_IN: // fallthrough

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -2070,9 +2070,9 @@ static char *coolsize(off_t size)
 	}
 
 	if (i > 0 && i < 6)
-		snprintf(size_buf, 12, "%lu.%0*lu%c", size, i, rem, U[i]);
+		snprintf(size_buf, 12, "%lu.%0*lu%c", (long)size, i, (long)rem, U[i]);
 	else
-		snprintf(size_buf, 12, "%lu%c", size, U[i]);
+		snprintf(size_buf, 12, "%lu%c", (long)size, U[i]);
 
 	return size_buf;
 }

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3275,21 +3275,21 @@ nochange:
 				/* Roll over, set cursor to last entry */
 				cur = ndents - 1;
 			break;
-		case SEL_PGDN:
-			if (cur < ndents - 1)
-				cur += MIN((xlines - 4), ndents - 1 - cur);
-			break;
-		case SEL_PGUP:
-			if (cur > 0)
-				cur -= MIN((xlines - 4), cur);
-			break;
+		case SEL_PGDN: // fallthrough
 		case SEL_CTRL_D:
-			if (cur < ndents - 1)
-				cur += MIN((xlines - 4) / 2, ndents - 1 - cur);
+			r = sel == SEL_PGDN ? (xlines - 4) - 1 : (xlines - 4) / 2;
+			curscroll = MIN(ndents - (xlines - 4), curscroll + r);
+			cur = (curscroll == ndents - (xlines - 4)) ? cur + r :
+				curscroll + MIN(SCROLLOFF, (xlines - 4) >> 1);
+			cur = MIN(ndents - 1, cur);
 			break;
+		case SEL_PGUP: // fallthrough
 		case SEL_CTRL_U:
-			if (cur > 0)
-				cur -= MIN((xlines - 4) / 2, cur);
+			r = sel == SEL_PGUP ? (xlines - 4) - 1 : (xlines - 4) / 2;
+			curscroll = MAX(0, curscroll - r);
+			cur = (curscroll == 0) ? cur - r :
+				curscroll + (xlines - 4) - MIN(SCROLLOFF, (xlines - 4) >> 1) - 1;
+			cur = MAX(0, cur);
 			break;
 		case SEL_HOME:
 			cur = 0;

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -1169,7 +1169,7 @@ static void rename_selection(const char *path)
 	while ((i = read(fd1, buf, sizeof(buf))) > 0) {
 		while (i) len += buf[--i] == '\n';
 	}
-    if (i < 0) goto finished_renaming;
+	if (i < 0) goto finished_renaming;
 
 	// Reopen file descriptor to get updated contents:
 	if ((fd2 = open(frenamed, O_RDONLY)) == -1)
@@ -1177,7 +1177,7 @@ static void rename_selection(const char *path)
 	while ((i = read(fd2, buf, sizeof(buf))) > 0) {
 		while (i) len2 += buf[--i] == '\n';
 	}
-    if (i < 0) goto finished_renaming;
+	if (i < 0) goto finished_renaming;
 
 	if (len2 != len) {
 		get_input("Error: wrong number of filenames. Press any key to continue...");

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -2070,9 +2070,9 @@ static char *coolsize(off_t size)
 	}
 
 	if (i > 0 && i < 6)
-		snprintf(size_buf, 12, "%lu.%0*lu%c", (long)size, i, (long)rem, U[i]);
+		snprintf(size_buf, 12, "%lu.%0*lu%c", (ulong)size, i, (ulong)rem, U[i]);
 	else
-		snprintf(size_buf, 12, "%lu%c", (long)size, U[i]);
+		snprintf(size_buf, 12, "%lu%c", (ulong)size, U[i]);
 
 	return size_buf;
 }

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -1129,7 +1129,7 @@ static void rename_selection(const char *path)
 	char *name;
 
 	strncpy(fselected, g_tmpfpath, g_tmpfplen);
-	strlcat(fselected, messages[STR_TMPFILE], strlen(messages[STR_TMPFILE]));
+	strncat(fselected, messages[STR_TMPFILE], strlen(messages[STR_TMPFILE]));
 	strncpy(frenamed, fselected, PATH_MAX);
 
 	if ((fd1 = mkstemp(fselected)) == -1)

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3158,9 +3158,10 @@ nochange:
 			// Handle clicking on a file:
 			if (2 <= event.y && event.y < xlines - 2) {
 				// Get index of the first file listed on-screen:
-				r = MIN(MAX(0, cur-((xlines-4)>>1)), ndents-(xlines-4));
+				r = MAX(0, MIN(cur-((xlines-4)>>1), ndents-(xlines-4)));
 				// Add the mouse click position to get the clicked file:
 				r += event.y - 2;
+                printf("CLICKED: %d", r);
 
 				if (r >= ndents)
 					goto nochange;

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3161,7 +3161,6 @@ nochange:
 				r = MAX(0, MIN(cur-((xlines-4)>>1), ndents-(xlines-4)));
 				// Add the mouse click position to get the clicked file:
 				r += event.y - 2;
-                printf("CLICKED: %d", r);
 
 				if (r >= ndents)
 					goto nochange;

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3170,8 +3170,9 @@ nochange:
 				// Single click just selects, double click also opens
 				if (event.bstate != BUTTON1_DOUBLE_CLICKED)
 					break;
+                // fallthrough
 			} else
-				goto nochange; // fallthrough
+				goto nochange;
 		case SEL_NAV_IN: // fallthrough
 		case SEL_GOIN:
 			/* Cannot descend in empty directories */

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3135,14 +3135,16 @@ nochange:
 			goto begin;
 		case SEL_CLICK:
 			if (getmouse(&event) != OK)
-				break;
+				goto nochange;
 
 			// Handle clicking on a context at the top:
 			if (event.y == 0) {
 				// Get context from: "[1 2 3 4]..."
 				r = event.x/2;
-				if (event.x != 1 + 2*r)
-					break; // The character after the context number
+
+				if (event.x != 1 + (r << 1))
+					goto nochange; // The character after the context number
+
 				if (0 <= r && r < CTX_MAX && r != cfg.curctx) {
 					savecurctx(&cfg, path, dents[cur].name, r);
 
@@ -3154,25 +3156,26 @@ nochange:
 					setdirwatch();
 					goto begin;
 				}
-				break;
+				goto nochange;
 			}
 
 			// Handle clicking on a file:
-			if (2 <= event.y && event.y < LINES - 2) {
-				r = 0;
-				if (cur-(LINES-4)/2 > 0)
-					r = cur-(LINES-4)/2;
-				if (ndents >= LINES-4 && ndents - (LINES-4) < r)
-					r = ndents - (LINES-4);
-				r += event.y - 2;
+			if (2 <= event.y && event.y < xlines - 2) {
+				r = event.y - 2;
+
 				if (r >= ndents)
-					break;
-				cur = r;
+					goto nochange;
+
+				if (ndents > (xlines - 4) && cur >= ((xlines - 4) >> 1))
+					cur -= ((xlines - 4) >> 1) - r;
+				else
+					cur = r;
+
 				// Single click just selects, double click also opens
 				if (event.bstate != BUTTON1_DOUBLE_CLICKED)
-					break; // fallthrough
+					break;
 			} else
-				break;
+				goto nochange; // fallthrough
 		case SEL_NAV_IN: // fallthrough
 		case SEL_GOIN:
 			/* Cannot descend in empty directories */

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -291,7 +291,6 @@ static bm bookmark[BM_MAX];
 static size_t g_tmpfplen;
 static uchar g_crc;
 static uchar BLK_SHIFT = 9;
-static uchar opener_flag = F_NOTRACE;
 static bool interrupted = FALSE;
 
 /* Retain old signal handlers */
@@ -392,10 +391,9 @@ static const char * const messages[] = {
 #define NNN_NO_AUTOSELECT 9
 #define NNN_RESTRICT_NAV_OPEN 10
 #define NNN_RESTRICT_0B 11
-#define NNN_OPENER_DETACH 12
-#define NNN_TRASH 13
+#define NNN_TRASH 12
 #ifdef __linux__
-#define NNN_OPS_PROG 14
+#define NNN_OPS_PROG 13
 #endif
 
 static const char * const env_cfg[] = {
@@ -411,7 +409,6 @@ static const char * const env_cfg[] = {
 	"NNN_NO_AUTOSELECT",
 	"NNN_RESTRICT_NAV_OPEN",
 	"NNN_RESTRICT_0B",
-	"NNN_OPENER_DETACH",
 	"NNN_TRASH",
 #ifdef __linux__
 	"NNN_OPS_PROG",
@@ -3151,7 +3148,7 @@ nochange:
 				}
 
 				/* Invoke desktop opener as last resort */
-				spawn(opener, newpath, NULL, NULL, opener_flag);
+				spawn(opener, newpath, NULL, NULL, F_NOTRACE | F_NOWAIT);
 				continue;
 			}
 			default:
@@ -4276,8 +4273,6 @@ int main(int argc, char *argv[])
 
 	/* Get custom opener, if set */
 	opener = xgetenv(env_cfg[NNN_OPENER], utils[OPENER]);
-	if (xgetenv_set(env_cfg[NNN_OPENER_DETACH]))
-		opener_flag |= F_NOWAIT;
 	DPRINTF_S(opener);
 
 	/* Parse bookmarks string */
@@ -4321,7 +4316,7 @@ int main(int argc, char *argv[])
 		}
 
 		if (S_ISREG(sb.st_mode)) {
-			spawn(opener, initpath, NULL, NULL, opener_flag);
+			spawn(opener, initpath, NULL, NULL, F_NOTRACE | F_NOWAIT);
 			return 0;
 		}
 	}

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3757,7 +3757,14 @@ nochange:
 				tmp = xreadline(tmp, "archive name: ");
 				break;
 			case SEL_OPENWITH:
+#ifdef NORL
 				tmp = xreadline(NULL, "open with: ");
+#else
+				presel = 0;
+				tmp = getreadline("open with: ", path, ipath, &presel);
+				if (presel == MSGWAIT)
+					goto nochange;
+#endif
 				break;
 			case SEL_NEW:
 				tmp = xreadline(NULL, "name/link suffix [@ for none]: ");

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3029,7 +3029,7 @@ static void browse(char *ipath)
 	char mark[PATH_MAX] __attribute__ ((aligned));
 	char rundir[PATH_MAX] __attribute__ ((aligned));
 	char runfile[NAME_MAX + 1] __attribute__ ((aligned));
-	int r = -1, fd, presel, ncp = 0, copystartid = 0, copyendid = 0;
+	int r = -1, fd, presel, ncp = 0, copystartid = 0, copyendid = 0, onscreen;
 	enum action sel;
 	bool dir_changed = FALSE;
 	struct stat sb;
@@ -3107,6 +3107,7 @@ begin:
 
 	while (1) {
 		redraw(path);
+        onscreen = xlines - 4;
 nochange:
 		/* Exit if parent has exited */
 		if (getppid() == 1)
@@ -3139,7 +3140,7 @@ nochange:
 			// Handle clicking on a context at the top:
 			if (event.y == 0) {
 				// Get context from: "[1 2 3 4]..."
-				r = event.x/2;
+				r = event.x >> 1;
 
 				if (event.x != 1 + (r << 1))
 					goto nochange; // The character after the context number
@@ -3276,18 +3277,18 @@ nochange:
 			break;
 		case SEL_PGDN: // fallthrough
 		case SEL_CTRL_D:
-			r = sel == SEL_PGDN ? (xlines - 4) - 1 : (xlines - 4) / 2;
-			curscroll = MIN(ndents - (xlines - 4), curscroll + r);
-			cur = (curscroll == ndents - (xlines - 4)) ? cur + r :
-				curscroll + MIN(SCROLLOFF, (xlines - 4) >> 1);
+			r = sel == SEL_PGDN ? onscreen - 1 : onscreen >> 1;
+			curscroll = MIN(ndents - onscreen, curscroll + r);
+			cur = (curscroll == ndents - onscreen) ? cur + r :
+				curscroll + MIN(SCROLLOFF, onscreen >> 1);
 			cur = MIN(ndents - 1, cur);
 			break;
 		case SEL_PGUP: // fallthrough
 		case SEL_CTRL_U:
-			r = sel == SEL_PGUP ? (xlines - 4) - 1 : (xlines - 4) / 2;
+			r = sel == SEL_PGUP ? onscreen - 1 : onscreen >> 1;
 			curscroll = MAX(0, curscroll - r);
 			cur = (curscroll == 0) ? cur - r :
-				curscroll + (xlines - 4) - MIN(SCROLLOFF, (xlines - 4) >> 1) - 1;
+				curscroll + onscreen - MIN(SCROLLOFF, onscreen >> 1) - 1;
 			cur = MAX(0, cur);
 			break;
 		case SEL_HOME:

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -109,6 +109,8 @@
 #define LEN(x) (sizeof(x) / sizeof(*(x)))
 #undef MIN
 #define MIN(x, y) ((x) < (y) ? (x) : (y))
+#undef MAX
+#define MAX(x, y) ((x) > (y) ? (x) : (y))
 #define ISODD(x) ((x) & 1)
 #define ISBLANK(x) ((x) == ' ' || (x) == '\t')
 #define TOUPPER(ch) \
@@ -3155,15 +3157,15 @@ nochange:
 
 			// Handle clicking on a file:
 			if (2 <= event.y && event.y < xlines - 2) {
-				r = event.y - 2;
+				// Get index of the first file listed on-screen:
+				r = MIN(MAX(0, cur-((xlines-4)>>1)), ndents-(xlines-4));
+				// Add the mouse click position to get the clicked file:
+				r += event.y - 2;
 
 				if (r >= ndents)
 					goto nochange;
 
-				if (ndents > (xlines - 4) && cur >= ((xlines - 4) >> 1))
-					cur -= ((xlines - 4) >> 1) - r;
-				else
-					cur = r;
+				cur = r;
 
 				// Single click just selects, double click also opens
 				if (event.bstate != BUTTON1_DOUBLE_CLICKED)

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -4359,10 +4359,6 @@ int main(int argc, char *argv[])
 	if (!setup_config())
 		return 1;
 
-	/* Get custom opener, if set */
-	opener = xgetenv(env_cfg[NNN_OPENER], utils[OPENER]);
-	DPRINTF_S(opener);
-
 	/* Parse bookmarks string */
 	if (!parsebmstr()) {
 		fprintf(stderr, "%s\n", env_cfg[NNN_BMS]);
@@ -4389,23 +4385,6 @@ int main(int argc, char *argv[])
 		if (!initpath) {
 			xerror();
 			return 1;
-		}
-
-		/*
-		 * If nnn is set as the file manager, applications may try to open
-		 * files by invoking nnn. In that case pass the file path to the
-		 * desktop opener and exit.
-		 */
-		struct stat sb;
-
-		if (stat(initpath, &sb) == -1) {
-			xerror();
-			return 1;
-		}
-
-		if (S_ISREG(sb.st_mode)) {
-			spawn(opener, initpath, NULL, NULL, F_NOTRACE | F_NOWAIT);
-			return 0;
 		}
 	}
 
@@ -4443,6 +4422,10 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 #endif
+
+	/* Get custom opener, if set */
+	opener = xgetenv(env_cfg[NNN_OPENER], utils[OPENER]);
+	DPRINTF_S(opener);
 
 	/* Set nnn nesting level, idletimeout used as tmp var */
 	idletimeout = xatoi(getenv(env_cfg[NNNLVL]));

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -1129,7 +1129,7 @@ static void rename_selection(const char *path)
 	char *name;
 
 	strncpy(fselected, g_tmpfpath, g_tmpfplen);
-	strncat(fselected, messages[STR_TMPFILE], PATH_MAX);
+	strlcat(fselected, messages[STR_TMPFILE], strlen(messages[STR_TMPFILE]));
 	strncpy(frenamed, fselected, PATH_MAX);
 
 	if ((fd1 = mkstemp(fselected)) == -1)

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3985,7 +3985,7 @@ nochange:
 				goto begin;
 			case SEL_LAUNCH:
 				if (getutil(utils[NLAUNCH])) {
-					spawn(utils[NLAUNCH], NULL, NULL, path, F_NORMAL);
+					spawn(utils[NLAUNCH], "0", NULL, path, F_NORMAL);
 					break;
 				} // fallthrough
 			default: /* SEL_RUNCMD */


### PR DESCRIPTION
This change removes the vidir external dependency. It's a bit longer than I was expecting because I wanted to support the current behavior of "rename files in the current directory" as well as "rename selected files", which means some code was needed to handle writing the current directory's filenames to a temp file, and all the corresponding error checking. I also added error checking to guard against if the user accidentally added or removed some lines.