### PR TITLE
Do not swallow keypress after printwait

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -2024,12 +2024,10 @@ static int nextsel(int presel)
 		//DPRINTF_D(c);
 		//DPRINTF_S(keyname(c));
 
-		/* Clear previous filter when manually starting */
-		if (c == FILTER)
-			clearfilter();
-
-		if (presel == MSGWAIT)
+		if (c == ERR && presel == MSGWAIT)
 			c = (cfg.filtermode) ? FILTER : CONTROL('L');
+		else if (c == FILTER) /* Clear previous filter when manually starting */
+			clearfilter();
 	}
 
 	if (c == -1) {


### PR DESCRIPTION
>>> but for some reason the presence of that message eats up the ';'
>>
>> I see. That's a problem.
>
> can we fix this? don't eat the key press while popup is shown, but move it down the global key handling pipeline maybe?

This implements this change and seems to work for me, but I'm very uncertain if I'm not breaking anything else by this patch?