### PR TITLE
Set CP in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ MANPREFIX ?= $(PREFIX)/share/man
 STRIP ?= strip
 PKG_CONFIG ?= pkg-config
 INSTALL ?= install
+CP ?= cp
 
 CFLAGS_OPTIMIZATION ?= -O3
 


### PR DESCRIPTION
$(CP) is not set by GNU Make
Seems like [1] is a full list of what GNU Make defines implicitly
[1] https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html