### PR TITLE
fix fzf bookmarks plugin environment variable

### DIFF
--- a/plugins/bookmarks
+++ b/plugins/bookmarks
@@ -25,7 +25,7 @@
 # Shell: POSIX compliant
 # Author: Todd Yamakawa
 
-if [[ -z "$BOOKMARKS_DIR" ]]; then
+if [ -z "$BOOKMARKS_DIR" ]; then
   BOOKMARKS_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/nnn/bookmarks"
 fi
 

--- a/plugins/bookmarks
+++ b/plugins/bookmarks
@@ -25,7 +25,9 @@
 # Shell: POSIX compliant
 # Author: Todd Yamakawa
 
-BOOKMARKS_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/nnn/bookmarks"
+if [[ -z "$BOOKMARKS_DIR" ]]; then
+  BOOKMARKS_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/nnn/bookmarks"
+fi
 
 # Check if NNN_PIPE is set
 if [ -z "$NNN_PIPE" ]; then


### PR DESCRIPTION
Setting a custom $BOOKMARKS_DIR env is overwritten by the plugin, so only the default directory can be used.
- Check if the variable is defined before setting the default.