### PR TITLE
Always use builtin alloca()

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -90,9 +90,6 @@
 #include <signal.h>
 #include <stdarg.h>
 #include <stdlib.h>
-#ifdef __sun
-#include <alloca.h>
-#endif
 #include <string.h>
 #include <strings.h>
 #include <time.h>
@@ -102,6 +99,15 @@
 #endif
 #include <ftw.h>
 #include <wchar.h>
+
+#if !defined(alloca) && defined(__GNUC__)
+/*
+ * GCC doesn't expand alloca() to __builtin_alloca() in standards mode
+ * (-std=...) and not all standard libraries do or supply it, e.g.
+ * NetBSD/arm64 so explicitly use the builtin.
+ */
+#define alloca(size) __builtin_alloca(size)
+#endif
 
 #include "nnn.h"
 #include "dbg.h"


### PR DESCRIPTION
Fixes the build on NetBSD 9 on arm64.

GCC expands alloca() to __builtin_alloca() but only in nonstandard mode,
e.g. when -std=... is not supplied.  In standards mode (with -std=...)
alloca() is left undefined by GCC. The C library may define it but it
also may not, as on NetBSD on arm64:

    $ uname -srp
    NetBSD 9.0 aarch64

    $ cat alloca.c
    #include <stdlib.h>
    int main() { char *p = alloca(10); }

    $ gcc alloca.c

    $ gcc -std=c99 alloca.c
    alloca.c:(.text+0xc): warning: Warning: reference to the libc
     supplied alloca(3); this most likely will not work. Please use the
     compiler provided version of alloca(3), by supplying the
     appropriate compiler flags (e.g. not -std=c89).
    ld: alloca.c:(.text+0xc): undefined reference to `alloca'

The fix is to either not use standards mode (undesirable) or to
explicitly use the builtin, which is what this patch does.

This is also sufficient for Solarius/Illumos so that check and include
are removed.