### PR TITLE
Remote name can contain the path

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -4028,7 +4028,7 @@ static bool remote_mount(char *newpath)
 	/* Convert "Host" to "Host:" */
 	size_t len = xstrlen(tmp);
 
-	if (tmp[len - 1] != ':') { /* Append ':' if missing */
+	if (strchr(tmp, ':') == NULL) { /* Append ':' if missing */
 		tmp[len] = ':';
 		tmp[len + 1] = '\0';
 	}


### PR DESCRIPTION
If there is a ':' in the remote name, let it be. So there's a option to
input just the `remotename` (that will be transformed to `remotename:`), or
`remotename:/with/path`.