### PR TITLE
adding support for ueberzug into plugins/preview-tui

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -172,7 +172,7 @@ preview_file () {
             elif exists viu; then
                 viu -t "$1"
             elif exists ueberzug; then
-                preview_ueberzug "$1"
+                preview_ueberzug "$cols" "$lines" "$1"
             else
                 fifo_pager print_bin_info "$1"
             fi
@@ -196,12 +196,10 @@ preview_file () {
 }
 
 preview_ueberzug() {
-    height=$(tput lines)
-    width=$(tput cols)
-    ueberzug layer --parser json 0< <(
-        printf '{"action": "add", "identifier": "nnn_ueberzug", "x": 0, "y": 0, "max_width": "%s", "max_height": "%s", "path": "%s"}\n' "$width" "$height" "$1"
-        read
-    )
+    {
+        printf '{"action": "add", "identifier": "nnn_ueberzug", "x": 0, "y": 0, "width": "%s", "height": "%s", "path": "%s"}\n' "$1" "$2" "$3"
+        read -r
+    } | ueberzug layer --parser json
 }
 
 if [ "$PREVIEW_MODE" ] ; then

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -17,7 +17,7 @@
 #    - tar
 #    - man
 #    - optional: bat for code syntax highlighting
-#    - optional: kitty terminal or catimg for images
+#    - optional: kitty terminal, catimg, viu, or ueberzug for images
 #    - optional: scope.sh file viewer from ranger.
 #                To use:
 #                1. drop scope.sh executable in $PATH
@@ -171,6 +171,8 @@ preview_file () {
                 catimg "$1"
             elif exists viu; then
                 viu -t "$1"
+            elif exists ueberzug; then
+                preview_ueberzug "$1"
             else
                 fifo_pager print_bin_info "$1"
             fi
@@ -191,6 +193,15 @@ preview_file () {
             $PAGER "$1" &
         fi
     fi
+}
+
+preview_ueberzug() {
+    height=$(tput lines)
+    width=$(tput cols)
+    ueberzug layer --parser json 0< <(
+        printf '{"action": "add", "identifier": "nnn_ueberzug", "x": 0, "y": 0, "max_width": "%s", "max_height": "%s", "path": "%s"}\n' "$width" "$height" "$1"
+        read
+    )
 }
 
 if [ "$PREVIEW_MODE" ] ; then


### PR DESCRIPTION
I was able to add support for ```ueberzug``` in the ```preview-tui``` plugin. However, I couldn't support it in the ```preview-tabbed``` plugin because for some reason ```ueberzug``` does not want to work inside a terminal embedded in a ```tabbed``` window.