### PR TITLE
Fix arrow keys not working on mintty

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -1714,7 +1714,7 @@ static bool initcurses(void *oldmask)
 	}
 
 	settimeout(); /* One second */
-	set_escdelay(0);
+	set_escdelay(25);
 	return TRUE;
 }
 


### PR DESCRIPTION
I have an old box, using the mintty terminal emulator, where arrow key navigation no longer works after the recent change to the ncurses Escape delay from 25 ms to 0.

Would it be okay to revert back to 25 ms? Even though mine is a corner case, probably due to a slow terminal and/or host, nnn is the only ncurses program having issues on this system. Vim, htop, etc. all work fine, and they all seem to have settled on a delay of 25 ms.

Having no delay at all is bound to break the arrow keys in some other situations as well.

Cheers.