### PR TITLE
Indicate when range selection and plugin picker are waiting for input

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3432,6 +3432,14 @@ static void printkv(kv *kvarr, FILE *fp, uchar max)
 		fprintf(fp, " %c: %s\n", (char)kvarr[i].key, kvarr[i].val);
 }
 
+static void sprintkv(kv *kvarr, char *buf, uchar max)
+{
+	uchar i = 0;
+
+	for (; i < max && kvarr[i].key; ++i)
+		buf += snprintf(buf, CMD_LEN_MAX, " %c=%s", (char)kvarr[i].key, kvarr[i].val);
+}
+
 /*
  * The help string tokens (each line) start with a HEX value
  * which indicates the number of spaces to print before the
@@ -5180,10 +5188,15 @@ nochange:
 				}
 
 				if (sel == SEL_PLUGKEY) {
+					xstrlcpy(g_buf, "pick plugin:", CMD_LEN_MAX);
+					sprintkv(plug, g_buf + strlen(g_buf), PLUGIN_MAX);
+					printprompt(g_buf);
 					r = get_input(NULL);
 					tmp = get_kv_val(plug, NULL, r, PLUGIN_MAX, FALSE);
-					if (!tmp)
+					if (!tmp) {
+						clearprompt();
 						goto nochange;
+					}
 
 					if (tmp[0] == '_' && tmp[1]) {
 						xstrlcpy(newpath, ++tmp, PATH_MAX);

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -307,7 +307,6 @@ static context g_ctx[CTX_MAX] __attribute__ ((aligned));
 static int ndents, cur, curscroll, total_dents = ENTRY_INCR;
 static int xlines, xcols;
 static int nselected;
-static bool rangesel;
 static uint idle;
 static uint idletimeout, selbufpos, lastappendpos, selbuflen;
 static char *bmstr;
@@ -333,6 +332,7 @@ static kv plug[PLUGIN_MAX];
 static uchar g_tmpfplen;
 static uchar blk_shift = BLK_SHIFT_512;
 static bool interrupted = FALSE;
+static bool rangesel = FALSE;
 
 /* Retain old signal handlers */
 #ifdef __linux__
@@ -4136,7 +4136,8 @@ static void redraw(char *path)
 			c = cfg.apparentsz ? 'a' : 'd';
 
 			mvprintw(lastln, 0, "%d/%d [%d:%s] %cu:%s free:%s files:%lu %lldB %s",
-				 cur + 1, ndents, cfg.selmode, (rangesel ? "*" : nselected ? xitoa(nselected) : ""),
+				 cur + 1, ndents, cfg.selmode,
+				 (rangesel ? "*" : (nselected ? xitoa(nselected) : "")),
 				 c, buf, coolsize(get_fs_info(path, FREE)), num_files,
 				 (ll)pent->blocks << blk_shift, ptr);
 		} else { /* light or detail mode */
@@ -4149,7 +4150,8 @@ static void redraw(char *path)
 			buf[sizeof(buf)-1] = '\0';
 
 			mvprintw(lastln, 0, "%d/%d [%d:%s] %s%s %s %s %s [%s]",
-				 cur + 1, ndents, cfg.selmode, (rangesel ? "*" : nselected ? xitoa(nselected) : ""),
+				 cur + 1, ndents, cfg.selmode,
+				 (rangesel ? "*" : (nselected ? xitoa(nselected) : "")),
 				 sort, buf, get_lsperms(pent->mode), coolsize(pent->size), ptr, base);
 		}
 	} else


### PR DESCRIPTION
Use `[1:*]` as indicator that range selection is in progress.

Removed `range sel on` popup because it is useless now.

When `;` is pressed, it will show a prompt with all available plugins.

Fixes: #405