### PR TITLE
Don't ignore fwrite errors

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -745,9 +745,9 @@ static void writecp(const char *buf, const size_t buflen)
 		return;
 
 	FILE *fp = fopen(g_cppath, "w");
-
 	if (fp) {
-		fwrite(buf, 1, buflen, fp);
+		if (fwrite(buf, 1, buflen, fp) != buflen)
+			printwarn(NULL);
 		fclose(fp);
 	} else
 		printwarn(NULL);


### PR DESCRIPTION
Fixes warning on CentOS 6:

    src/nnn.c:754: warning: ignoring return value of 'fwrite', declared with attribute warn_unused_result