### PR TITLE
Make NNN_COLORS override NO_COLORS

### DIFF
--- a/nnn.1
+++ b/nnn.1
@@ -417,7 +417,7 @@ separated by \fI;\fR:
 \fBnnn:\fR this is a special variable set to the hovered entry before executing
 a command from the command prompt or spawning a shell.
 .Pp
-\fBNO_COLOR:\fR if defined, disable ANSI color output.
+\fBNO_COLOR:\fR disable ANSI color output (overridden by \fBNNN_COLORS\fR).
 .Sh KNOWN ISSUES
 .Nm
 may not handle keypresses correctly when used with tmux (see issue #104 for

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -1498,9 +1498,13 @@ static bool initcurses(void *oldmask)
 #endif
 	curs_set(FALSE); /* Hide cursor */
 
-	if (!getenv("NO_COLOR")) {
+	char *colors = getenv(env_cfg[NNN_COLORS]);
+
+	if (colors || !getenv("NO_COLOR")) {
 		short i;
-		char *colors = xgetenv(env_cfg[NNN_COLORS], "4444");
+
+		if (!colors)
+			colors = "4444";
 
 		start_color();
 		use_default_colors();


### PR DESCRIPTION
This is the minimal patch, but we could save a `getenv` call with very few more code.