### PR TITLE
Order toggle: fix toggling reverse

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -4973,7 +4973,7 @@ nochange:
 				r = get_input(messages[MSG_ORDER]);
 
 				if ((r == 'a' || r == 'd' || r == 'e'
-				    || r == 'r' || r == 's' || r == 't')
+				    || r == 's' || r == 't')
 				    && (entrycmpfn == &reventrycmp))
 					entrycmpfn = &entrycmp;
 


### PR DESCRIPTION

Follow-up to https://github.com/jarun/nnn/commit/5fb4d637eefc9aa4ca10c79b837f6f8930d9f68b

Tested order toggle, I like the idea, this is a small bug fix:

Press `o` -> `r` -> `o` -> `r`
Expected: order gets to original sort.
Actual: order gets stuck in reverse mode.
