### PR TITLE
preview-tui splits are inverted

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -64,10 +64,10 @@ else
     TERMINAL="${TERMINAL:-xterm}"
 fi
 
-if [ -z "$SPLIT" ] && [ $(($(tput lines) * 2)) -gt "$(tput cols)" ] ; then
-    SPLIT='v'
-elif [ "$SPLIT" != 'v' ] ; then
+if [ -z "$SPLIT" ] && [ $(($(tput lines) * 2)) -gt "$(tput cols)" ]; then
     SPLIT='h'
+elif [ "$SPLIT" != 'h' ]; then
+    SPLIT='v'
 fi
 
 exists() {


### PR DESCRIPTION
I forgot to invert them properly. It now works like this:

![image](https://user-images.githubusercontent.com/25647296/84159030-df6eec80-aa6c-11ea-8ce3-a294b1e8c958.png)

![image](https://user-images.githubusercontent.com/25647296/84159056-e72e9100-aa6c-11ea-9993-602b5505243c.png)

Which is how it used to work, and how you'd expect it.
