### PR TITLE
fix sshfs not utilizing -o options

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3579,7 +3579,7 @@ static bool archive_mount(char *name, char *path, char *newpath, int *presel)
 
 static bool remote_mount(char *newpath, int *presel)
 {
-	uchar flag = F_CLI;
+	uchar flag = F_MULTI;
 	int r, opt = get_input(messages[MSG_REMOTE_OPTS]);
 	char *tmp, *env, *cmd;
 


### PR DESCRIPTION
This is a quick and dirty hack to potentially fix one issues apparent
in issue #458.

This is mostly untested guess work.