### PR TITLE
getpulgs now asks before overwriting

### DIFF
--- a/plugins/getplugs
+++ b/plugins/getplugs
@@ -18,7 +18,7 @@ merge () {
 	cp -vRf $1 $2
 }
 
-prompt() {
+prompt () {
 	echo "Plugin $1 already exists and is different."
 	echo -n "Keep (k), merge (m), overwrite (o) [default: k]? "
 	read operation

--- a/plugins/getplugs
+++ b/plugins/getplugs
@@ -13,6 +13,25 @@ is_cmd_exists () {
     echo $?
 }
 
+merge () {
+	vimdiff $1 $2
+	cp -vRf $1 $2
+}
+
+prompt() {
+	echo "Plugin $1 already exists and is different."
+	echo -n "Keep (k), merge (m), overwrite (o) [default: k]? "
+	read operation
+
+	if [ "$operation" = "m" ]; then
+		op="merge"
+	elif [ "$operation" = "o" ]; then
+		op="cp -vRf"
+	else
+		op="true"
+	fi
+}
+
 if [ "$(is_cmd_exists sudo)" -eq "0" ]; then
     sucmd=sudo
 elif [ "$(is_cmd_exists doas)" -eq "0" ]; then
@@ -29,6 +48,19 @@ fi
 cd $CONFIG_DIR
 curl -Ls -O https://github.com/jarun/nnn/archive/master.tar.gz
 tar -zxf master.tar.gz
-cp -vRf nnn-master/plugins .
+
+cd nnn-master/plugins
+for f in *; do
+	if [ -f ../../plugins/$f ]; then
+		if [ "$(diff --brief $f ../../plugins/$f)" ]; then
+			prompt $f
+			$op $f ../../plugins/
+		fi
+	else
+		cp -vRf $f ../../plugins/
+	fi
+done
+cd ../..
+
 $sucmd mv -vf nnn-master/misc/nlaunch/nlaunch /usr/local/bin/
 rm -rf nnn-master/ master.tar.gz README.md


### PR DESCRIPTION
Now it asks before overwriting existing modified plugins and also doesn't copy plugins if they are already there. The output of `cp` looks a bit different now, but I don't think that matters.

I just now noticed that there's a space missing at `prompt`, I'll add it in with any other request if there are any.