### PR TITLE
Avoid trying to edit a non-existing file

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -5453,6 +5453,8 @@ nochange:
 
 			if (ndents)
 				mkpath(path, dents[cur].name, newpath);
+			else if (sel == SEL_EDIT) /* Avoid trying to edit a non-existing file */
+				goto nochange;
 
 			switch (sel) {
 			case SEL_REDRAW:


### PR DESCRIPTION
The previous implementation was inconsistent, sometimes it would
inherit the name of the parent folder of the current directory.

Other scenarios i encountered were:
1. Yield a empty search result, and try to edit. It would seemingly
   randomly select a file or folder
2. What would happen in a root path without any files residing?

In the end I don't think it matters if you adopt this change, but at least I whipped up a pull request for you, rather than just posting it...

And I finally managed to fix my merge conflicts, so I'm back in sync with master.

I noticed my `xreadline()` `ctrl-w` implementation isn't needed as upstream has it now, but I noticed `filterentries()` is missing it. Is this intended? I would make a pull request for that but my merge conflict resolving took too much of my time now... I shouldn've posted this piece in todo notes... alas take care!