### PR TITLE
Show prompt for bookmark selection

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -4620,7 +4620,7 @@ nochange:
 			}
 
 			if (!get_kv_val(bookmark, newpath, fd, BM_MAX, TRUE)) {
-				printwait(messages[MSG_INVBM_KEY], &presel);
+				clearprompt();
 				goto nochange;
 			}
 

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -458,6 +458,7 @@ static char * const utils[] = {
 #define MSG_RCLONE_DELAY 35
 #define MSG_APP_NAME 36
 #define MSG_ARCHIVE_OPTS 37
+#define MSG_PLUGIN_KEYS 38
 
 static const char * const messages[] = {
 	"no traversal",
@@ -498,6 +499,7 @@ static const char * const messages[] = {
 	"may take a while, try refresh",
 	"app name: ",
 	"e'x'tract / 'l'ist / 'm'ount?",
+	"plugin keys:",
 };
 
 /* Supported configuration environment variables */
@@ -3415,12 +3417,12 @@ static void printkv(kv *kvarr, FILE *fp, uchar max)
 		fprintf(fp, " %c: %s\n", (char)kvarr[i].key, kvarr[i].val);
 }
 
-static void sprintkv(kv *kvarr, char *buf, uchar max)
+static void sprintkeys(kv *kvarr, char *buf, uchar max)
 {
 	uchar i = 0;
 
 	for (; i < max && kvarr[i].key; ++i)
-		buf += snprintf(buf, CMD_LEN_MAX, " %c=%s", (char)kvarr[i].key, kvarr[i].val);
+		buf += snprintf(buf, CMD_LEN_MAX, " %c", (char)kvarr[i].key);
 }
 
 /*
@@ -5174,8 +5176,8 @@ nochange:
 				}
 
 				if (sel == SEL_PLUGKEY) {
-					xstrlcpy(g_buf, "pick plugin:", CMD_LEN_MAX);
-					sprintkv(plug, g_buf + strlen(g_buf), PLUGIN_MAX);
+					xstrlcpy(g_buf, messages[MSG_PLUGIN_KEYS], CMD_LEN_MAX);
+					sprintkeys(plug, g_buf + strlen(g_buf), PLUGIN_MAX);
 					printprompt(g_buf);
 					r = get_input(NULL);
 					tmp = get_kv_val(plug, NULL, r, PLUGIN_MAX, FALSE);

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -459,6 +459,7 @@ static char * const utils[] = {
 #define MSG_APP_NAME 36
 #define MSG_ARCHIVE_OPTS 37
 #define MSG_PLUGIN_KEYS 38
+#define MSG_BOOKMARK_KEYS 39
 
 static const char * const messages[] = {
 	"no traversal",
@@ -500,6 +501,7 @@ static const char * const messages[] = {
 	"app name: ",
 	"e'x'tract / 'l'ist / 'm'ount?",
 	"plugin keys:",
+	"bookmark keys:",
 };
 
 /* Supported configuration environment variables */
@@ -4555,6 +4557,9 @@ nochange:
 				fd = sel - SEL_CTX1 + '1';
 				break;
 			default:
+				xstrlcpy(g_buf, messages[MSG_BOOKMARK_KEYS], CMD_LEN_MAX);
+				sprintkeys(bookmark, g_buf + strlen(g_buf), BM_MAX);
+				printprompt(g_buf);
 				fd = get_input(NULL);
 			}
 
@@ -4619,8 +4624,10 @@ nochange:
 				goto nochange;
 			}
 
-			if (!xdiraccess(newpath))
+			if (!xdiraccess(newpath)) {
+				printwait(messages[MSG_ACCESS], &presel);
 				goto nochange;
+			}
 
 			if (strcmp(path, newpath) == 0)
 				break;

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -422,49 +422,46 @@ static char * const utils[] = {
 /* Common strings */
 #define MSG_NO_TRAVERSAL 0
 #define MSG_INVBM_KEY 1
-#define STR_DATE_ID 2
-#define STR_TMPFILE 3
-#define MSG_0_SELECTED 4
-#define MSG_UTIL_MISSING 5
-#define MSG_FAILED 6
-#define MSG_SSN_NAME 7
-#define MSG_CP_MV_AS 8
-#define MSG_CUR_SEL_OPTS 9
-#define MSG_FORCE_RM 10
-#define MSG_CREATE_CTX 11
-#define MSG_NEW_OPTS 12
-#define MSG_CLI_MODE 13
-#define MSG_OVERWRITE 14
-#define MSG_SSN_OPTS 15
-#define MSG_QUIT_ALL 16
-#define MSG_HOSTNAME 17
-#define MSG_ARCHIVE_NAME 18
-#define MSG_OPEN_WITH 19
-#define MSG_REL_PATH 20
-#define MSG_LINK_SUFFIX 21
-#define MSG_COPY_NAME 22
-#define MSG_CONTINUE 23
-#define MSG_SEL_MISSING 24
-#define MSG_ACCESS 25
-#define MSG_0_CREATED 26
-#define MSG_NOT_REG_FILE 27
-#define MSG_PERM_DENIED 28
-#define MSG_EMPTY_FILE 29
-#define MSG_UNSUPPORTED 30
-#define MSG_NOT_SET 31
-#define MSG_DIR_CHANGED 32
-#define MSG_0_FILES 33
-#define MSG_EXISTS 34
-#define MSG_FEW_COLOUMNS 35
-#define MSG_REMOTE_OPTS 36
-#define MSG_RCLONE_DELAY 37
-#define MSG_APP_NAME 38
-#define MSG_ARCHIVE_OPTS 39
+#define STR_TMPFILE 2
+#define MSG_0_SELECTED 3
+#define MSG_UTIL_MISSING 4
+#define MSG_FAILED 5
+#define MSG_SSN_NAME 6
+#define MSG_CP_MV_AS 7
+#define MSG_CUR_SEL_OPTS 8
+#define MSG_FORCE_RM 9
+#define MSG_CREATE_CTX 10
+#define MSG_NEW_OPTS 11
+#define MSG_CLI_MODE 12
+#define MSG_OVERWRITE 13
+#define MSG_SSN_OPTS 14
+#define MSG_QUIT_ALL 15
+#define MSG_HOSTNAME 16
+#define MSG_ARCHIVE_NAME 17
+#define MSG_OPEN_WITH 18
+#define MSG_REL_PATH 19
+#define MSG_LINK_SUFFIX 20
+#define MSG_COPY_NAME 21
+#define MSG_CONTINUE 22
+#define MSG_SEL_MISSING 23
+#define MSG_ACCESS 24
+#define MSG_0_CREATED 25
+#define MSG_NOT_REG_FILE 26
+#define MSG_PERM_DENIED 27
+#define MSG_EMPTY_FILE 28
+#define MSG_UNSUPPORTED 29
+#define MSG_NOT_SET 30
+#define MSG_DIR_CHANGED 31
+#define MSG_EXISTS 32
+#define MSG_FEW_COLUMNS 33
+#define MSG_REMOTE_OPTS 34
+#define MSG_RCLONE_DELAY 35
+#define MSG_APP_NAME 36
+#define MSG_ARCHIVE_OPTS 37
 
 static const char * const messages[] = {
 	"no traversal",
 	"invalid key",
-	"%F %T %z",
 	"/.nnnXXXXXX",
 	"0 selected",
 	"missing util",
@@ -495,7 +492,6 @@ static const char * const messages[] = {
 	"unsupported file",
 	"not set",
 	"dir changed, range sel off",
-	"0 files",
 	"entry exists",
 	"too few columns!",
 	"'s'shfs / 'r'clone?",
@@ -4018,7 +4014,7 @@ static void redraw(char *path)
 
 	/* Fail redraw if < than 10 columns, context info prints 10 chars */
 	if (ncols < MIN_DISPLAY_COLS) {
-		printmsg(messages[MSG_FEW_COLOUMNS]);
+		printmsg(messages[MSG_FEW_COLUMNS]);
 		return;
 	}
 

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3420,9 +3420,14 @@ static void printkv(kv *kvarr, FILE *fp, uchar max)
 static void sprintkeys(kv *kvarr, char *buf, uchar max)
 {
 	uchar i = 0;
+	uchar j = 0;
 
-	for (; i < max && kvarr[i].key; ++i)
-		buf += snprintf(buf, CMD_LEN_MAX, " %c", (char)kvarr[i].key);
+	for (; i < max && kvarr[i].key; ++i, j+=2) {
+		buf[j] = ' ';
+		buf[j+1] = kvarr[i].key;
+	}
+
+	buf[j] = '\0';
 }
 
 /*


### PR DESCRIPTION
Follow-up to #406 

May be easier to review by commits.

Things I want to particularly bring your attention to:

1. I noticed there are 3 unused `MSG_`, I cleaned them up, let me know if this was wrong.

2. We used to error-out when pressing non-existent bookmark key after `,` - this made sense when it was non-interactive, but now that we are showing `bookmark keys: a b c d` it may be intentional that user presses something else to cancel operation. In this case I no longer show error, just silently clear prompt. This is exactly the same behavior as pressing non-existent plugin key after `;`.

> - if you press a bookmark key where the bookmark destination is the same as current dir. You need to clearprompt() here.

This seems to work well out of the box, prompt is cleared even if I choose bookmark destination as the current dir 👍 

> - bookmark destination cannot be accessed. Add a printwait() with "MSG_ACCESS" in this case. it is missing today.

Added 👍 