### PR TITLE
Wrap FILE_MIME_OPTS use in check

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3698,9 +3698,11 @@ static bool show_stats(const char *fpath, const struct stat *sb)
 			}
 			fprintf(fp, " %s\n  ", begin);
 
+#ifdef FILE_MIME_OPTS
 			/* Show the file mime type */
 			get_output(g_buf, CMD_LEN_MAX, "file", FILE_MIME_OPTS, fpath, FALSE);
 			fprintf(fp, "%s", g_buf);
+#endif
 		}
 	}
 


### PR DESCRIPTION
We leave it undefined on Solaris/Illumos (at the top of `nnn.c`)
because no such options exists, so only use it if we have it. This
fixes the build on OpenIndiana Hipster, an Illumos distribution.