### PR TITLE
browse: fix nnn -e

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -5404,7 +5404,7 @@ nochange:
 				if (cfg.useeditor && (!sb.st_size ||
 #ifdef FILE_MIME_OPTS
 				    (get_output(g_buf, CMD_LEN_MAX, "file", FILE_MIME_OPTS, newpath, FALSE)
-				    && !(((int *)g_buf)[0] == *(int *)"text" && g_buf[4] == '/')))) {
+				    && !strncmp(g_buf, "text/", 5)))) {
 #else
 				    /* no mime option; guess from description instead */
 				    (get_output(g_buf, CMD_LEN_MAX, "file", "-b", newpath, FALSE)


### PR DESCRIPTION
The current code will start editor if the mime doesn't start with
"text/". But, we want the opposite.

Simplify the check by using `strncmp` instead.

We may improve by writing a helper: `start_withs` in the future.

This change also cleans -Wstrict-aliasing on Ubuntu 16.04 LTS