### PR TITLE
SEL_FIRST now displays the correct message

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -565,10 +565,10 @@ static const char * const messages[] = {
 	"invalid regex",
 	"'a'u / 'd'u / 'e'xtn / 'r'ev / 's'ize / 't'ime / 'v'er / 'c'lear?",
 	"unmount failed! try lazy?",
+	"first file (\')/char?",
 	"remove tmp file?",
 	"unchanged",
 	"cancelled",
-	"first file (\')/char?",
 	"0 entries",
 #ifndef DIR_LIMITED_SELECTION
 	"dir changed, range sel off", /* Must be the last entry */


### PR DESCRIPTION
A bit scary when you get prompted to remove a file but you wanted to
select a file.

I also made sure all strings are correctly ordered.