### PR TITLE
nuke: use macOS open when GUI enabled

### DIFF
--- a/plugins/fzopen
+++ b/plugins/fzopen
@@ -29,5 +29,10 @@ case "$(file -biL "$entry")" in
     *text*)
         "${VISUAL:-$EDITOR}" "$entry" ;;
     *)
-        xdg-open "$entry" >/dev/null 2>&1 ;;
+        if uname | grep -q "Darwin"; then
+            open "$entry" >/dev/null 2>&1
+        else
+            xdg-open "$entry" >/dev/null 2>&1
+        fi
+        ;;
 esac

--- a/plugins/imgview
+++ b/plugins/imgview
@@ -39,7 +39,11 @@ if [ -z "$1" ] || ! [ -s "$1" ]; then
     exit 1
 fi
 
-if command -v imvr >/dev/null 2>&1; then
+if uname | grep -q "Darwin"; then
+    if [ -f "$1" ]; then
+        open "$1" >/dev/null 2>&1 &
+    fi
+elif command -v imvr >/dev/null 2>&1; then
     if [ -f "$1" ]; then
         view_dir imvr "$1" >/dev/null 2>&1 &
     elif [ -d "$1" ] || [ -h "$1" ]; then

--- a/plugins/nuke
+++ b/plugins/nuke
@@ -79,12 +79,17 @@ FNAME=$(basename "$1")
 EDITOR="${EDITOR:-vi}"
 PAGER="${PAGER:-less -R}"
 ext="${FNAME##*.}"
-if ! [ -z "$ext" ]; then
+if [ -n "$ext" ]; then
     ext="$(printf "%s" "${ext}" | tr '[:upper:]' '[:lower:]')"
 fi
 
+uname=$(uname)
+
 handle_pdf() {
-    if [ "$GUI" -ne 0 ] && which zathura >/dev/null 2>&1; then
+    if [ "$GUI" -ne 0 ] && [ "$uname" = Darwin ]; then
+        open "${FPATH}" >/dev/null 2>&1 &
+        exit 0
+    elif [ "$GUI" -ne 0 ] && which zathura >/dev/null 2>&1; then
         zathura "${FPATH}" >/dev/null 2>&1 &
         exit 0
     elif which pdftotext >/dev/null 2>&1; then
@@ -120,7 +125,10 @@ handle_audio() {
 }
 
 handle_video() {
-    if [ "$GUI" -ne 0 ] && which smplayer >/dev/null 2>&1; then
+    if [ "$GUI" -ne 0 ] && [ "$uname" = Darwin ]; then
+        open "${FPATH}" >/dev/null 2>&1 &
+        exit 0
+    elif [ "$GUI" -ne 0 ] && which smplayer >/dev/null 2>&1; then
         smplayer "${FPATH}" >/dev/null 2>&1 &
         exit 0
     elif [ "$GUI" -ne 0 ] && which mpv >/dev/null 2>&1; then
@@ -294,7 +302,10 @@ handle_multimedia() {
 
         ## Image
         image/*)
-            if [ "$GUI" -ne 0 ] && which imvr >/dev/null 2>&1; then
+            if [ "$GUI" -ne 0 ] && [ "$uname" = Darwin ]; then
+                open "${FPATH}" >/dev/null 2>&1 &
+                exit 0
+            elif [ "$GUI" -ne 0 ] && which imvr >/dev/null 2>&1; then
                 load_dir imvr "${FPATH}" >/dev/null 2>&1 &
                 exit 0
             elif [ "$GUI" -ne 0 ] && which sxiv >/dev/null 2>&1; then

--- a/plugins/nuke
+++ b/plugins/nuke
@@ -83,10 +83,12 @@ if [ -n "$ext" ]; then
     ext="$(printf "%s" "${ext}" | tr '[:upper:]' '[:lower:]')"
 fi
 
-uname=$(uname)
+is_mac() {
+    uname | grep -q "Darwin"
+}
 
 handle_pdf() {
-    if [ "$GUI" -ne 0 ] && [ "$uname" = Darwin ]; then
+    if [ "$GUI" -ne 0 ] && is_mac; then
         open "${FPATH}" >/dev/null 2>&1 &
         exit 0
     elif [ "$GUI" -ne 0 ] && which zathura >/dev/null 2>&1; then
@@ -125,7 +127,7 @@ handle_audio() {
 }
 
 handle_video() {
-    if [ "$GUI" -ne 0 ] && [ "$uname" = Darwin ]; then
+    if [ "$GUI" -ne 0 ] && is_mac; then
         open "${FPATH}" >/dev/null 2>&1 &
         exit 0
     elif [ "$GUI" -ne 0 ] && which smplayer >/dev/null 2>&1; then
@@ -302,7 +304,7 @@ handle_multimedia() {
 
         ## Image
         image/*)
-            if [ "$GUI" -ne 0 ] && [ "$uname" = Darwin ]; then
+            if [ "$GUI" -ne 0 ] && is_mac; then
                 open "${FPATH}" >/dev/null 2>&1 &
                 exit 0
             elif [ "$GUI" -ne 0 ] && which imvr >/dev/null 2>&1; then

--- a/plugins/pskill
+++ b/plugins/pskill
@@ -29,5 +29,7 @@ if ! [ -z "$psname" ]; then
     fi
 
     cmd="$(ps -ax | grep -iw "$psname" | "$fuzzy" | sed -e 's/^[ \t]*//' | cut -d' ' -f1)"
-    $sucmd kill -9 "$cmd"
+    if [ -n "$cmd" ]; then
+        $sucmd kill -9 "$cmd"
+    fi
 fi


### PR DESCRIPTION
For non-macOS users, this has no effect (`[ "$uname" = Darwin ]` is false). For macOS users, this has the effect of using `open` as the primary command for images, videos, and PDFs. `open` uses the default opener for the given filetype at the OS level, meaning the program that is launched is still user-configurable through the OS.