### PR TITLE
Gracefully abort prompts on Esc

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -4580,6 +4580,9 @@ nochange:
 			}
 
 			switch (fd) {
+			case 27:
+				clearprompt();
+				goto nochange;
 			case '~': // fallthrough
 			case '`': // fallthrough
 			case '-': // fallthrough
@@ -5208,6 +5211,10 @@ nochange:
 					printkeys(plug, g_buf + strlen(g_buf), PLUGIN_MAX);
 					printprompt(g_buf);
 					r = get_input(NULL);
+					if (r == 27) {
+						clearprompt();
+						goto nochange;
+					}
 					tmp = get_kv_val(plug, NULL, r, PLUGIN_MAX, FALSE);
 					if (!tmp) {
 						printwait(messages[MSG_INVALID_KEY], &presel);


### PR DESCRIPTION
Follow-up to https://github.com/jarun/nnn/commit/8d3c24d19fd6a69b63df1d7ce9625838b4c065a0

I like the informative messages, but I want to have an ability to gracefully cancel prompt without error messages.