### PR TITLE
Implemented edit selection buffer

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -953,6 +953,7 @@ static bool seledit(void)
 		goto emptyedit;
 	}
 
+	nselected = lines;
 	writesel(pselbuf, selbufpos - 1);
 
 	return TRUE;

--- a/src/nnn.h
+++ b/src/nnn.h
@@ -79,6 +79,7 @@ enum action {
 	SEL_SELMUL,
 	SEL_SELALL,
 	SEL_SELLST,
+	SEL_SELEDIT,
 	SEL_CP,
 	SEL_MV,
 	SEL_RMMUL,
@@ -209,6 +210,8 @@ static struct key bindings[] = {
 	{ 'a',            SEL_SELALL },
 	/* Show list of copied files */
 	{ 'M',            SEL_SELLST },
+	/* Edit selection buffer */
+	{ CONTROL('G'),   SEL_SELEDIT },
 	/* Copy from selection buffer */
 	{ 'P',            SEL_CP },
 	/* Move from selection buffer */

--- a/src/nnn.h
+++ b/src/nnn.h
@@ -211,7 +211,7 @@ static struct key bindings[] = {
 	/* Show list of copied files */
 	{ 'M',            SEL_SELLST },
 	/* Edit selection buffer */
-	{ CONTROL('G'),   SEL_SELEDIT },
+	{ 'K',            SEL_SELEDIT },
 	/* Copy from selection buffer */
 	{ 'P',            SEL_CP },
 	/* Move from selection buffer */


### PR DESCRIPTION
Currently there is no way to unselect something that was wrongly selected other than clearing the whole selection, which at times can get really annoying. The simplest way to solve this was to just allow the user to edit the selection buffer.

As for the keybind, function name and the action name I just chose something so that it has a name. Feel free to suggest other options if you want me to change them.