### PR TITLE
Fix 100% CPU usage if STDIN closes

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3447,6 +3447,10 @@ nochange:
 			goto begin;
 		}
 
+		/* If STDIN is no longer a tty (closed) we should exit */
+		if(!cfg.picker && !isatty(STDIN_FILENO))
+			return;
+
 		sel = nextsel(presel);
 		if (presel)
 			presel = 0;
@@ -4790,7 +4794,7 @@ int main(int argc, char *argv[])
 	}
 
 	/* Confirm we are in a terminal */
-	if (!cfg.picker && !(isatty(0) && isatty(1)))
+	if (!cfg.picker && !(isatty(STDIN_FILENO) && isatty(STDOUT_FILENO)))
 		exit(1);
 
 	/* Get the context colors; copier used as tmp var */

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3448,7 +3448,7 @@ nochange:
 		}
 
 		/* If STDIN is no longer a tty (closed) we should exit */
-		if(!cfg.picker && !isatty(STDIN_FILENO))
+		if (!isatty(STDIN_FILENO) && !cfg.picker)
 			return;
 
 		sel = nextsel(presel);


### PR DESCRIPTION
As the title says. We should also update the troubleshooting section of the wiki now that this is no longer a thing.

Remember that other programs might not check for this so if you spawn them as children they can still use 100% CPU. People need fix their programs to not do that.