### PR TITLE
Fix frozen terminal caused by opener

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -215,6 +215,7 @@
 #define F_NORMAL  0x08  /* spawn child process in non-curses regular CLI mode */
 #define F_CONFIRM 0x10  /* run command - show results before exit (must have F_NORMAL) */
 #define F_CHKRTN  0x20  /* wait for user prompt if cmd returns failure status */
+#define F_ALLNULL 0x44  /* stdin, stdout and stderr mapped to /dev/null */
 #define F_CLI     (F_NORMAL | F_MULTI)
 #define F_SILENT  (F_CLI | F_NOTRACE)
 
@@ -1910,6 +1911,8 @@ static int spawn(char *file, char *arg1, char *arg2, uchar_t flag)
 		if (flag & F_NOTRACE) {
 			int fd = open("/dev/null", O_WRONLY, 0200);
 
+			if (flag & F_ALLNULL)
+				dup2(fd, 0);
 			dup2(fd, 1);
 			dup2(fd, 2);
 			close(fd);

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -215,7 +215,7 @@
 #define F_NORMAL  0x08  /* spawn child process in non-curses regular CLI mode */
 #define F_CONFIRM 0x10  /* run command - show results before exit (must have F_NORMAL) */
 #define F_CHKRTN  0x20  /* wait for user prompt if cmd returns failure status */
-#define F_ALLNULL 0x44  /* stdin, stdout and stderr mapped to /dev/null */
+#define F_NOSTDIN 0x40  /* suppress stdin */
 #define F_CLI     (F_NORMAL | F_MULTI)
 #define F_SILENT  (F_CLI | F_NOTRACE)
 
@@ -1911,7 +1911,7 @@ static int spawn(char *file, char *arg1, char *arg2, uchar_t flag)
 		if (flag & F_NOTRACE) {
 			int fd = open("/dev/null", O_WRONLY, 0200);
 
-			if (flag & F_ALLNULL)
+			if (flag & F_NOSTDIN)
 				dup2(fd, 0);
 			dup2(fd, 1);
 			dup2(fd, 2);
@@ -5870,7 +5870,7 @@ static bool browse(char *ipath, const char *session, int pkey)
 	enum action sel;
 	struct stat sb;
 	int r = -1, presel, selstartid = 0, selendid = 0;
-	const uchar_t opener_flags = (cfg.cliopener ? F_CLI : (F_NOTRACE | F_NOWAIT));
+	const uchar_t opener_flags = (cfg.cliopener ? F_CLI : (F_NOTRACE | F_NOSTDIN | F_NOWAIT));
 	bool watch = FALSE;
 
 #ifndef NOMOUSE


### PR DESCRIPTION
`xdg-open` would launch a cli program that would contest the terminal for character input resulting in a unresponsive terminal that's hard to use. There are many references to this issue, but I'm bad at finding them.

If you send `xdg-opens`'s `std{in,out,err}` to the shadow realm it seems to prevent it from launching cli programs (probably because they don't want to work without any I/O, but I guess you can may be able to find some oddballs) so it defaults to some gui program (probably firefox) and that doesn't block the terminal.

This should be tested to make sure the other openers are okay with silencing their `std{in,out,err}`.