### PR TITLE
unmount() ask for target if not found

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -2898,7 +2898,7 @@ static bool sshfs_mount(char *newpath, int *presel)
  * Unmounts if the directory represented by name is a mount point.
  * Otherwise, asks for hostname
  */
-static bool unmount(char *name, char *newpath, int *presel)
+static bool unmount(char *name, char *newpath, int *presel, char *currentpath)
 {
 	static char cmd[] = "fusermount3"; /* Arch Linux utility */
 	static bool found = FALSE;
@@ -2913,7 +2913,7 @@ static bool unmount(char *name, char *newpath, int *presel)
 		found = TRUE;
 	}
 
-	if (tmp) {
+	if (tmp && strcmp(cfgdir, currentpath) == 0) {
 		mkpath(cfgdir, tmp, newpath);
 		child = lstat(newpath, &sb) != -1;
 		parent = lstat(dirname(newpath), &psb) != -1;
@@ -4683,7 +4683,7 @@ nochange:
 			goto begin;
 		case SEL_UMOUNT:
 			tmp = ndents ? dents[cur].name : NULL;
-			unmount(tmp, newpath, &presel);
+			unmount(tmp, newpath, &presel, path);
 			goto nochange;
 		case SEL_QUITCD: // fallthrough
 		case SEL_QUIT:


### PR DESCRIPTION
unmount() now properly asks for which target to unmount if it cannot
automatically deduce which folder to unmount.


Btw, the automatic deduction of detecting unmount folder doesn't work nice in:
1. if you are hovering over a `*.zip` which you have previously mounted, you have to go to the mountfolder and then unmount it, rather than `u` over the zip file.
2. if you happen to press `u` while hover over a file which shares the same name as a mountpoint, it will automatically `unmount()` the mountpoint which collides