### PR TITLE
Added 2 plugins for drag and drop support

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -12,6 +12,8 @@ The currently available plugins are listed below.
 | boom | sh | [moc](http://moc.daper.net/) | Play random music from dir |
 | dups | sh | find, md5sum,<br>sort uniq xargs | List non-empty duplicate files in current dir |
 | checksum | sh | md5sum,<br>sha256sum | Create and verify checksums |
+| drag-file | sh | [dragon](https://github.com/mwh/dragon) | Drag and drop files from nnn |
+| drop-file | sh | [dragon](https://github.com/mwh/dragon) | Drag and drop files into nnn |
 | fzy-open | sh | fzy, xdg-open | Fuzzy find a file in dir subtree and edit or xdg-open |
 | getplugs | sh | curl | Update plugins |
 | hexview | sh | xxd | View a file in hex in `$PAGER` |

--- a/plugins/drag-file
+++ b/plugins/drag-file
@@ -1,0 +1,49 @@
+#!/usr/bin/env sh
+
+# Description: Open a Drag and drop window, to drop files onto other programs
+#
+# Shell: POSIX compliant
+# Author: 0xACE
+
+selection=${XDG_CONFIG_HOME:-$HOME/.config}/nnn/.selection
+resp=f
+all=
+
+dnd()
+{
+    dragon "$@"
+}
+
+function use_all()
+{
+    echo -n "mark --all (a) [default=none]: "
+    read resp
+    if [ "$resp" = "a" ]; then
+        all="--all"
+    else
+        all=""
+    fi
+}
+
+if [ -s "$selection" ]; then
+    echo -n "work with selection (s), current working directory (d) or current file (f) [default=f]: "
+    read resp
+else
+    echo -n "work with current working directory (d) or current file (f) [default=f]: "
+    read resp
+    if [ "$resp" = "s" ]; then
+        resp=f
+    fi
+fi
+
+if [ "$resp" = "s" ]; then
+    use_all
+    sed -z 's|'"$PWD/"'||g' < "$selection" | xargs -0 dnd "$all" &
+elif [ "$resp" = "d" ]; then
+    use_all
+    dnd "$all" "$PWD/"* &
+else
+    if [ -n "$1" ] && [ -e "$1" ]; then
+        dnd "$1" &
+    fi
+fi

--- a/plugins/drag-file
+++ b/plugins/drag-file
@@ -2,6 +2,7 @@
 
 # Description: Open a Drag and drop window, to drop files onto other programs
 #
+# Dependency: https://github.com/mwh/dragon
 # Shell: POSIX compliant
 # Author: 0xACE
 

--- a/plugins/drop-file
+++ b/plugins/drop-file
@@ -3,11 +3,12 @@
 # Description: Provides drag and drop window for files.
 #
 # Files that are dropped will be added to nnn's selection
-# Some webbased files will be downloaded to current directory with curl
+# Some web based files will be downloaded to current directory with curl
 # and it may overwrite some existing files
 #
-# The user has to mm to clear nnn's selection first
+# The user has to press mm to clear nnn's selection first
 #
+# Dependency: https://github.com/mwh/dragon
 # Shell: POSIX compliant
 # Author: 0xACE
 

--- a/plugins/drop-file
+++ b/plugins/drop-file
@@ -1,0 +1,39 @@
+#!/usr/bin/env sh
+
+# Description: Provides drag and drop window for files.
+#
+# Files that are dropped will be added to nnn's selection
+# Some webbased files will be downloaded to current directory with curl
+# and it may overwrite some existing files
+#
+# The user has to mm to clear nnn's selection first
+#
+# Shell: POSIX compliant
+# Author: 0xACE
+
+selection=${XDG_CONFIG_HOME:-$HOME/.config}/nnn/.selection
+
+dnd()
+{
+    dragon "$@"
+}
+
+function add_file() {
+	echo -n "$@" >> "$selection"
+	echo -ne "\0" >> "$selection"
+}
+
+echo -n > "$selection"
+
+# which dnd
+# upstream calls it dragon
+
+dnd --print-path --target | while read f
+do
+	if echo -n "$f" | grep '^\(https\?\|ftps\?\|s\?ftp\):\/\/' ; then
+		curl -LJO "$f"
+		add_file "$PWD/$(basename "$f")"
+	elif [ -e "$f" ]; then
+		add_file "$f"
+	fi
+done &


### PR DESCRIPTION
These scripts uses https://github.com/mwh/dragon
and curl.

It allows nnn to drag and drop files either to other programs, or to
itself.


Not that I recommend adopting it. But just incase anyone has a need for it, here it is.

It has helped me on multiple occasions, particularly when I want to upload files into the webbrowser via `nnn`.


The shell scripts are not polished and could probably need to be tended by someone who cares more.