### PR TITLE
fix bookmarks plugin on empty output

### DIFF
--- a/plugins/bookmarks
+++ b/plugins/bookmarks
@@ -44,7 +44,11 @@ get_links() {
         [ -d "$entry" ] || continue
 
         printf "%20s -> %s\n" "$(basename "$entry")" "$(readlink -f "$entry")"
-    done | fzf | awk 'END { print "'"$BOOKMARKS_DIR"'/"$1 }'
+    done | fzf |
+    awk 'END {
+        if(length($1) == 0){ print "'"$PWD"'" }
+        else { print "'"$BOOKMARKS_DIR"'/"$1 }
+        }'
 }
 
 # Choose symlink with fzf

--- a/plugins/bookmarks
+++ b/plugins/bookmarks
@@ -49,7 +49,6 @@ get_links() {
         if (length($1) == 0) { print "'"$PWD"'" }
         else { print "'"$BOOKMARKS_DIR"'/"$1 }
     }'
-
 }
 
 # Choose symlink with fzf

--- a/plugins/bookmarks
+++ b/plugins/bookmarks
@@ -46,9 +46,10 @@ get_links() {
         printf "%20s -> %s\n" "$(basename "$entry")" "$(readlink -f "$entry")"
     done | fzf |
     awk 'END {
-        if(length($1) == 0){ print "'"$PWD"'" }
+        if (length($1) == 0) { print "'"$PWD"'" }
         else { print "'"$BOOKMARKS_DIR"'/"$1 }
-        }'
+    }'
+
 }
 
 # Choose symlink with fzf


### PR DESCRIPTION
If no bookmark was selected from `fzf` with bookmarks plugin (i.e. pressing Esc key), nnn would change to `$BOOKMARKS_DIR`.
- With this PR the output would be to keep nnn in the current directory, and only change directory if a bookmark is selected.