### PR TITLE
Added GPG encrypt and decrypt plugins

### DIFF
--- a/plugins/gpgd
+++ b/plugins/gpgd
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-# Description: gpg decryption
+# Description: Decrypts selected files using gpg. The contents of the decrypted file are stored in a file with extension .dec
+#
+# Note: If an appropriate private key cannot be found gpg silently prints a message in the background and no files are written.
 #
 # Shell: POSIX compliant
 # Author: KlzXS

--- a/plugins/gpgd
+++ b/plugins/gpgd
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Description: gpg decryption
+#
+# Shell: POSIX compliant
+# Author: KlzXS
+
+selection=${NNN_SEL:-${XDG_CONFIG_HOME:-$HOME/.config}/nnn/.selection}
+
+files=$(tr '\0' '\n' < "$selection")
+
+printf "%s" "$files" | xargs -n1 -I{} gpg --decrypt --output "{}.dec" {}
+

--- a/plugins/gpge
+++ b/plugins/gpge
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-# Description: gpg encryption
+# Description: Encrypts selected files using gpg. Can encrypt either asymmetrically (key) or symmetrically (passphrase).
+#              If asymmetric encryption is chosen a key can be chosen from the list of capable public keys using fzf.
 #
 # Note: symmetric encryption only works for a single file as per gpg limitations
 #

--- a/plugins/gpge
+++ b/plugins/gpge
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Description: gpg encryption
+#
+# Note: symmetric encryption only works for a single file as per gpg limitations
+#
+# Shell: POSIX compliant
+# Author: KlzXS
+
+selection=${NNN_SEL:-${XDG_CONFIG_HOME:-$HOME/.config}/nnn/.selection}
+
+printf "(s)ymmetric, (a)symmetric? [default=a] "
+read -r symmetry
+
+files=$(tr '\0' '\n' < "$selection")
+if [ "$symmetry" = "s" ]; then
+	gpg --symmetric "$files"
+else
+	keyids=$(gpg --list-public-keys --with-colons | grep -E "pub:(.*:){10}.*[eE].*:" | awk -F ":" '{print $5}')
+
+	#awk needs literal $10
+	#shellcheck disable=SC2016
+	keyuids=$(printf "%s" "$keyids" | xargs -n1 -I{} sh -c 'gpg --list-key --with-colons "{}" | grep "uid" | awk -F ":" '\''{printf "%s %s\n", "{}", $10}'\''')
+
+	recipient=$(printf "%s" "$keyuids" | fzf | awk '{print $1}')
+
+	printf "%s" "$files" | xargs -n1 gpg --encrypt --recipient "$recipient"
+fi
+


### PR DESCRIPTION
The encrypt plugin can either encrypt using a key or a passphrase (only a single file with a passphrase, gpg limitation). If asymmetric is chosen it lists the available public keys that support encryption along with the user id of that key in `fzf`.

The decrypt plugin attempts to decrypt a file. If there is no secret key gpg silently prints a message in the background. Decrypted files are saved in `original_name.dec`, I couldn't think of anything better and writing out to the shell seems like the lesser option.