### PR TITLE
do build configuration with variables instead of targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Notes:
 
 #### Library dependencies
 
-A curses library with wide char support (e.g. ncursesw), libreadline (`make norl` to drop) and standard libc.
+A curses library with wide char support (e.g. ncursesw), libreadline (`make O_NORL=1` to drop) and standard libc.
 
 #### Utility dependencies
 


### PR DESCRIPTION
This patch reduces the error-prone copy-pasting of targets for each new configuration and allows any permutation of flags.

Make build options can now be invoked like this:

- `make debug` -> `make O_DEBUG=1`
- `make norl` -> `make O_NORL=1`
- `make noloc` -> `make O_NOLOC=1`

Flags can also be combined, so eg. `noloc` + `debug` is possible with `make O_NOLOC=1 O_DEBUG=1`.

I have also included support for backwards-compatible invocation, so this patch doesn't break anything. This compatibility code can be removed in the future.
