### PR TITLE
Add comment for imv command in imgview plugin. Check with which instead of version

### DIFF
--- a/plugins/imgview
+++ b/plugins/imgview
@@ -43,22 +43,24 @@ if uname | grep -q "Darwin"; then
     if [ -f "$1" ]; then
         open "$1" >/dev/null 2>&1 &
     fi
-elif command -v imvr >/dev/null 2>&1; then
+# `imvr` is often callable as `imv` on Linux distros
+# You might need to change the reference below
+elif which imvr >/dev/null 2>&1; then
     if [ -f "$1" ]; then
         view_dir imvr "$1" >/dev/null 2>&1 &
     elif [ -d "$1" ] || [ -h "$1" ]; then
         imvr "$1" >/dev/null 2>&1 &
     fi
-elif command -v sxiv >/dev/null 2>&1; then
+elif which sxiv >/dev/null 2>&1; then
     if [ -f "$1" ]; then
         view_dir sxiv "$1" >/dev/null 2>&1 &
     elif [ -d "$1" ] || [ -h "$1" ]; then
         sxiv -qt "$1" >/dev/null 2>&1 &
     fi
-elif command -v viu >/dev/null 2>&1; then
+elif which viu >/dev/null 2>&1; then
     viu -n "$1" | less -R
 else
-    printf "install imv/sxiv/viu"
+    printf "Please install imv/sxiv/viu and check their callable names match the plugin source"
     read -r _
     exit 2
 fi

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -81,7 +81,7 @@ elif [ "$SPLIT" != 'h' ]; then
 fi
 
 exists() {
-    command -v "$1" >/dev/null 2>&1
+    which "$1" >/dev/null 2>&1
 }
 
 fifo_pager() {

--- a/plugins/renamer
+++ b/plugins/renamer
@@ -14,10 +14,10 @@
 
 selection=${NNN_SEL:-${XDG_CONFIG_HOME:-$HOME/.config}/nnn/.selection}
 
-if command -v qmv >/dev/null 2>&1; then
+if which qmv >/dev/null 2>&1; then
 	batchrenamesel="qmv -fdo -da"
 	batchrename="qmv -fdo -a"
-elif command -v vidir >/dev/null 2>&1; then
+elif which vidir >/dev/null 2>&1; then
 	batchrenamesel="vidir"
 	batchrename="vidir"
 else


### PR DESCRIPTION
Adds a comment to mention that `imvr` is often `imv` in certain linux distros. Also makes all the checks use `which` instead of `command -v` which can also vary from system to system.