### PR TITLE
Improvements for distribution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,16 +64,10 @@ jobs:
             # Clean up
             rm -rf ./.git
             rm -rf ./dist/*
-            # Pack source
-            cd ..
-            tar -czf ${CIRCLE_PROJECT_REPONAME}-${CIRCLE_TAG}.tar.gz ${CIRCLE_PROJECT_REPONAME}
-            cd ${CIRCLE_PROJECT_REPONAME}
             # Use latest installed python3 from pyenv
             export PYENV_VERSION="$(pyenv versions | grep -Po '\b3\.\d+\.\d+' | tail -1)"
             pip install packagecore
             packagecore -c misc/packagecore/packagecore.yaml -o ./dist/ ${CIRCLE_TAG#v}
-            # Move source pack to dist
-            mv ../${CIRCLE_PROJECT_REPONAME}-${CIRCLE_TAG}.tar.gz dist/
 
       - run:
           name: "publish to GitHub"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,10 +64,14 @@ jobs:
             # Clean up
             rm -rf ./.git
             rm -rf ./dist/*
+            # Pack source
+            git archive -o ../${CIRCLE_PROJECT_REPONAME}-${CIRCLE_TAG}.tar.gz --format tar.gz --prefix=${CIRCLE_PROJECT_REPONAME}-${CIRCLE_TAG#v}/ ${CIRCLE_TAG}
             # Use latest installed python3 from pyenv
             export PYENV_VERSION="$(pyenv versions | grep -Po '\b3\.\d+\.\d+' | tail -1)"
             pip install packagecore
             packagecore -c misc/packagecore/packagecore.yaml -o ./dist/ ${CIRCLE_TAG#v}
+            # Move source pack to dist
+            mv ../${CIRCLE_PROJECT_REPONAME}-${CIRCLE_TAG}.tar.gz dist/
 
       - run:
           name: "publish to GitHub"

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,6 @@ CFLAGS += $(CFLAGS_CURSES)
 
 LDLIBS += $(LDLIBS_CURSES)
 
-DISTFILES = src nnn.1 Makefile README.md LICENSE
 SRC = src/nnn.c
 HEADERS = src/nnn.h
 BIN = nnn
@@ -85,16 +84,14 @@ uninstall:
 strip: $(BIN)
 	$(STRIP) $^
 
-dist:
-	mkdir -p nnn-$(VERSION)
-	$(CP) -r $(DISTFILES) nnn-$(VERSION)
-	tar -cf nnn-$(VERSION).tar nnn-$(VERSION)
-	gzip nnn-$(VERSION).tar
-	$(RM) -r nnn-$(VERSION)
+sign:
+	git archive -o nnn-$(VERSION).tar.gz --format tar.gz --prefix=nnn-$(VERSION)/ v$(VERSION)
+	gpg --detach-sign nnn-$(VERSION).tar.gz
+	rm -f nnn-$(VERSION).tar.gz
 
 clean:
-	$(RM) -f $(BIN) nnn-$(VERSION).tar.gz
+	$(RM) -f $(BIN) *.sig
 
 skip: ;
 
-.PHONY: all debug install uninstall strip dist clean
+.PHONY: all debug install uninstall strip sign clean

--- a/Makefile
+++ b/Makefile
@@ -97,10 +97,10 @@ sign:
 	gpg --detach-sign --yes nnn-$(VERSION).tar.gz
 	rm -f nnn-$(VERSION).tar.gz
 
-	$(eval TOKEN=$(shell cat /tmp/access_token))
 	$(eval ID=$(shell curl -s 'https://api.github.com/repos/jarun/nnn/releases/tags/v$(VERSION)' | jq .id))
 	curl -XPOST 'https://uploads.github.com/repos/jarun/nnn/releases/$(ID)/assets?name=nnn-$(VERSION).tar.gz.sig' \
-	    -H 'Authorization: token $(TOKEN)' -H 'Content-Type: application/pgp-signature' --upload-file nnn-$(VERSION).tar.gz.sig
+	    -H 'Authorization: token $(NNN_SIG_UPLOAD_TOKEN)' -H 'Content-Type: application/pgp-signature' \
+	    --upload-file nnn-$(VERSION).tar.gz.sig
 
 clean:
 	$(RM) -f $(BIN) nnn-$(VERSION).tar.gz *.sig

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ CFLAGS += $(CFLAGS_CURSES)
 
 LDLIBS += $(LDLIBS_CURSES)
 
+DISTFILES = src nnn.1 Makefile README.md LICENSE
 SRC = src/nnn.c
 HEADERS = src/nnn.h
 BIN = nnn
@@ -84,6 +85,13 @@ uninstall:
 strip: $(BIN)
 	$(STRIP) $^
 
+dist:
+	mkdir -p nnn-$(VERSION)
+	$(CP) -r $(DISTFILES) nnn-$(VERSION)
+	tar -cf nnn-$(VERSION).tar nnn-$(VERSION)
+	gzip nnn-$(VERSION).tar
+	$(RM) -r nnn-$(VERSION)
+
 sign:
 	git archive -o nnn-$(VERSION).tar.gz --format tar.gz --prefix=nnn-$(VERSION)/ v$(VERSION)
 	gpg --detach-sign nnn-$(VERSION).tar.gz
@@ -94,4 +102,4 @@ clean:
 
 skip: ;
 
-.PHONY: all debug install uninstall strip sign clean
+.PHONY: all debug install uninstall strip dist sign clean

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ sign:
 	rm -f nnn-$(VERSION).tar.gz
 
 clean:
-	$(RM) -f $(BIN) *.sig
+	$(RM) -f $(BIN) nnn-$(VERSION).tar.gz *.sig
 
 skip: ;
 

--- a/Makefile
+++ b/Makefile
@@ -94,8 +94,13 @@ dist:
 
 sign:
 	git archive -o nnn-$(VERSION).tar.gz --format tar.gz --prefix=nnn-$(VERSION)/ v$(VERSION)
-	gpg --detach-sign nnn-$(VERSION).tar.gz
+	gpg --detach-sign --yes nnn-$(VERSION).tar.gz
 	rm -f nnn-$(VERSION).tar.gz
+
+	$(eval TOKEN=$(shell cat /tmp/access_token))
+	$(eval ID=$(shell curl -s 'https://api.github.com/repos/jarun/nnn/releases/tags/v$(VERSION)' | jq .id))
+	curl -XPOST 'https://uploads.github.com/repos/jarun/nnn/releases/$(ID)/assets?name=nnn-$(VERSION).tar.gz.sig' \
+	    -H 'Authorization: token $(TOKEN)' -H 'Content-Type: application/pgp-signature' --upload-file nnn-$(VERSION).tar.gz.sig
 
 clean:
 	$(RM) -f $(BIN) nnn-$(VERSION).tar.gz *.sig


### PR DESCRIPTION
Let's start on #416, I would need your feedback to better understand your current workflow, because I want to integrate the signing process as seamlessly as possible in your current release procedure.

My current assumptions:

- Releases are done via CircleCI, all you do is push a tag, and then `package-and-publish` is triggered and it creates Github release with all the assets.
- `make dist` is not used whatsoever (I will delete it).
- You will not upload your PGP private key to CircleCI, so signing has to happen locally on your machine, and uploaded to Github release independently.

I updated CircleCI not to generate sources tarball, we need to remember to notify other package maintainers that they need to switch to the source tarball generated by Github itself:

```diff
- https://github.com/jarun/nnn/releases/download/v2.8.1/nnn-v2.8.1.tar.gz
+ https://github.com/jarun/nnn/archive/v2.8.1.tar.gz
```

I created `make sign` that assumes the repo is already tagged with `v$(VERSION)`, it uses Git command to generate the exact same bit-by-bit identical tarball, signs it and removes the tarball.

You will need to upload the `nnn-$(VERSION).tar.gz.sig` file to Github afterwards. Would you like me to try to find some ways to automate this? We could maybe use `github.com/tcnksm/ghr` if you are okay with installing that locally?

To test, run `make sign` today, download the [source tarball](https://github.com/jarun/nnn/archive/v2.8.1.tar.gz) from Github, and run:

```
gpg --verify ./nnn-2.8.1.tar.gz.sig /path/to/downloaded/nnn-2.8.1.tar.gz
```

It should report `Good signature`.

I made `make sign` only prepare signature for the source tarball, because it's easy to replicate creation of this tarball locally without downloading anything, and because that's the only signature I personally need for Arch Linux 😉. If you'd like to sign the rest of the release assets, we would need to download stuff from Github release, sign them, and then upload the signatures. This might be an overkill for now, but let me know what you prefer.

Fixes #416. So happy that you agreed to provide signatures! 🎉 