### PR TITLE
Fix quitcd snippets for 'zsh' and 'bash'

### DIFF
--- a/misc/quitcd/quitcd.bash
+++ b/misc/quitcd/quitcd.bash
@@ -1,8 +1,8 @@
 n()
 {
-    nnn "$@"
-
     NNN_TMPFILE=${XDG_CONFIG_HOME:-$HOME/.config}/nnn/.lastd
+
+    nnn "$@"
 
     if [ -f $NNN_TMPFILE ]; then
             . $NNN_TMPFILE

--- a/misc/quitcd/quitcd.fish
+++ b/misc/quitcd/quitcd.fish
@@ -3,10 +3,10 @@
 # or, add the lines to the 'config.fish' file.
 
 function n --description 'support nnn quit and change directory'
-    nnn $argv
-
     # NOTE: set NNN_TMPFILE correctly if you use 'XDG_CONFIG_HOME'
     set NNN_TMPFILE ~/.config/nnn/.lastd
+
+    nnn $argv
 
     if test -e $NNN_TMPFILE
             source $NNN_TMPFILE

--- a/misc/quitcd/quitcd.zsh
+++ b/misc/quitcd/quitcd.zsh
@@ -1,8 +1,8 @@
 n()
 {
-    nnn "$@"
-
     NNN_TMPFILE=${XDG_CONFIG_HOME:-$HOME/.config}/nnn/.lastd
+
+    nnn "$@"
 
     if [ -f $NNN_TMPFILE ]; then
             . $NNN_TMPFILE


### PR DESCRIPTION
`NNN_TMPFILE` variable should be declared before  calling`nnn`.