### PR TITLE
bookmarks: Pipe error to PAGER and clean up code

### DIFF
--- a/plugins/bookmarks
+++ b/plugins/bookmarks
@@ -17,6 +17,7 @@
 #     `ln -s /path/to/movies              movies`
 #
 # Bonus tip: Add `$BOOKMARKS_DIR` to your `$CDPATH`
+# https://linux.101hacks.com/cd-command/cdpath/
 #
 # TODO:
 #   1. Remove `fzf` dependency
@@ -27,7 +28,10 @@
 BOOKMARKS_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/nnn/bookmarks"
 
 # Check if NNN_PIPE is set
-[ -z "$NNN_PIPE" ] && { echo 'NNN_PIPE is not set'; exit 2; }
+if [ -z "$NNN_PIPE" ]; then
+    echo 'ERROR: NNN_PIPE is not set' | ${PAGER:-less}
+    exit 2
+fi
 
 # Get all directory symlinks
 get_links() {
@@ -37,12 +41,12 @@ get_links() {
         [ -h "$entry" ] || continue
         [ -d "$entry" ] || continue
 
-        echo "$(basename "$entry") ->  $(readlink -f "$entry")"
-    done | column -t
+        printf "%20s -> %s\n" "$(basename "$entry")" "$(readlink -f "$entry")"
+    done | fzf | awk 'END { print "'"$BOOKMARKS_DIR"'/"$1 }'
 }
 
 # Choose symlink with fzf
-cddir="$(get_links "$BOOKMARKS_DIR" | fzf | awk 'END { print "'"$BOOKMARKS_DIR"'/"$1 }')"
+cddir="$(get_links "$BOOKMARKS_DIR")"
 
 # Writing result to NNN_PIPE will change nnn's active directory
 # https://github.com/jarun/nnn/tree/master/plugins#send-data-to-nnn


### PR DESCRIPTION
column -t is slow because it waits for the for loop to finish before formatting. I found `printf` to be an acceptable alternative.

Also when NNN_PIPE isn't set, I print the error message in `$PAGER` so users can figure out what's gone wrong.