### PR TITLE
Remove -Wno-unused-parameter and do cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ else
 	LDLIBS_CURSES ?= -lncurses
 endif
 
-CFLAGS += -Wall -Wextra -Wno-unused-parameter
+CFLAGS += -Wall -Wextra
 CFLAGS += $(CFLAGS_OPTIMIZATION)
 CFLAGS += $(CFLAGS_CURSES)
 


### PR DESCRIPTION
Not truly necessary, but feels cleaner.
Disabling warnings is kind of bad practice.
If a parameter is genuinely not used with a reason for it to be there, be explicit about it locally.
