### PR TITLE
Check for alternative name for drag/drop exec

### DIFF
--- a/plugins/drag-file
+++ b/plugins/drag-file
@@ -12,7 +12,11 @@ all=
 
 dnd()
 {
-    dragon "$@"
+    if which dragon-drag-and-drop; then
+	dragon-drag-and-drop "$@"
+    else
+	dragon "$@"
+    fi
 }
 
 function use_all()

--- a/plugins/drop-file
+++ b/plugins/drop-file
@@ -16,7 +16,11 @@ selection=${XDG_CONFIG_HOME:-$HOME/.config}/nnn/.selection
 
 dnd()
 {
-    dragon "$@"
+    if which dragon-drag-and-drop; then
+	dragon-drag-and-drop "$@"
+    else
+	dragon "$@"
+    fi
 }
 
 function add_file() {


### PR DESCRIPTION
KDE dragon player collides with the name of the drag/drop dependency. On
archlinux the binary is renamed to `dragon-drag-and-drop`.

This change tries `dragon-drag-and-drop` before defaulting to `dragon`.