### PR TITLE
Allow launching plugins with Alt + plugin's key

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -2564,7 +2564,14 @@ static int filterentries(char *path, char *lastname)
 #ifndef NOMOUSE
 		case KEY_MOUSE: // fallthrough
 #endif
-		case 27: /* Exit filter mode on Escape */
+		case 27: /* Exit filter mode on Escape and Alt+key */
+			nodelay(getwin(stdout), TRUE);
+			r = get_wch(ch);
+			nodelay(getwin(stdout), FALSE);
+			if (r != ERR) {
+				unget_wch(*ch);
+				*ch = CONTROL('S');
+			}
 			goto end;
 		}
 
@@ -2776,7 +2783,12 @@ static char *xreadline(const char *prefill, const char *prompt)
 				len -= pos;
 				pos = 0;
 				continue;
-			case 27: /* Exit prompt on Escape */
+			case 27: /* Exit prompt on Escape, but just filter out Alt+key */
+				nodelay(getwin(stdout), TRUE);
+				r = get_wch(ch);
+				nodelay(getwin(stdout), FALSE);
+				if (r != ERR)
+					continue;
 				len = 0;
 				goto END;
 			}

--- a/src/nnn.h
+++ b/src/nnn.h
@@ -230,6 +230,7 @@ static struct key bindings[] = {
 	/* Run a plugin */
 	{ ';',            SEL_PLUGIN },
 	{ CONTROL('S'),   SEL_PLUGIN },
+	{ '\033',         SEL_PLUGIN }, /* 'Alt' modifier prefix */
 	/* Run command */
 	{ '!',            SEL_SHELL },
 	{ CONTROL(']'),   SEL_SHELL },


### PR DESCRIPTION
In terminals Alt+*key* is 2 characters : `'\033'` (or Esc, or ^[) and the *key*.
Just setting `'\033'` as a binding for the plugin key makes all plugins available on Alt+*plugin's key*.