### PR TITLE
preview-tui: Add kitty terminal support

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -4,7 +4,10 @@
 #
 # Note: This plugin needs a "NNN_FIFO" to work.
 #
-# Dependencies: tmux (>=3.0) or xterm (or set $TERMINAL), file, tree
+# Dependencies:
+#   - tmux (>=3.0) or kitty (allow_remote_control on) or xterm (or set $TERMINAL)
+#   - file
+#   - tree
 #
 # Usage:
 #   You need to set a NNN_FIFO path and set a key for the plugin,
@@ -60,6 +63,11 @@ fi
 
 if [ -e "${TMUX%%,*}" ] && [ "$(tmux -V | cut -c6)" -eq 3 ] ; then
     tmux split-window -e "NNN_FIFO=$NNN_FIFO" -e "PREVIEW_MODE=1" -dh "$0" "$1"
+elif [ "$TERM" = "xterm-kitty" ] && kitty @ ls > /dev/null 2>&1 ; then
+    kitty @ launch --no-response\
+          --title "nnn preview" --keep-focus --cwd="$PWD" \
+          --env "NNN_FIFO=$NNN_FIFO" --env "PREVIEW_MODE=1" \
+          "$0" "$1" > /dev/null
 else
     PREVIEW_MODE=1 $TERMINAL -e "$0" "$1" &
 fi


### PR DESCRIPTION
***This is work in progress, it breaks nnn UI for now!***

So I tried implementing kitty remote control into preview-tui, and it almost works ... but there are bugs, that migh be on kitty's side.
1. It breaks `nnn`'s input (you have to press keys multiple time for one to be registered)
2. It shows a wierd backtrace when quitting `nnn` (maybe `kitty @ launch ...` is still running in the background edit: exactly, it can be removed by redirecting stderr to /dev/null)

I fear that kitty is trying to be too smart here, and does wierd thing to the terminal state. Or using remote control in script is just not enough tested. Or I'm missing something.

Anyways, I don't use kitty, so I'm out of this. I'll just leave it there if someone want to try to make it work better.