### PR TITLE
Opinionated xstrlcpy changes

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -359,7 +359,6 @@ static kv *bookmark;
 static kv *plug;
 static uchar tmpfplen;
 static uchar blk_shift = BLK_SHIFT_512;
-static const uint _WSHIFT = (LONG_SIZE == 8) ? 3 : 2;
 #ifndef NOMOUSE
 static int middle_click_key;
 #endif
@@ -937,54 +936,21 @@ static void *xrealloc(void *pcur, size_t len)
  * Always null ('\0') terminates if both src and dest are valid pointers.
  * Returns the number of bytes copied including terminating null byte.
  */
-static size_t xstrlcpy(char *dest, const char *src, size_t n)
+static size_t xstrlcpy(char *restrict dest, const char *restrict src, size_t n)
 {
 	if (!src || !dest || !n)
 		return 0;
 
-	ulong *s, *d;
-	size_t len = strlen(src) + 1, blocks;
-
-	if (n > len)
+	size_t len = strlen(src) + 1;
+	if (len <= n) {
+		memcpy(dest, src, len);
 		n = len;
-	else if (len > n)
-		/* Save total number of bytes to copy in len */
-		len = n;
-
-	/*
-	 * To enable -O3 ensure src and dest are 16-byte aligned
-	 * More info: https://www.felixcloutier.com/x86/MOVDQA:VMOVDQA32:VMOVDQA64
-	 */
-	if ((n >= LONG_SIZE) && (((ulong)src & _ALIGNMENT_MASK) == 0 &&
-	    ((ulong)dest & _ALIGNMENT_MASK) == 0)) {
-		s = (ulong *)src;
-		d = (ulong *)dest;
-		blocks = n >> _WSHIFT;
-		n &= LONG_SIZE - 1;
-
-		while (blocks) {
-			*d = *s; // NOLINT
-			++d, ++s;
-			--blocks;
-		}
-
-		if (!n) {
-			dest = (char *)d;
-			*--dest = '\0';
-			return len;
-		}
-
-		src = (char *)s;
-		dest = (char *)d;
+	} else {
+		memcpy(dest, src, n - 1);
+		dest[n - 1] = '\0';
 	}
 
-	while (--n && (*dest = *src)) // NOLINT
-		++dest, ++src;
-
-	if (!n)
-		*dest = '\0';
-
-	return len;
+	return n;
 }
 
 static bool is_suffix(const char *str, const char *suffix)


### PR DESCRIPTION
Two major changes to xstrlcpy. One is that I unvectorized it because every platform I could find does a memcpy at a stride of at least 8 bytes on x86_64, and I couldn't come up with a way to get rid of the `strlen` and remain vectorized in C. (There's really no good way to get them to emit the `pcmpeqb` that we might want I could find; I tried for a while and gave up since compilers can't really understand alignment guarantees…). Also, I changed `xstrlcpy` to `xstrsncpy` because the operation we're performing isn't actually a `strlcpy` so I felt it was less confusing.