### PR TITLE
Make showsel print warning when nothing is selected

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -5007,6 +5007,7 @@ nochange:
 					presel = FILTER;
 				break;
 			}
+			printwait(messages[MSG_0_SELECTED], &presel);
 			goto nochange;
 		case SEL_SELEDIT:
 			r = editselection();


### PR DESCRIPTION
Pressing `y` after starting `nnn` will print `0 selected` instead of silently failing.