### PR TITLE
preview-tui: make scope & pistol run before `file`

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -114,17 +114,6 @@ preview_file () {
     kill %- %+ 2>/dev/null && wait %- %+ 2>/dev/null
     clear
 
-    # Detecting the exact type of the file: the encoding, mime type, and
-    # extension in lowercase.
-    encoding="$(file -Lb --mime-encoding -- "$1")"
-    mimetype="$(file -Lb --mime-type -- "$1")"
-    ext="${1##*.}"
-    if [ -n "$ext" ]; then
-        ext="$(printf "%s" "${ext}" | tr '[:upper:]' '[:lower:]')"
-    fi
-    lines=$(($(tput lines)-1))
-    cols=$(tput cols)
-
     # Trying to use pistol if it's available.
     if [ "$USE_PISTOL" -ne 0 ] && exists pistol; then
         fifo_pager pistol "$1"
@@ -137,6 +126,17 @@ preview_file () {
             "True" 2>/dev/null
         return
     fi
+
+    # Detecting the exact type of the file: the encoding, mime type, and
+    # extension in lowercase.
+    encoding="$(file -Lb --mime-encoding -- "$1")"
+    mimetype="$(file -Lb --mime-type -- "$1")"
+    ext="${1##*.}"
+    if [ -n "$ext" ]; then
+        ext="$(printf "%s" "${ext}" | tr '[:upper:]' '[:lower:]')"
+    fi
+    lines=$(($(tput lines)-1))
+    cols=$(tput cols)
 
     # Otherwise, falling back to the defaults.
     if [ -d "$1" ]; then


### PR DESCRIPTION
Both Pistol and `scope.sh` run `file --mimetype` or an equivalent, internally. Thus, for speed, it's better to run them before almost anything else.

Specifically for Pistol, the motivation for his creation was to avoid as much as possible shell code when previewing files, so for this plugin, the least can be done is this.

I don't use nnn and I didnt test this patch. I just thought it's trivial.