### PR TITLE
Fix not properly checking if file is selected

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -4863,7 +4863,7 @@ nochange:
 
 			/* Toggle selection status */
 			dents[cur].flags ^= FILE_SELECTED;
-			dents[cur].flags ? ++nselected : --nselected;
+			(dents[cur].flags & FILE_SELECTED) ? ++nselected : --nselected;
 
 			if (!nselected) {
 				writesel(NULL, 0);


### PR DESCRIPTION
This solves the issues described in #400.

> In case I select files with Space, the number of selected files
is shown within the status bar. But when I de-select them again
the plus sign is removed but the number in the status bar is
increased instead of decreased.