### PR TITLE
Add alternative shortcut for redraw

### DIFF
--- a/src/nnn.h
+++ b/src/nnn.h
@@ -188,6 +188,7 @@ static struct key bindings[] = {
 	{ CONTROL('T'),   SEL_SORT },
 	/* Redraw window */
 	{ CONTROL('L'),   SEL_REDRAW },
+	{ 'R',            SEL_REDRAW },
 	/* Select current file path */
 	{ CONTROL('J'),   SEL_SEL },
 	{ ' ',            SEL_SEL },


### PR DESCRIPTION
Hey there!

First, thanks for `nnn` :)

I started using `nnn`, but quickly realized a conflict of shortcuts with my config. I use `^H`, `^J`, `^K`, `^L` for navigating tmux/vim panes, so I'm not able to trigger a redraw.

Of course it's my responsibility if I overwrite such a common shortcut like `^L` and I'm aware of adapting `nnn.h` to [change shortcuts](https://github.com/jarun/nnn/wiki/Usage#keyboard-mouse). But I could imagine this is quite a common use case (given the popularity of e.g. [vim-tmux-navigator](https://github.com/christoomey/vim-tmux-navigator/).

I noticed `^J` and `^K` already have alternatives. So I wonder if you're willing to add an alternative shortcut for redraw?

I choose `R` in this PR as it feels natural to me, but it's just an idea :)