### PR TITLE
Fix: BSD expr syntax error on empty $NNNLVL with quitcd.fish

### DIFF
--- a/misc/quitcd/quitcd.fish
+++ b/misc/quitcd/quitcd.fish
@@ -4,7 +4,7 @@
 
 function n --description 'support nnn quit and change directory'
     # Block nesting of nnn in subshells
-    if test -n NNNLVL
+    if test -n "$NNNLVL"
         if [ (expr $NNNLVL + 0) -ge 1 ]
             echo "nnn is already running"
             return


### PR DESCRIPTION
I'm a `fish` user on macOS. In #428, @JanneSalokoski pointed out that 

> MacOS uses BSD expr, instead of GNU expr. This causes a syntax error any time nnn is quit, if $NNNLVL is nothing. I added a test if $NNNLVL is defined to prevent the syntax error.

I thought the problem was fixed with `quitcd.fish`, but according to my experience, it continues to occur when `$NNNLVL` is unset:

```fish
~> n
expr: syntax error
[: Missing argument at index 2

~/.config/fish/functions/n.fish (line 8):
        if [ (expr $NNNLVL + 0) -ge 1 ]
           ^
in function 'n'
```

... so I modified the script again to make sure that it works.