### PR TITLE
use $VISUAL environment variable for plugins

### DIFF
--- a/plugins/.nmv
+++ b/plugins/.nmv
@@ -16,7 +16,7 @@
 # Shell: bash
 # Author: KlzXS
 
-EDITOR="${EDITOR:-vi}"
+EDITOR="${VISUAL:-${EDITOR:-vi}}"
 TMPDIR="${TMPDIR:-/tmp}"
 INCLUDE_HIDDEN="${INCLUDE_HIDDEN:-0}"
 VERBOSE="${VERBOSE:-0}"

--- a/plugins/bulknew
+++ b/plugins/bulknew
@@ -9,7 +9,7 @@
 # Shell: POSIX compliant
 # Author: KlzXS
 
-EDITOR="${EDITOR:-vi}"
+EDITOR="${VISUAL:-${EDITOR:-vi}}"
 TMPDIR="${TMPDIR:-/tmp}"
 
 printf "'f'ile / 'd'ir? "

--- a/plugins/dups
+++ b/plugins/dups
@@ -14,7 +14,7 @@
 # If the size of a file has more that $size_digits digits the file will be misplaced
 # 12 digits fit files up to 931GiB
 
-EDITOR="${EDITOR:-vi}"
+EDITOR="${VISUAL:-${EDITOR:-vi}}"
 TMPDIR="${TMPDIR:-/tmp}"
 
 size_digits=12

--- a/plugins/suedit
+++ b/plugins/suedit
@@ -5,7 +5,7 @@
 # Shell: POSIX compliant
 # Author: Anna Arad
 
-EDITOR="${EDITOR:-vim}"
+EDITOR="${VISUAL:-${EDITOR:-vi}}"
 
 is_cmd_exists () {
     which "$1" > /dev/null 2>&1


### PR DESCRIPTION
falls back to previous behavior if $VISUAL is not set ($EDITOR then vi)

Here are the rest of them.