### PR TITLE
stop readline from overwriting LINES

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -4783,7 +4783,9 @@ int main(int argc, char *argv[])
 	setlocale(LC_ALL, "");
 
 #ifndef NORL
+#if RL_READLINE_VERSION >= 0x0603
 	rl_change_environment = 0;
+#endif
 	/* Bind TAB to cycling */
 	rl_variable_bind("completion-ignore-case", "on");
 #ifdef __linux__

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -4783,6 +4783,7 @@ int main(int argc, char *argv[])
 	setlocale(LC_ALL, "");
 
 #ifndef NORL
+	rl_change_environment = 0;
 	/* Bind TAB to cycling */
 	rl_variable_bind("completion-ignore-case", "on");
 #ifdef __linux__

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -4784,6 +4784,7 @@ int main(int argc, char *argv[])
 
 #ifndef NORL
 #if RL_READLINE_VERSION >= 0x0603
+	/* readline would overwrite the WINCH signal hook */
 	rl_change_environment = 0;
 #endif
 	/* Bind TAB to cycling */


### PR DESCRIPTION
Turns out I'm a ducking liar, I guess I found some time to do it now afterall.

The problem was that readline would completely block LINES from updating
after prompting the user. I'm not entirely sure why this happened, but
at least this patch fixes the problem.