### PR TITLE
Double click only works on same item

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -5190,6 +5190,7 @@ static bool browse(char *ipath, const char *session)
 #ifndef NOMOUSE
 	MEVENT event;
 	struct timespec mousetimings[2] = {{.tv_sec = 0, .tv_nsec = 0}, {.tv_sec = 0, .tv_nsec = 0} };
+	int mousedent[2] = {-1, -1};
 	bool currentmouse = 1;
 	bool rightclicksel = 0;
 #endif
@@ -5423,13 +5424,16 @@ nochange:
 				    CLOCK_REALTIME,
 #endif
 				    &mousetimings[currentmouse]);
+				mousedent[currentmouse] = cur;
 
-				/*Single click just selects, double click also opens */
-				if (((_ABSSUB(mousetimings[0].tv_sec, mousetimings[1].tv_sec) << 30)
-				  + (mousetimings[0].tv_nsec - mousetimings[1].tv_nsec))
-					> DOUBLECLICK_INTERVAL_NS)
+				/* Single click just selects, double click falls through to SEL_GOIN */
+				if ((mousedent[0] != mousedent[1]) ||
+				  (((_ABSSUB(mousetimings[0].tv_sec, mousetimings[1].tv_sec) << 30)
+				  + (_ABSSUB(mousetimings[0].tv_nsec, mousetimings[1].tv_nsec)))
+					> DOUBLECLICK_INTERVAL_NS))
 					break;
 				mousetimings[currentmouse].tv_sec = 0;
+				mousedent[currentmouse] = -1;
 			} else {
 				if (cfg.filtermode || filterset())
 					presel = FILTER;


### PR DESCRIPTION
This patch disables accidental triggering of double clicking when you
are just single clicking on multiple objects fast.

Btw regarding long hold clicking on termux, on my phone a menu pops up, are you sure you want me to look into long hold clicking on termux?

The reason I'm posting this commit is because I rebased my personal branch on `upstream/master` at the cost of dumping some of my personal patches, just to keep up with this project.

The merge conflicts were severe the past 6months. Lets see what will break in my personal build after this event.

(Sry for posting it here, but I didn't want to start another thread/discussion for this)

EDIT: Note this patch was written in the spur of the moment because I found it annoying as I was testing out `nnn`, but I think it's difficult for this to introduce new problems