### PR TITLE
Add nvim as a diff tool for getplugs plugin

### DIFF
--- a/plugins/diffs
+++ b/plugins/diffs
@@ -13,9 +13,9 @@
 selection=${XDG_CONFIG_HOME:-$HOME/.config}/nnn/.selection
 
 if which nvim >/dev/null 2>&1; then
-  diffcmd=(nvim -d)
+    diffcmd="nvim -d"
 else
-  diffcmd=(vimdiff +0)
+    diffcmd="vimdiff +0"
 fi
 
 dirdiff() {
@@ -23,7 +23,7 @@ dirdiff() {
     dir2=$(mktemp "${TMPDIR:-/tmp}"/nnn-"$(basename "$2")".XXXXXXXX)
     ls -A1 "$1" > "$dir1"
     ls -A1 "$2" > "$dir2"
-    "${diffcmd[@]}" "$dir1" "$dir2"
+    $diffcmd "$dir1" "$dir2"
     rm "$dir1" "$dir2"
 }
 
@@ -39,14 +39,14 @@ if [ -s "$selection" ]; then
             #     Vim: Warning: Input is not from a terminal
             # xargs -0 -o vimdiff < $selection
 
-            xargs -0 "${diffcmd[@]}" < "$selection"
+            eval xargs -0 "$diffcmd" < "$selection"
         fi
     elif ! [ -z "$1" ]; then
         f1="$(echo "$arr" | sed -n '1p')"
         if [ -d "$f1" ] && [ -d "$1" ]; then
             dirdiff "$f1" "$1"
         elif [ -f "$f1" ] && [ -f "$1" ]; then
-            "${diffcmd[@]}" "$f1" "$1"
+            $diffcmd "$f1" "$1"
         else
             echo "cannot compare file with directory"
         fi

--- a/plugins/diffs
+++ b/plugins/diffs
@@ -12,12 +12,18 @@
 
 selection=${XDG_CONFIG_HOME:-$HOME/.config}/nnn/.selection
 
+if which nvim >/dev/null 2>&1; then
+  diffcmd=(nvim -d)
+else
+  diffcmd=(vimdiff +0)
+fi
+
 dirdiff() {
     dir1=$(mktemp "${TMPDIR:-/tmp}"/nnn-"$(basename "$1")".XXXXXXXX)
     dir2=$(mktemp "${TMPDIR:-/tmp}"/nnn-"$(basename "$2")".XXXXXXXX)
     ls -A1 "$1" > "$dir1"
     ls -A1 "$2" > "$dir2"
-    vimdiff "$dir1" "$dir2"
+    "${diffcmd[@]}" "$dir1" "$dir2"
     rm "$dir1" "$dir2"
 }
 
@@ -33,14 +39,14 @@ if [ -s "$selection" ]; then
             #     Vim: Warning: Input is not from a terminal
             # xargs -0 -o vimdiff < $selection
 
-            xargs -0 vimdiff +0 < "$selection"
+            xargs -0 "${diffcmd[@]}" < "$selection"
         fi
     elif ! [ -z "$1" ]; then
         f1="$(echo "$arr" | sed -n '1p')"
         if [ -d "$f1" ] && [ -d "$1" ]; then
             dirdiff "$f1" "$1"
         elif [ -f "$f1" ] && [ -f "$1" ]; then
-            vimdiff +0 "$f1" "$1"
+            "${diffcmd[@]}" "$f1" "$1"
         else
             echo "cannot compare file with directory"
         fi

--- a/plugins/getplugs
+++ b/plugins/getplugs
@@ -22,7 +22,7 @@ merge () {
 }
 
 prompt () {
-	printf "%s" "Plugin $1 already exists and is different.\n"
+	printf "%s\n" "Plugin $1 already exists and is different."
 	printf "Keep (k), merge (m), overwrite (o) [default: k]? "
 	read -r operation
 

--- a/plugins/getplugs
+++ b/plugins/getplugs
@@ -8,10 +8,10 @@
 CONFIG_DIR=${XDG_CONFIG_HOME:-$HOME/.config}/nnn/
 PLUGIN_DIR=${XDG_CONFIG_HOME:-$HOME/.config}/nnn/plugins
 
-is_cmd_exists () {
-    which "$1" > /dev/null 2>&1
-    echo $?
-}
+# is_cmd_exists () {
+#     which "$1" > /dev/null 2>&1
+#     echo $?
+# }
 
 merge () {
 	if which nvim >/dev/null 2>&1; then

--- a/plugins/getplugs
+++ b/plugins/getplugs
@@ -14,7 +14,11 @@ is_cmd_exists () {
 }
 
 merge () {
-	vimdiff +0 "$1" "$2"
+	if which nvim >/dev/null 2>&1; then
+		nvim -d "$1" "$2"
+	else
+		vimdiff +0 "$1" "$2"
+	fi
 }
 
 prompt () {

--- a/plugins/nuke
+++ b/plugins/nuke
@@ -76,6 +76,7 @@ IMAGE_CACHE_PATH="$(dirname "$1")"/.thumbs
 
 FPATH="$1"
 FNAME=$(basename "$1")
+EDITOR="${EDITOR:-vi}"
 ext="${FNAME##*.}"
 if ! [ -z "$ext" ]; then
     ext="$(printf "%s" "${ext}" | tr '[:upper:]' '[:lower:]')"
@@ -181,7 +182,7 @@ handle_extension() {
 
         ## Log files
         log)
-            vi "${FPATH}"
+            "$EDITOR" "${FPATH}"
             exit 0;;
 
         ## BitTorrent
@@ -418,7 +419,7 @@ handle_mime() {
 
         ## Text
         text/* | */xml)
-            vi "${FPATH}"
+            "$EDITOR" "${FPATH}"
             exit 0;;
             ## Syntax highlight
             # if [[ "$( stat --printf='%s' -- "${FPATH}" )" -gt "${HIGHLIGHT_SIZE_MAX}" ]]; then

--- a/plugins/nuke
+++ b/plugins/nuke
@@ -77,6 +77,7 @@ IMAGE_CACHE_PATH="$(dirname "$1")"/.thumbs
 FPATH="$1"
 FNAME=$(basename "$1")
 EDITOR="${EDITOR:-vi}"
+PAGER="${PAGER:-less -R}"
 ext="${FNAME##*.}"
 if ! [ -z "$ext" ]; then
     ext="$(printf "%s" "${ext}" | tr '[:upper:]' '[:lower:]')"
@@ -88,13 +89,13 @@ handle_pdf() {
         exit 0
     elif which pdftotext >/dev/null 2>&1; then
         ## Preview as text conversion
-        pdftotext -l 10 -nopgbrk -q -- "${FPATH}" - | less -R
+        pdftotext -l 10 -nopgbrk -q -- "${FPATH}" - | eval "$PAGER"
         exit 0
     elif which mutool >/dev/null 2>&1; then
         mutool draw -F txt -i -- "${FPATH}" 1-10
         exit 0
     elif which exiftool >/dev/null 2>&1; then
-        exiftool "${FPATH}" | less -R
+        exiftool "${FPATH}" | eval "$PAGER"
         exit 0
     fi
 }
@@ -107,10 +108,10 @@ handle_audio() {
         mpv "${FPATH}" >/dev/null 2>&1 &
         exit 0
     elif which mediainfo >/dev/null 2>&1; then
-        mediainfo "${FPATH}" | less -R
+        mediainfo "${FPATH}" | eval "$PAGER"
         exit 0
     elif which exiftool >/dev/null 2>&1; then
-        exiftool "${FPATH}"| less -R
+        exiftool "${FPATH}"| eval "$PAGER"
         exit 0
     fi
 }
@@ -126,13 +127,13 @@ handle_video() {
         # Thumbnail
         [ -d "${IMAGE_CACHE_PATH}" ] || mkdir "${IMAGE_CACHE_PATH}"
         ffmpegthumbnailer -i "${FPATH}" -o "${IMAGE_CACHE_PATH}/${FNAME}.jpg" -s 0
-        viu -n "${IMAGE_CACHE_PATH}/${FNAME}.jpg" | less -R
+        viu -n "${IMAGE_CACHE_PATH}/${FNAME}.jpg" | eval "$PAGER"
         exit 0
     elif which mediainfo >/dev/null 2>&1; then
-        mediainfo "${FPATH}" | less -R
+        mediainfo "${FPATH}" | eval "$PAGER"
         exit 0
     elif which exiftool >/dev/null 2>&1; then
-        exiftool "${FPATH}"| less -R
+        exiftool "${FPATH}"| eval "$PAGER"
         exit 0
     fi
 }
@@ -144,23 +145,23 @@ handle_extension() {
         a|ace|alz|arc|arj|bz|bz2|cab|cpio|deb|gz|jar|lha|lz|lzh|lzma|lzo|\
         rpm|rz|t7z|tar|tbz|tbz2|tgz|tlz|txz|tZ|tzo|war|xpi|xz|Z|zip)
             if which atool >/dev/null 2>&1; then
-                atool --list -- "${FPATH}" | less -R
+                atool --list -- "${FPATH}" | eval "$PAGER"
                 exit 0
             elif which bsdtar >/dev/null 2>&1; then
-                bsdtar --list --file "${FPATH}" | less -R
+                bsdtar --list --file "${FPATH}" | eval "$PAGER"
                 exit 0
             fi
             exit 1;;
         rar)
             if which unrar >/dev/null 2>&1; then
                 ## Avoid password prompt by providing empty password
-                unrar lt -p- -- "${FPATH}" | less -R
+                unrar lt -p- -- "${FPATH}" | eval "$PAGER"
             fi
             exit 1;;
         7z)
             if which 7z >/dev/null 2>&1; then
                 ## Avoid password prompt by providing empty password
-                7z l -p -- "${FPATH}" | less -R
+                7z l -p -- "${FPATH}" | eval "$PAGER"
                 exit 0
             fi
             exit 1;;
@@ -200,7 +201,7 @@ handle_extension() {
         odt|ods|odp|sxw)
             if which odt2txt >/dev/null 2>&1; then
                 ## Preview as text conversion
-                odt2txt "${FPATH}" | less -R
+                odt2txt "${FPATH}" | eval "$PAGER"
                 exit 0
             fi
             exit 1;;
@@ -208,10 +209,10 @@ handle_extension() {
         ## Markdown
         md)
             if which glow >/dev/null 2>&1; then
-                glow -sdark "${FPATH}" | less -R
+                glow -sdark "${FPATH}" | eval "$PAGER"
                 exit 0
             elif which lowdown >/dev/null 2>&1; then
-                lowdown -Tterm "${FPATH}" | less -R
+                lowdown -Tterm "${FPATH}" | eval "$PAGER"
                 exit 0
             fi
             ;;
@@ -220,13 +221,13 @@ handle_extension() {
         htm|html|xhtml)
             ## Preview as text conversion
             if which w3m >/dev/null 2>&1; then
-                w3m -dump "${FPATH}" | less -R
+                w3m -dump "${FPATH}" | eval "$PAGER"
                 exit 0
             elif which lynx >/dev/null 2>&1; then
-                lynx -dump -- "${FPATH}" | less -R
+                lynx -dump -- "${FPATH}" | eval "$PAGER"
                 exit 0
             elif which elinks >/dev/null 2>&1; then
-                elinks -dump "${FPATH}" | less -R
+                elinks -dump "${FPATH}" | eval "$PAGER"
                 exit 0
             fi
             ;;
@@ -234,10 +235,10 @@ handle_extension() {
         ## JSON
         json)
             if which jq >/dev/null 2>&1; then
-                jq --color-output . "${FPATH}" | less -R
+                jq --color-output . "${FPATH}" | eval "$PAGER"
                 exit 0
             elif which python >/dev/null 2>&1; then
-                python -m json.tool -- "${FPATH}" | less -R
+                python -m json.tool -- "${FPATH}" | eval "$PAGER"
                 exit 0
             fi
             ;;
@@ -293,13 +294,13 @@ handle_multimedia() {
                 sxiv_load_dir "${FPATH}" >/dev/null 2>&1 &
                 exit 0
             elif which viu >/dev/null 2>&1; then
-                viu -n "${FPATH}" | less -R
+                viu -n "${FPATH}" | eval "$PAGER"
                 exit 0
             elif which img2txt >/dev/null 2>&1; then
-                img2txt --gamma=0.6 -- "${FPATH}" | less -R
+                img2txt --gamma=0.6 -- "${FPATH}" | eval "$PAGER"
                 exit 0
             elif which exiftool >/dev/null 2>&1; then
-                exiftool "${FPATH}" | less -R
+                exiftool "${FPATH}" | eval "$PAGER"
                 exit 0
             fi
             # local orientation
@@ -443,10 +444,10 @@ handle_mime() {
         image/vnd.djvu)
             if which djvutxt >/dev/null 2>&1; then
                 ## Preview as text conversion (requires djvulibre)
-                djvutxt "${FPATH}" | less -R
+                djvutxt "${FPATH}" | eval "$PAGER"
                 exit 0
             elif which exiftool >/dev/null 2>&1; then
-                exiftool "${FPATH}" | less -R
+                exiftool "${FPATH}" | eval "$PAGER"
                 exit 0
             fi
             exit 1;;


### PR DESCRIPTION
On current version of `getplugs`, it doesn't seem support `neovim` as comparison/diff tool. I believe it could be better if we add `neovim` diff tool as well, since `neovim` uses different command than `vim` and `gvim` for comparing files.

https://github.com/jarun/nnn/blob/12df1ab083d9692d97c2bf248000cc5e94a0445d/plugins/getplugs#L17

Here's related error message:

```
Plugin ./nuke already exists and is different.\nKeep (k), merge (m), overwrite (o) [default: k]? m
/home/akrifari/.config/nnn/plugins/getplugs: line 17: vimdiff: command not found
```
