### PR TITLE
Kitty splits

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -180,7 +180,8 @@ if [ "$PREVIEW_MODE" ] ; then
         preview_file "$selection"
     done
 
-    # Restoring the previous preview for kitty users
+    # Restoring the previous layout for kitty users. This will only work for
+    # kitty >= 0.18.0.
     if [ "$TERMINAL" = "kitty" ]; then
         kitty @ last-used-layout --no-response >/dev/null 2>&1
     fi
@@ -194,11 +195,11 @@ if [ "$TERMINAL" = "tmux" ]; then
 
     tmux split-window -e "NNN_FIFO=$NNN_FIFO" -e "PREVIEW_MODE=1" -d"$SPLIT" "$0" "$1"
 elif [ "$TERMINAL" = "kitty" ]; then
-    # Setting the layout for the new window.
+    # Setting the layout for the new window. It will be restored after the
+    # script ends.
     kitty @ goto-layout splits >/dev/null
 
     # Trying to use kitty's integrated window management as the split window.
-    # The layout will be restored after the script ends.
     kitty @ launch --no-response --title "nnn preview" --keep-focus \
           --cwd "$PWD" --env "NNN_FIFO=$NNN_FIFO" --env "PREVIEW_MODE=1" \
           --location "${SPLIT}split" "$0" "$1" >/dev/null

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -64,10 +64,10 @@ else
     TERMINAL="${TERMINAL:-xterm}"
 fi
 
-if [ -z "$SPLIT" ] && [ $(($(tput lines) * 2)) -gt "$(tput cols)" ]; then
-    SPLIT='h'
-elif [ "$SPLIT" != 'h' ]; then
+if [ -z "$SPLIT" ] && [ $(($(tput lines) * 2)) -gt "$(tput cols)" ] ; then
     SPLIT='v'
+elif [ "$SPLIT" != 'v' ] ; then
+    SPLIT='h'
 fi
 
 exists() {
@@ -179,6 +179,12 @@ if [ "$PREVIEW_MODE" ] ; then
     while read -r selection ; do
         preview_file "$selection"
     done
+
+    # Restoring the previous preview for kitty users
+    if [ "$TERMINAL" = "kitty" ]; then
+        kitty @ last-used-layout --no-response >/dev/null 2>&1
+    fi
+
     exit 0
 fi
 
@@ -195,8 +201,7 @@ elif [ "$TERMINAL" = "kitty" ]; then
     # The layout will be restored after the script ends.
     kitty @ launch --no-response --title "nnn preview" --keep-focus \
           --cwd "$PWD" --env "NNN_FIFO=$NNN_FIFO" --env "PREVIEW_MODE=1" \
-          --location "${SPLIT}split" sh -c "\"$0\" \"$1\";" \
-          "kitty @ last-used-layout --no-response >/dev/null 2>&1" >/dev/null
+          --location "${SPLIT}split" "$0" "$1" >/dev/null
 else
     PREVIEW_MODE=1 $TERMINAL -e "$0" "$1" &
 fi

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -192,12 +192,11 @@ elif [ "$TERMINAL" = "kitty" ]; then
     kitty @ goto-layout splits >/dev/null
 
     # Trying to use kitty's integrated window management as the split window.
+    # The layout will be restored after the script ends.
     kitty @ launch --no-response --title "nnn preview" --keep-focus \
           --cwd "$PWD" --env "NNN_FIFO=$NNN_FIFO" --env "PREVIEW_MODE=1" \
-          --location "${SPLIT}split" "$0" "$1" >/dev/null
-
-    # Restoring the previous layout.
-    kitty @ last-used-layout --no-response >/dev/null 2>&1
+          --location "${SPLIT}split" sh -c "\"$0\" \"$1\";" \
+          "kitty @ last-used-layout --no-response >/dev/null 2>&1" >/dev/null
 else
     PREVIEW_MODE=1 $TERMINAL -e "$0" "$1" &
 fi


### PR DESCRIPTION
Continuation of https://github.com/jarun/nnn/pull/634

So turns out that after managing to get `--no-response` for `kitty @ last-used-layout`, it doesn't exactly work as I wanted to. `kitty @ launch` is non-blocking, so `kitty @ last-used-layout` is executed immediately afterwards, and the layout goes back to the original one, which is horizontal by default. The layout should only be restored after the script is done.

I also wanted to add a note indicating that this will only work for versions older than 0.17.4, but I'm not sure what number the next release is going to have. Can you give us a hint, @kovidgoyal?