### PR TITLE
preview-tui: simplify, add generic fifo_pager()

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -5,7 +5,8 @@
 # Note: This plugin needs a "NNN_FIFO" to work.
 #
 # Dependencies: tmux (>=3.0) or xterm or $TERMINAL, less or $PAGER,
-#               file, stat, tree, add you own! (see examples in code)
+#               file, stat, tree, man, tar, unzip, ...
+#                      ... add you own! (see examples in code)
 #
 # Usage:
 #   You need to set a NNN_FIFO path and set a key for the plugin,
@@ -57,13 +58,13 @@ preview_file () {
     encoding="$(file -Lb --mime-encoding -- "$1")"
 
     # Detect mime type
-    #mimetype="$(file -Lb --mime-type -- "$1")"
+    mimetype="$(file -Lb --mime-type -- "$1")"
 
     # Detect file extention - use if you need
-    #ext="${1##*.}"
-    #if [ -n "$ext" ]; then
-    #    ext="$(printf "%s" "${ext}" | tr '[:upper:]' '[:lower:]')"
-    #fi
+    ext="${1##*.}"
+    if [ -n "$ext" ]; then
+        ext="$(printf "%s" "${ext}" | tr '[:upper:]' '[:lower:]')"
+    fi
 
     if [ -d "$1" ]; then
         # Print directory tree
@@ -71,12 +72,12 @@ preview_file () {
         fifo_pager tree
     #elif [ "${mimetype%%/*}" = "image" ] ; then
     #    catimg "$1"
-    #elif [ "$mimetype" = "text/troff" ] ; then
-    #    fifo_pager man -Pcat -l "$1"
-    #elif [ "$mimetype" = "application/zip" ] ; then
-    #    fifo_pager unzip -l "$1"
-    #elif [ "$ext" = "gz" ] || [ "$ext" = "bz2" ] ; then
-    #    fifo_pager tar -tvf "$1"
+    elif [ "$mimetype" = "text/troff" ] ; then
+        fifo_pager man -Pcat -l "$1"
+    elif [ "$mimetype" = "application/zip" ] ; then
+        fifo_pager unzip -l "$1"
+    elif [ "$ext" = "gz" ] || [ "$ext" = "bz2" ] ; then
+        fifo_pager tar -tvf "$1"
     elif [ "$encoding" = "binary" ] ; then
         # Binary file: just print filetype info
         echo "-------- binary file --------"

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -4,19 +4,24 @@
 #
 # Note: This plugin needs a "NNN_FIFO" to work.
 #
-# Dependencies: tmux (>=3.0) or xterm or $TERMINAL, less or $PAGER, file, tree
+# Dependencies: tmux (>=3.0) or xterm or $TERMINAL, less or $PAGER,
+#               file, stat, tree, add you own! (see examples in code)
 #
 # Usage:
 #   You need to set a NNN_FIFO path and set a key for the plugin,
 #   then start `nnn`:
+#
+#     $ nnn -a
+#
+#   or
 #
 #     $ NNN_FIFO=/tmp/nnn.fifo nnn
 #
 #   Then in `nnn`, launch the `preview-tui` plugin.
 #
 #   If you provide the same NNN_FIFO to all nnn instances, there will be a
-#   single common preview window. I you provide different FIFO path, they
-#   will be independent.
+#   single common preview window. I you provide different FIFO path (e.g.
+#   with -a), they will be independent.
 #
 #   Configure SPLIT to either "h" or "v" to set a 'h'orizontal split or a
 #   'v'ertical split
@@ -25,62 +30,58 @@
 # Authors: Todd Yamakawa, Léo Villeveygoux, @Recidiviste
 
 TERMINAL="${TERMINAL:-xterm}"
-PAGER="${PAGER:-less}"
-SPLIT=
+PAGER="${PAGER:-less -R}"
 
-lines=$(($(tput lines)-1))
-cols=$(tput cols)
+fifo_pager() {
+    cmd="$1"
+    shift
 
-beginswith() {
-    case $1 in "$2"*) true;; *) false;; esac;
+    # We use a FIFO to access $PAGER PID in jobs control
+    tmpfifopath="${TMPDIR:-/tmp}/nnn-preview-tui-fifo.$$"
+    mkfifo "$tmpfifopath" || return
+
+    $PAGER < "$tmpfifopath" &
+
+    (
+        exec > "$tmpfifopath"
+        "$cmd" "$@" &
+    )
+
+    rm "$tmpfifopath"
 }
 
 preview_file () {
-    kill "$(jobs -p)" 2>/dev/null
+    kill %- %+ 2>/dev/null
     clear
 
-    encoding="$(file -b --mime-encoding "$1")"
+    encoding="$(file -Lb --mime-encoding -- "$1")"
 
     # Detect mime type
-    mimetype="$(file --dereference --brief --mime-type -- "$1")"
+    #mimetype="$(file -Lb --mime-type -- "$1")"
 
-    # Detect file extention
-    ext="${1##*.}"
-    if ! [ -z "$ext" ]; then
-        ext="$(printf "%s" "${ext}" | tr '[:upper:]' '[:lower:]')"
-    fi
+    # Detect file extention - use if you need
+    #ext="${1##*.}"
+    #if [ -n "$ext" ]; then
+    #    ext="$(printf "%s" "${ext}" | tr '[:upper:]' '[:lower:]')"
+    #fi
 
     if [ -d "$1" ]; then
         # Print directory tree
-
         cd "$1" || return
-
-        # We use a FIFO to access less PID
-        tmpfifopath="${TMPDIR:-/tmp}/nnn-preview-tui-fifo.$$"
-        mkfifo "$tmpfifopath" || return
-
-        $PAGER < "$tmpfifopath" &
-
-        (
-            exec > "$tmpfifopath"
-            tree&
-        )
-
-        rm "$tmpfifopath"
-    #elif beginswith "$mimetype" "image/" ; then
-    #    viu "$1" | head -n "$lines"
-    #elif beginswith "$mimetype" "text/troff" ; then
-    #    man -l "$1" &
-    elif beginswith "$mimetype" "application/zip" ; then
-        #$PAGER "$(zip -sf "$1")" &
-        $PAGER "$(unzip -l "$1")" &
-    elif [ "$ext" = "gz" ] || [ "$ext" = "bz2" ] ; then
-        $PAGER "$(tar -tvf "$1")" &
+        fifo_pager tree
+    #elif [ "${mimetype%%/*}" = "image" ] ; then
+    #    catimg "$1"
+    #elif [ "$mimetype" = "text/troff" ] ; then
+    #    fifo_pager man -Pcat -l "$1"
+    #elif [ "$mimetype" = "application/zip" ] ; then
+    #    fifo_pager unzip -l "$1"
+    #elif [ "$ext" = "gz" ] || [ "$ext" = "bz2" ] ; then
+    #    fifo_pager tar -tvf "$1"
     elif [ "$encoding" = "binary" ] ; then
         # Binary file: just print filetype info
         echo "-------- binary file --------"
         file -b "$1"
-        echo ''
+        echo
         stat "$1"
     else
         # Text file:
@@ -105,13 +106,9 @@ if [ "$PREVIEW_MODE" ] ; then
 fi
 
 if [ -e "${TMUX%%,*}" ] && [ "$(tmux -V | cut -c6)" -eq 3 ] ; then
-    if [ -z "$SPLIT" ]; then
-        if [ "$(( lines * 2 ))" -gt "$cols" ]; then
-            SPLIT='v'
-        else
-            SPLIT='h'
-        fi
-    elif [ "$SPLIT" != "h" ] && [ "$SPLIT" != "v" ] ; then
+    if [ -z "$SPLIT" ] && [ $(($(tput lines) * 2)) -gt "$(tput cols)" ] ; then
+        SPLIT='v'
+    elif [ "$SPLIT" != 'v' ] ; then
         SPLIT='h'
     fi
 


### PR DESCRIPTION
I've commented new filetype checks for now, as we need to discuss which ones
should be included by default, keeping in mind that this is supposed to be a
minimal, adaptable plugin.

Maybe the `tar` listing is a good candidate? as it's probably a dependency people already have installed.