### PR TITLE
deactivate INOTIFY for CYGWIN

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -35,8 +35,10 @@
 #if defined(__arm__) || defined(__i386__)
 #define _FILE_OFFSET_BITS 64 /* Support large files on 32-bit */
 #endif
+#if !defined(__CYGWIN__)
 #include <sys/inotify.h>
 #define LINUX_INOTIFY
+#endif
 #if !defined(__GLIBC__)
 #include <sys/types.h>
 #endif


### PR DESCRIPTION
inotify is a Linux kernel feature. It is not available within CYGWIN.