### PR TITLE
Fallbacks for absent NAME_MAX and PATH_MAX

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -118,6 +118,18 @@
 #define S_BLKSIZE 512 /* S_BLKSIZE is missing on Android NDK (Termux) */
 #endif
 
+/*
+ * NAME_MAX and PATH_MAX may not exist, e.g. with dirent.c_name being a
+ * flexible array on Illumos. Use somewhat accomodating fallback values.
+ */
+#ifndef NAME_MAX
+#define NAME_MAX 512
+#endif
+
+#ifndef PATH_MAX
+#define PATH_MAX 8191
+#endif
+
 #define _ABSSUB(N, M) (((N) <= (M)) ? ((M) - (N)) : ((N) - (M)))
 #define DOUBLECLICK_INTERVAL_NS (400000000)
 #define XDELAY_INTERVAL_MS (350000) /* 350 ms delay */

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -123,11 +123,11 @@
  * flexible array on Illumos. Use somewhat accomodating fallback values.
  */
 #ifndef NAME_MAX
-#define NAME_MAX 512
+#define NAME_MAX 255
 #endif
 
 #ifndef PATH_MAX
-#define PATH_MAX 8191
+#define PATH_MAX 4096
 #endif
 
 #define _ABSSUB(N, M) (((N) <= (M)) ? ((M) - (N)) : ((N) - (M)))

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -74,9 +74,6 @@
 #include <fcntl.h>
 #include <libgen.h>
 #include <limits.h>
-#ifdef __gnu_hurd__
-#define PATH_MAX 4096
-#endif
 #ifndef NOLOCALE
 #include <locale.h>
 #endif


### PR DESCRIPTION
Certainly NAME_MAX isn't guaranteed to exist and on (some versions of?)
Illumos and SmartOS it doesn't, so provide some reasonably accommodating
fallbacks.