### PR TITLE
nuke plugin: use $VISUAL environment variable

### DIFF
--- a/plugins/nuke
+++ b/plugins/nuke
@@ -76,7 +76,7 @@ IMAGE_CACHE_PATH="$(dirname "$1")"/.thumbs
 
 FPATH="$1"
 FNAME=$(basename "$1")
-EDITOR="${EDITOR:-vi}"
+EDITOR="${VISUAL:-${EDITOR:-vi}}"
 PAGER="${PAGER:-less -R}"
 ext="${FNAME##*.}"
 if [ -n "$ext" ]; then


### PR DESCRIPTION
falls back to previous behavior if $VISUAL is not set ($EDITOR then vi)



I think it's convention that `$VISUAL` should be checked first. `$EDITOR` is meant for non-visual text editor (like `ed`) on older terminals.