### PR TITLE
Make selection based archives use relative paths

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -1302,7 +1302,7 @@ static void archive_selection(const char *cmd, const char *archive, const char *
 	char *buf = (char *)malloc(CMD_LEN_MAX * sizeof(char));
 	snprintf(buf, CMD_LEN_MAX,
 #ifdef __linux__
-		 "xargs -0 -a %s %s %s", g_cppath, cmd, archive);
+		"sed -ze 's|^%s/||' '%s' | xargs -0 %s %s", curpath, g_cppath, cmd, archive);
 #else
 		 "cat %s | xargs -0 -o %s %s", g_cppath, cmd, archive);
 #endif

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -1303,6 +1303,9 @@ static void archive_selection(const char *cmd, const char *archive, const char *
 	snprintf(buf, CMD_LEN_MAX,
 #ifdef __linux__
 		"sed -ze 's|^%s/||' '%s' | xargs -0 %s %s", curpath, g_cppath, cmd, archive);
+#elif defined __APPLE__
+		"cat '%s' | tr '\\0' '\n' | sed -e 's|^%s/||' | tr '\n' '\\0' | xargs -0 %s %s",
+		g_cppath, curpath, cmd, archive);
 #else
 		 "cat %s | xargs -0 -o %s %s", g_cppath, cmd, archive);
 #endif


### PR DESCRIPTION
This will create archives relative to your current working directory
rather than a full path when when creating the archive based on your
current selection.

I don't expect this to be adopted to `upstream` but issue #311 seemed to want this and I'm guessing many others expect it to be working this way.