### PR TITLE
Allow setting arbitrary (1..8) CTX_MAX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,8 @@ ifeq ($(O_NOFIFO),1)
 	CPPFLAGS += -DNOFIFO
 endif
 
-ifeq ($(O_CTX8),1)
-	CPPFLAGS += -DCTX8
+ifdef O_CTXMAX
+	CPPFLAGS += -DCTX_MAX=$(O_CTXMAX)
 endif
 
 ifeq ($(shell $(PKG_CONFIG) ncursesw && echo 1),1)

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -157,14 +157,8 @@
 #define EXEC_ARGS_MAX 8
 #define LIST_FILES_MAX (1 << 16)
 #define SCROLLOFF 3
-
-#ifndef CTX8
-#define CTX_MAX 4
-#else
-#define CTX_MAX 8
-#endif
-
 #define MIN_DISPLAY_COLS ((CTX_MAX * 2) + 2) /* Two chars for [ and ] */
+#define CTX_SEL_CASE(num) case SEL_CTX##num:
 #define LONG_SIZE sizeof(ulong)
 #define ARCHIVE_CMD_LEN 16
 #define BLK_SHIFT_512 9
@@ -5740,16 +5734,7 @@ nochange:
 			goto begin;
 		case SEL_CYCLE: // fallthrough
 		case SEL_CYCLER: // fallthrough
-		case SEL_CTX1: // fallthrough
-		case SEL_CTX2: // fallthrough
-		case SEL_CTX3: // fallthrough
-		case SEL_CTX4:
-#ifdef CTX8
-		case SEL_CTX5:
-		case SEL_CTX6:
-		case SEL_CTX7:
-		case SEL_CTX8:
-#endif
+		REPEAT(CTX_MAX, CTX_SEL_CASE)
 			r = handle_context_switch(sel);
 			if (r < 0)
 				continue;

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3570,7 +3570,7 @@ static uchar get_free_ctx(void)
 	uchar r = cfg.curctx;
 
 	do
-		r = (r + 1) & ~CTX_MAX;
+		(r == CTX_MAX - 1) ? (r = 0) : ++r;
 	while (g_ctx[r].c_cfg.ctxactive && (r != cfg.curctx));
 
 	return r;
@@ -4878,11 +4878,11 @@ static int handle_context_switch(enum action sel)
 		r = cfg.curctx;
 		if (sel == SEL_CYCLE)
 			do
-				r = (r + 1) & ~CTX_MAX;
+				(r == CTX_MAX - 1) ? (r = 0) : ++r;
 			while (!g_ctx[r].c_cfg.ctxactive);
 		else
 			do
-				r = (r + (CTX_MAX - 1)) & (CTX_MAX - 1);
+				(r == 0) ? (r = CTX_MAX - 1) : --r;
 			while (!g_ctx[r].c_cfg.ctxactive);
 		// fallthrough
 	default: /* SEL_CTXN */
@@ -6445,9 +6445,9 @@ nochange:
 		case SEL_QUITFAIL:
 			if (sel == SEL_QUITCTX) {
 				int ctx = cfg.curctx;
-				for (r = (ctx + 1) & ~CTX_MAX;
+				for ((r == CTX_MAX - 1) ? (r = 0) : ++r;
 				     (r != ctx) && !g_ctx[r].c_cfg.ctxactive;
-				     r = ((r + 1) & ~CTX_MAX)) {
+				     (r == CTX_MAX - 1) ? (r = 0) : ++r) {
 				};
 
 				if (r != ctx) {

--- a/src/nnn.h
+++ b/src/nnn.h
@@ -32,6 +32,27 @@
 
 #include <curses.h>
 
+/* Handle variable CTX_MAX */
+#ifndef CTX_MAX
+#    define CTX_MAX 4
+#elif (CTX_MAX < 1) || (CTX_MAX > 8)
+#    error "CTX_MAX should be in range 1..8"
+#endif
+
+#define REPEAT(num, macro) REPEAT_START(num, macro)
+#define REPEAT_START(num, macro) REPEAT_##num(macro)
+#define REPEAT_1(macro) macro(1)
+#define REPEAT_2(macro) REPEAT_1(macro) macro(2)
+#define REPEAT_3(macro) REPEAT_2(macro) macro(3)
+#define REPEAT_4(macro) REPEAT_3(macro) macro(4)
+#define REPEAT_5(macro) REPEAT_4(macro) macro(5)
+#define REPEAT_6(macro) REPEAT_5(macro) macro(6)
+#define REPEAT_7(macro) REPEAT_6(macro) macro(7)
+#define REPEAT_8(macro) REPEAT_7(macro) macro(8)
+
+#define SEL_CTX(num) SEL_CTX##num,
+#define CTX_KEYDEF(num) {'0' + (num), SEL_CTX##num},
+
 #define CONTROL(c) ((c) & 0x1f)
 
 /* Supported actions */
@@ -56,16 +77,9 @@ enum action {
 	SEL_REMOTE,
 	SEL_CYCLE,
 	SEL_CYCLER,
-	SEL_CTX1,
-	SEL_CTX2,
-	SEL_CTX3,
-	SEL_CTX4,
-#ifdef CTX8
-	SEL_CTX5,
-	SEL_CTX6,
-	SEL_CTX7,
-	SEL_CTX8,
-#endif
+
+	REPEAT(CTX_MAX, SEL_CTX)
+
 	SEL_PIN,
 	SEL_FLTR,
 	SEL_MFLTR,
@@ -167,16 +181,7 @@ static struct key bindings[] = {
 	/* Cycle contexts in reverse direction */
 	{ KEY_BTAB,       SEL_CYCLER },
 	/* Go to/create context N */
-	{ '1',            SEL_CTX1 },
-	{ '2',            SEL_CTX2 },
-	{ '3',            SEL_CTX3 },
-	{ '4',            SEL_CTX4 },
-#ifdef CTX8
-	{ '5',            SEL_CTX5 },
-	{ '6',            SEL_CTX6 },
-	{ '7',            SEL_CTX7 },
-	{ '8',            SEL_CTX8 },
-#endif
+	REPEAT(CTX_MAX, CTX_KEYDEF)
 	/* Mark a path to visit later */
 	{ ',',            SEL_PIN },
 	/* Filter */


### PR DESCRIPTION
This builds up on @jarun's recent commits and @0xACE's #570, plus a bit of macro magic (to generate SEL enum/key list/cases).

The way it handles non power of two CTX_MAX was found elsewhere in nnn code, there is no more `%` only int cmp/inc/dec/affectation.