### PR TITLE
Shorten home path in the header to "~".

### DIFF
--- a/nnn.1
+++ b/nnn.1
@@ -67,6 +67,9 @@ supports the following options:
 .Fl d
         detail mode
 .Pp
+.Fl F
+        show full path for the home directory instead of "~"
+.Pp
 .Fl e
         open text files in $VISUAL (else $EDITOR, fallback vi) [preferably CLI]
 .Pp

--- a/src/nnn.h
+++ b/src/nnn.h
@@ -64,6 +64,7 @@ enum action {
 	SEL_MFLTR,
 	SEL_HIDDEN,
 	SEL_DETAIL,
+	SEL_FULLPATH,
 	SEL_STATS,
 	SEL_CHMODX,
 	SEL_ARCHIVE,
@@ -168,6 +169,8 @@ static struct key bindings[] = {
 	{ KEY_F(5),       SEL_HIDDEN },
 	/* Detailed listing */
 	{ 'd',            SEL_DETAIL },
+	/* Show full home path */
+	{ 'F',            SEL_FULLPATH },
 	/* File details */
 	{ 'f',            SEL_STATS },
 	{ CONTROL('F'),   SEL_STATS },


### PR DESCRIPTION
Hi! I made this little change in "nnn" and I thought that some people
might like it as well. I didn't find any information on the proper way to
contribute, so if this isn't it please ignore this merge request.

---

In the UNIX world "\~" is a synonym for the home folder of the current
user. This commit substitutes the full path of the home for the current
user with the char "\~" in the header.

An user that prefers to see the whole address for the home directory
can do so passing the command line argument "F" or using the "F"
toggle when the software is already running.