### PR TITLE
List of files as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ It runs smoothly on the Pi, [Termux](https://www.youtube.com/watch?v=AbaauM7gUJw
   - FreeDesktop compliant trash (needs trash-cli)
   - Cross-dir file/all/range selection
   - Batch renamer (feature-limited) for selection or dir
+  - Display a list of files from stdin
   - Copy (as), move (as), delete, archive, link selection
   - Dir updates, notification on cp, mv, rm completion
   - Copy file paths to system clipboard on select

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -5412,7 +5412,11 @@ nochange:
 		case SEL_STATS: // fallthrough
 		case SEL_CHMODX:
 			if (ndents) {
-				mkpath((xstrcmp(path, g_listpath) ? path : g_prefixpath), dents[cur].name, newpath);
+				if (g_listpath && xstrcmp(path, g_listpath) == 0)
+					mkpath(g_prefixpath, dents[cur].name, newpath);
+				else
+					mkpath(path, dents[cur].name, newpath);
+
 				if (lstat(newpath, &sb) == -1
 				    || (sel == SEL_STATS && !show_stats(newpath, &sb))
 				    || (sel == SEL_CHMODX && !xchmod(newpath, sb.st_mode))) {
@@ -5594,7 +5598,11 @@ nochange:
 				}
 
 				if (r == 'c') {
-					mkpath((xstrcmp(path, g_listpath) ? path : g_prefixpath), dents[cur].name, newpath);
+					if(g_listpath && xstrcmp(path, g_listpath) == 0)
+						mkpath(g_prefixpath, dents[cur].name, newpath);
+					else
+						mkpath(path, dents[cur].name, newpath);
+
 					xrm(newpath);
 
 					if (cur && access(newpath, F_OK) == -1) {

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -1036,6 +1036,8 @@ static char *xrealpath(const char *path, const char *cwd)
 	const char *src, *next;
 	char *dst;
 	char *resolved_path = malloc(src_size + (*path == '/' ? 0 : cwd_size) + 1);
+	if (!resolved_path)
+		return NULL;
 
 	/* Turn relative paths into absolute */
 	if (path[0] != '/')
@@ -6202,12 +6204,12 @@ static char *load_input()
 
 	g_prefixpath = malloc(sizeof(char) * PATH_MAX);
 	if (!g_prefixpath)
-		goto malloc_1;
+		goto malloc_2;
 
 	xstrlcpy(g_prefixpath, paths[0], strlen(paths[0]) + 1);
 	for (i = 1; i < entries; ++i) {
 		if (!common_prefix(paths[i], g_prefixpath))
-			goto malloc_1;
+			goto malloc_2;
 	}
 
 	if (entries == 1) {
@@ -6221,11 +6223,16 @@ static char *load_input()
 	tmpdir = make_tmp_tree(paths, entries, g_prefixpath);
 
 	if (tmpdir) {
+		for (i = entries - 1; i >= 0; --i)
+			free(paths[i]);
 		free(input);
 
 		return tmpdir;
 	}
 
+malloc_2:
+	for (i = entries - 1; i >= 0; --i)
+		free(paths[i]);
 malloc_1:
 	free(input);
 	return NULL;

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -1244,16 +1244,18 @@ static void endselection(void)
 	fd = open(g_tmpfpath, O_RDONLY);
 	if (fd == -1) {
 		DPRINTF_S(strerror(errno));
-		if (unlink(g_tmpfpath))
+		if (unlink(g_tmpfpath)) {
 			DPRINTF_S(strerror(errno));
+		}
 		return;
 	}
 
 	count = read(fd, pselbuf, selbuflen);
 	if (count < 0) {
 		DPRINTF_S(strerror(errno));
-		if (close(fd) || unlink(g_tmpfpath))
+		if (close(fd) || unlink(g_tmpfpath)) {
 			DPRINTF_S(strerror(errno));
+		}
 		return;
 	}
 
@@ -1337,8 +1339,9 @@ static int editselection(void)
 	count = read(fd, pselbuf, selbuflen);
 	if (count < 0) {
 		DPRINTF_S(strerror(errno));
-		if (close(fd) || unlink(g_tmpfpath))
+		if (close(fd) || unlink(g_tmpfpath)) {
 			DPRINTF_S(strerror(errno));
+		}
 		goto emptyedit;
 	}
 

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -543,7 +543,7 @@ static const char * const messages[] = {
 	"invalid regex",
 	"toggle 'a'u / 'd'u / 'e'xtn / 'r'everse / 's'ize / 't'ime / 'v'ersion?",
 	"unmount failed! try lazy?",
-	"some paths were invalid. ignoring",
+	"ignoring invalid paths...",
 #ifndef DIR_LIMITED_SELECTION
 	"dir changed, range sel off", /* Must be the last entry */
 #endif


### PR DESCRIPTION
Usage:
Either pipe command output into `nnn` or redirect a file to `stdin`. The paths must be separated by `\0`.
E.g. `find -size +1M | nnn` or `nnn < list_of_files.txt`

Up to 65,536 paths can be read at a time, and no more than 256M will be read from `stdin`. Reads are done in chunks of 512K.

A tmp directory is created and symlinks to the given paths are created with paths being as compressed as can be i.e. no directories are created that only contain another directory. This directory is removed on exit. Currently the symlinks are not followed for operations like remove and such. I'll do that tomorrow.

I didn't have much quality time to spend on time so it took a _bit_ longer that I would've liked but I haven't forgotten about it. Hopefully the code isn't that horrid.

This is really WIP, and I'm going to stop looking for bugs as I keep finding more and more as I get more and more tired.