### PR TITLE
preview-kitty polish (async version + text render for SVGs)

### DIFF
--- a/plugins/preview-kitty
+++ b/plugins/preview-kitty
@@ -38,8 +38,10 @@ preview_file () {
         # Print directory tree
         # shellcheck disable=SC2015
         cd "$1" && \
-        (COLUMNS=$cols exa -G --colour=always 2>/dev/null || ls --color=alway) | head -n $lines &
-    elif [ "${mime%%/*}" = "image" ] ; then
+        (COLUMNS=$cols exa -G --colour=always 2>/dev/null ||\
+        ls --color=alway) | head -n $lines &
+    # remove second clause to preview SVG files (but this is slow)
+    elif [ "${mime%%/*}" = "image" ] && [ "$encoding" = "binary" ] ; then
         kitty +kitten icat --silent --transfer-mode=stream --stdin=no "$1" &
     elif [ "$encoding" = "binary" ] ; then
         # Binary file: show file info

--- a/plugins/preview-kitty
+++ b/plugins/preview-kitty
@@ -27,6 +27,7 @@
 # Authors: Léo Villeveygoux
 
 preview_file () {
+    kill %% 2>/dev/null
     clear
     lines=$(($(tput lines)-1))
     cols=$(tput cols)
@@ -37,18 +38,18 @@ preview_file () {
         # Print directory tree
         # shellcheck disable=SC2015
         cd "$1" && \
-        COLUMNS=$cols exa -G --colour=always 2>/dev/null || ls --color=alway
+        (COLUMNS=$cols exa -G --colour=always 2>/dev/null || ls --color=alway) | head -n $lines &
     elif [ "${mime%%/*}" = "image" ] ; then
-        kitty +kitten icat --silent --transfer-mode=stream --stdin=no "$1"
+        kitty +kitten icat --silent --transfer-mode=stream --stdin=no "$1" &
     elif [ "$encoding" = "binary" ] ; then
         # Binary file: show file info
         printf -- "-------- \033[1;31mBinary file\033[0m --------\n"
-        mediainfo "$1" 2>/dev/null || file -b "$1"
+        (mediainfo "$1" 2>/dev/null || file -b "$1") | head -n $((lines - 1)) &
     else
         # Text file: print colored file content
-        bat --terminal-width="$cols" --paging=never --decorations=always \
-            --color=always "$1" 2>/dev/null || cat
-    fi | head -n $lines
+        (bat --terminal-width="$cols" --paging=never --decorations=always \
+            --color=always "$1" 2>/dev/null || cat) | head -n $lines &
+    fi
 }
 
 if [ "$PREVIEW_MODE" ] ; then


### PR DESCRIPTION
The first commit kills file viewers when a new file comes down the FIFO (we use fancier viewers in this plugin after all).

The second commit preview SVG files in text mode. This is a matter of taste at this point, as slow rendering SVGs won't block anything, but it's definitively faster. What do you think of this?

Fixes issues discussed in #582 