### PR TITLE
Updated wall plugin to the standard utility file

### DIFF
--- a/plugins/wall
+++ b/plugins/wall
@@ -12,7 +12,7 @@ cmd_exists () {
 }
 
 if [ -n "$1" ]; then
-    if [ "$(mimetype --output-format %m "$1" | awk -F '/' '{print $1}')" = "image" ]; then
+	if [ "$(file --mime-type "$1" | awk '{print $2}' | awk -F '/' '{print $1}')" = "image" ]; then
         if [ "$(cmd_exists nitrogen)" -eq "0" ]; then
 	        nitrogen --set-zoom-fill --save "$1"
         elif [ "$(cmd_exists wal)" -eq "0" ]; then


### PR DESCRIPTION
Small edit to use the standard utility file to get the mimetype instead of the mimetype script, which probably is based on Perl, in order to reduce the dependencies.