### PR TITLE
preview-kitty: fix crash on first file on dash

### DIFF
--- a/plugins/preview-kitty
+++ b/plugins/preview-kitty
@@ -63,7 +63,9 @@ if [ "$PREVIEW_MODE" ] ; then
 
     preview_file "$1"
 
-    exec < "$NNN_FIFO"
+    # use cat instead of 'exec <' to avoid issues with dash shell
+    # shellcheck disable=SC2002
+    cat "$NNN_FIFO" |\
     while read -r selection ; do
         preview_file "$selection"
     done


### PR DESCRIPTION
In the dash shell, when `exec < fifo` is interrupted by SIGCHLD, it exits.
So we replace it with `cat fifo |`.

Issue discussed in #614

@marioortizmanero I believe that you'll have to backport this to #634 