### PR TITLE
Adding support for `most` pager

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -64,7 +64,7 @@ TERMINAL="$TERMINAL"  # same goes for the terminal
 USE_SCOPE="${USE_SCOPE:-0}"
 USE_PISTOL="${USE_PISTOL:-0}"
 PAGER="${PAGER:-less -R}"
-exists bat && [ "$PAGER" = "most" ] && PAGER="less -R"
+[ "$PAGER" = "most" ] && exists bat && PAGER="less -R"
 
 if [ -e "${TMUX%%,*}" ] && tmux -V | grep -q '[ -][3456789]\.'; then
     TERMINAL=tmux

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -64,7 +64,7 @@ TERMINAL="$TERMINAL"  # same goes for the terminal
 USE_SCOPE="${USE_SCOPE:-0}"
 USE_PISTOL="${USE_PISTOL:-0}"
 PAGER="${PAGER:-less -R}"
-[ "$PAGER" = "most" ] && PAGER="less -R"
+exists bat && [ "$PAGER" = "most" ] && PAGER="less -R"
 
 if [ -e "${TMUX%%,*}" ] && tmux -V | grep -q '[ -][3456789]\.'; then
     TERMINAL=tmux

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -64,6 +64,7 @@ TERMINAL="$TERMINAL"  # same goes for the terminal
 USE_SCOPE="${USE_SCOPE:-0}"
 USE_PISTOL="${USE_PISTOL:-0}"
 PAGER="${PAGER:-less -R}"
+[ "$PAGER" = "most" ] && PAGER="less -R"
 
 if [ -e "${TMUX%%,*}" ] && tmux -V | grep -q '[ -][3456789]\.'; then
     TERMINAL=tmux

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -64,7 +64,7 @@ TERMINAL="$TERMINAL"  # same goes for the terminal
 USE_SCOPE="${USE_SCOPE:-0}"
 USE_PISTOL="${USE_PISTOL:-0}"
 PAGER="${PAGER:-less -R}"
-[ "$PAGER" = "most" ] && exists bat && PAGER="less -R"
+[ "$PAGER" = "most" ] && PAGER="less -R"
 
 if [ -e "${TMUX%%,*}" ] && tmux -V | grep -q '[ -][3456789]\.'; then
     TERMINAL=tmux


### PR DESCRIPTION
`most` pager, by default, does not support control characters. So, the idea is to add a test after the set of PAGER to change it to `less -R` so control chars can be interpreted

First, test for PAGER, than bat, than change.