### PR TITLE
Fix 'batch_rename' moving symlinks

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -1213,13 +1213,7 @@ static bool batch_rename(const char *path)
 	int fd1, fd2, i;
 	uint count = 0, lines = 0;
 	bool dir = FALSE, ret = FALSE;
-	const char renamecmd[] =
-#ifdef __OpenBSD__
-		/* OpenBSD does not have the -n option for mv */
-		"paste -d'\n' %s %s | tr '\n' '\\0' | xargs -0 -n2 mv 2>/dev/null";
-#else
-		"paste -d'\n' %s %s | tr '\n' '\\0' | xargs -0 -n2 mv -n 2>/dev/null";
-#endif
+	const char renamecmd[] = "awk 'FNR==NR{a[NR]=$0} a[FNR]!=$0{printf \"%%s\\0%%s\\0\",a[FNR],$0}' %s %s | xargs -0 -n2 mv 2>/dev/null";
 	char foriginal[TMP_LEN_MAX] = {0};
 	char buf[sizeof(renamecmd) + (PATH_MAX << 1)];
 


### PR DESCRIPTION
Replaced paste and tr with awk that only prints the lines that differ. Also there is no need for -n flag on mv as it won't get passed the same source and destination.