### PR TITLE
Fixed calculation of capacity on OpenBSD

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3285,7 +3285,7 @@ static size_t get_fs_info(const char *path, bool type)
 		return 0;
 
 	if (type == CAPACITY)
-		return svb.f_blocks << ffs((int)(svb.f_bsize >> 1));
+		return svb.f_blocks << ffs((int)(svb.f_frsize >> 1));
 
 	return svb.f_bavail << ffs((int)(svb.f_frsize >> 1));
 }


### PR DESCRIPTION
nnn reports on OpenBSD the wrong capacity of volumes.

On OpenBSD we use fragments, so that f_bsize and f_frsize differ. 

With the attached patch nnn reports the correct size on Linux as well as OpenBSD. (The manpage for statvfs on Linux also states that f_frsize ist correct)