### PR TITLE
Make strip explicit for all targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,6 @@ debug: $(SRC)
 
 norl: $(SRC)
 	$(CC) -DNORL $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(BIN) $^ $(LDLIBS)
-	$(STRIP) $(BIN)
 
 install: all
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(PREFIX)/bin


### PR DESCRIPTION
Use only the `strip` target fort stripping the binary.