### PR TITLE
Notify FIFO readers on exit (if any)

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -7291,6 +7291,7 @@ int main(int argc, char *argv[])
 #endif
 
 #ifndef NOFIFO
+	notify_fifo();
 	if (fifofd != -1)
 		close(fifofd);
 #endif


### PR DESCRIPTION
This allows to close preview windows opened just before exiting nnn.

See report in #578 discussion.