### PR TITLE
Fix inability to enter directories on an XFS filesystem on top of an md device

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -4970,7 +4970,7 @@ static int dentfill(char *path, struct entry **ppdents)
 			if (S_ISDIR(sb.st_mode))
 				dentp->flags |= DIR_OR_LINK_TO_DIR;
 #if !(defined(__sun) || defined(__HAIKU__)) /* no d_type */
-		} else if (dp->d_type == DT_DIR || (dp->d_type == DT_LNK && S_ISDIR(sb.st_mode))) {
+		} else if (dp->d_type == DT_DIR || ((dp->d_type == DT_LNK || dp->d_type == DT_UNKNOWN) && S_ISDIR(sb.st_mode))) {
 			dentp->flags |= DIR_OR_LINK_TO_DIR;
 #endif
 		}


### PR DESCRIPTION
nnn was refusing to enter any directories located on an XFS filesystem sitting on top of an md device, and showing me the error "unknown" in the status line.

This fix consists in adding a check for DT_UNKNOWN. Apparently, even on filesystems supporting d_type, readdir(3) can sometimes return a d_type of DT_UNKNOWN for performance reasons. Programs looking at d_type should always handle this case.

Issue encountered and fixed on Debian buster (XFS v4.20, md v4.1) using Linux kernels 5.7.6 and 4.19.60.