### PR TITLE
Fix check when char is unsigned

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -4320,9 +4320,11 @@ static void readpipe(int fd, char **path, char **lastname, char **lastdir)
 
 	if (g_buf[0] == '+')
 		ctx = (char)(get_free_ctx() + 1);
+	else if (g_buf[0] < '0')
+		return;
 	else {
 		ctx = g_buf[0] - '0';
-		if (ctx < 0 || ctx > CTX_MAX)
+		if (ctx > CTX_MAX)
 			return;
 	}
 


### PR DESCRIPTION
If char is unsigned (as on ARM) subtracting a larger number would
result in a wrap around, not a negative value.

    src/nnn.c: In function 'readpipe':
    src/nnn.c:4325:11: warning: comparison is always false due to limited
    range of data type [-Wtype-limits]

       if (ctx < 0 || ctx > CTX_MAX)
               ^