### PR TITLE
Allow plugins to write to $NNN_PIPE in background

### DIFF
--- a/plugins/mimelist
+++ b/plugins/mimelist
@@ -17,5 +17,4 @@ fi
 printf "mime: "
 read -r mime
 
-printf "%s" "+l" > "$NNN_PIPE"
-$fd | file -if- | grep "$mime" | awk -F: '{printf "%s\0", $1}' > "$NNN_PIPE"
+(printf "%s" "+l" ; $fd | file -if- | grep "$mime" | awk -F: '{printf "%s\0", $1}' ) > "$NNN_PIPE" &


### PR DESCRIPTION
This is a workaround to the fact that `nnn` reads from the pipe only
*after* plugin returned, so plugins couldn't write more that pipe
capacity to $NNN_PIPE or they would block.

You might want to increase `LIST_FILES_MAX` to test on large file lists.

@jarun @KlzXS please test.

I'm not sure about how I should handle error checking, too.