### PR TITLE
Fix wrong env. variable in "Edit in EDITOR" action

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -6414,7 +6414,7 @@ nochange:
 					copycurname();
 				goto nochange;
 			case SEL_EDIT:
-				spawn(editor, newpath, NULL, F_CLI);
+				spawn(enveditor, newpath, NULL, F_CLI);
 				continue;
 			default: /* SEL_LOCK */
 				lock_terminal();


### PR DESCRIPTION
nnn's help screen states that pressing `e` will edit the file under the cursor in "EDITOR".
I assume "EDITOR" refers to the environment variable `$EDITOR`, which is stored in the program's variable `enveditor`, not `editor`.

If this is not the desired behavior, I suggest to rename the respective statement on the help screen instead (since `editor` stores the environment variable `$VISUAL`):

> e  Edit in ~~EDITOR~~VISUAL