### PR TITLE
Add x2sel plugin (reverse .cbcp)

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -68,6 +68,7 @@ Plugins are installed to `${XDG_CONFIG_HOME:-$HOME/.config}/nnn/plugins`.
 | upload | Paste text to ix.io, upload binary to file.io | sh | curl, jq, tr |
 | vidthumb | Show video thumbnails in terminal | sh | [ffmpegthumbnailer](https://github.com/dirkvdb/ffmpegthumbnailer),<br>[lsix](https://github.com/hackerb9/lsix) |
 | wall | Set wallpaper or change colorscheme | sh | nitrogen/pywal |
+| x2sel | Copy newline-separated file list from system clipboard to selection | sh | tr, xsel/xclip<br>pbpaste/wl-paste<br>termux-clipboard-get<br>powershell.exe/`/dev/clipboard`|
 
 ## Invoking a plugin
 

--- a/plugins/x2sel
+++ b/plugins/x2sel
@@ -1,0 +1,57 @@
+#!/usr/bin/env sh
+
+# Description: Copy system clipboard newline-separated file list to selection
+# Requires: tr and
+#           xclip/xsel (Linux)
+#           pbpaste (macOS)
+#           termux-clipboard-get (Termux)
+#           powershell (WSL)
+#           cygwim's /dev/clipboard (Cygwin)
+#           wl-paste (Wayland)
+#
+# LIMITATION: breaks if a filename has newline in it
+#
+# Shell: POSIX compliant
+# Author: Léo Villeveygoux, after Arun Prakash Jana's .cbcp
+
+IFS="$(printf '%b_' '\n')"; IFS="${IFS%_}" # protect trailing \n
+
+SELECTION=${XDG_CONFIG_HOME:-$HOME/.config}/nnn/.selection
+
+getclip () {
+
+	if which xsel >/dev/null 2>&1; then
+		# Linux
+		xsel -bo
+	elif which xclip >/dev/null 2>&1; then
+		# Linux
+		xclip -sel clip -o
+	elif which pbpaste >/dev/null 2>&1; then
+		# macOS
+		pbpaste
+	elif which termux-clipboard-get >/dev/null 2>&1; then
+		# Termux
+		termux-clipboard-get
+	elif which powershell.exe >/dev/null 2>&1; then
+		# WSL
+		powershell.exe Get-Clipboard
+	elif [ -r /dev/clipboard ] ; then
+		# Cygwin
+		cat /dev/clipboard
+	elif which wl-paste >/dev/null 2>&1; then
+		# Wayland
+		wl-paste
+	fi
+
+}
+
+CLIPBOARD=$(getclip)
+
+# Check if clipboard actually contains a file list
+for file in $CLIPBOARD ; do
+	if [ ! -e "$file" ] ; then
+		exit 1;
+	fi
+done
+
+printf "%s" "$CLIPBOARD" | tr '\n' '\0' > "$SELECTION"


### PR DESCRIPTION
This plugin is based on `.cbcp` and does basically the reverse operation.
It copies system clipboard newline-separated file list to selection.

I need help to test:

- [ ] MacOS's `pbpaste`
- [ ] Termux's `termux-clipboard-get`
- [ ] Windows stuff
- [x] `wl-paste` (done)

I originally intended to call it automatically in `-x` mode like `.cbcp`, but I'm still unsure.

This allows to copy files from e.g. `thunar` and paste them in `nnn`.