### PR TITLE
Fix always archiving current file

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -5043,9 +5043,9 @@ nochange:
 
 				get_archive_cmd(cmd, tmp);
 
-				(r == 'y' || r == 'Y') ? archive_selection(cmd, tmp, path)
-						       : spawn(cmd, tmp, dents[cur].name,
-							       path, F_NORMAL | F_MULTI);
+				(r == 's') ? archive_selection(cmd, tmp, path)
+					   : spawn(cmd, tmp, dents[cur].name,
+						    path, F_NORMAL | F_MULTI);
 				break;
 			}
 			case SEL_OPENWITH:


### PR DESCRIPTION
Sorry if I messed up the formatting, was going by what `git diff` showed. My editor doesn't display it aligned.

Are there any other prompts that where changed but not the logic? I think we should make this part of 2.8, we don't want to break functionality that was previously there.