### PR TITLE
Release improvements, take 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,9 +65,7 @@ jobs:
             rm -rf ./.git
             rm -rf ./dist/*
             # Pack source
-            cd ..
-            tar -czf ${CIRCLE_PROJECT_REPONAME}-${CIRCLE_TAG}.tar.gz ${CIRCLE_PROJECT_REPONAME}
-            cd ${CIRCLE_PROJECT_REPONAME}
+            git archive -o ../${CIRCLE_PROJECT_REPONAME}-${CIRCLE_TAG}.tar.gz --format tar.gz --prefix=${CIRCLE_PROJECT_REPONAME}-${CIRCLE_TAG#v}/ ${CIRCLE_TAG}
             # Use latest installed python3 from pyenv
             export PYENV_VERSION="$(pyenv versions | grep -Po '\b3\.\d+\.\d+' | tail -1)"
             pip install packagecore

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,6 @@ jobs:
           name: "package with packagecore"
           command: |
             # Clean up
-            rm -rf ./.git
             rm -rf ./dist/*
             # Pack source
             git archive -o ../${CIRCLE_PROJECT_REPONAME}-${CIRCLE_TAG}.tar.gz --format tar.gz --prefix=${CIRCLE_PROJECT_REPONAME}-${CIRCLE_TAG#v}/ ${CIRCLE_TAG}


### PR DESCRIPTION
The error `fatal: Not a git repository (or any of the parent directories): .git` was caused because of `rm -rf .git` command in the beginning, I didn't notice it before 🙂 

It's a bit tricky to test CircleCI, but hopefully the rest should work just fine.

Most importantly, I saw you uploaded the signature as part of the release, so thank you very much for that - I'm about to push the release to Arch Linux now 👍 