### PR TITLE
preview-tui improvements

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -34,6 +34,7 @@
 #                To use:
 #                1. install ImageMagick
 #                2. set/export USE_GIFPREVIEW as 1
+#                3. set/export LOOP_GIF as 1 if you want to loop gif preview
 #    - optional: ffmpeg for audio thumbnails
 #                To use:
 #                1. install ffmpeg
@@ -97,8 +98,9 @@ USE_AUDIOPREVIEW="${USE_AUDIOPREVIEW:-0}"
 USE_FONTPREVIEW="${USE_FONTPREVIEW:-0}"
 USE_EPUBPREVIEW="${USE_EPUBPREVIEW:-0}"
 USE_PDFPREVIEW="${USE_PDFPREVIEW:-0}"
-USE_GIFPREVIEW="${USE_GIFPREVIEW:-0}"
 USE_OFFICEPREVIEW="${USE_OFFICEPREVIEW:-0}"
+USE_GIFPREVIEW="${USE_GIFPREVIEW:-0}"
+LOOP_GIFS="${LOOP_GIFS:-0}"
 PAGER="${PAGER:-less -R}"
 
 if [ "$USE_UEBERZUG" -ne 0 ]; then
@@ -258,9 +260,12 @@ preview_ueberzug() {
                         mkdir -p "/tmp/$3"
                         convert -coalesce "$3" "/tmp/$3/${3##*/}.png"
                     fi
-                        for frame in $(find /tmp/"$3"/*.png | sort -V); do
-                            ueberzug_layer "$1" "$2" "$frame"
-                            sleep 0.1
+                        while true; do
+                            for frame in $(find /tmp/"$3"/*.png | sort -V); do
+                                ueberzug_layer "$1" "$2" "$frame"
+                                sleep 0.1
+                            done
+                            [ "$LOOP_GIFS" -eq 0 ] && return
                         done &
                         gifloop=$!
                         return

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -189,19 +189,19 @@ preview_file () {
         fi
     elif [ "$encoding" = "binary" ]; then
         if [ "$USE_UEBERZUG" -ne 0 ] && exists ueberzug; then
-            if [ "$ext" = "gif" ] && [ "$USE_GIFPREVIEW" -ne 0 ]; then
+            if [ "$ext" = "gif" ]; then
                 preview_ueberzug "$cols" "$lines" "$1" "gif"
             elif [ "${mimetype%%/*}" = "image" ]; then
                 ueberzug_layer "$cols" "$lines" "$1"
-            elif [ "${mimetype%%/*}" = "audio" ]; then
+            elif [ "$USE_AUDIOPREVIEW" -ne 0 ] && [ "${mimetype%%/*}" = "audio" ]; then
                 preview_ueberzug "$cols" "$lines" "$1" "audio"
-            elif [ "${mimetype%%/*}" = "video" ]; then
+            elif [ "$USE_VIDEOPREVIEW" -ne 0 ] && [ "${mimetype%%/*}" = "video" ]; then
                 preview_ueberzug "$cols" "$lines" "$1" "video"
-            elif [ "$ext" = "pdf" ]; then
+            elif [ "$USE_PDFPREVIEW" -ne 0 ] && [ "$ext" = "pdf" ]; then
                 preview_ueberzug "$cols" "$lines" "$1" "pdf"
-            elif [ "$ext" = "epub" ]; then
+            elif [ "$USE_EPUBPREVIEW" -ne 0 ] && [ "$ext" = "epub" ]; then
                 preview_ueberzug "$cols" "$lines" "$1" "epub"
-            elif [ "${mimetype%%/*}" = "font" ]; then
+            elif [ "$USE_FONTPREVIEW" -ne 0 ] && [ "${mimetype%%/*}" = "font" ]; then
                 preview_ueberzug "$cols" "$lines" "$1" "font"
             fi
         elif [ "${mimetype%%/*}" = "image" ] || [ "${mimetype%%/*}" = "video" ]; then

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -251,7 +251,7 @@ generate_preview() {
                         convert -coalesce "$3" "$TMPDIR/$3/${3##*/}.png"
                     fi
                         while true; do
-                            for frame in $(find $TMPDIR/"$3"/*.png | sort -V); do
+                            for frame in $(find "$TMPDIR/$3"/*.png | sort -V); do
                                 display_preview "$1" "$2" "$frame"
                                 sleep 0.1
                             done

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -264,6 +264,9 @@ preview_ueberzug() {
                         done &
                         gifloop=$!
                         return
+                 else
+                    ueberzug_layer "$1" "$2" "$3"
+                    return
                  fi ;;
             office) libreoffice --convert-to png "$3" --outdir "/tmp/${3%/*}" > /dev/null 2>&1
                     filename="$(echo "${3##*/}" | cut -d. -f1)"
@@ -283,11 +286,6 @@ ueberzug_remove() {
     printf '{"action": "remove", "identifier": "nnn_ueberzug"}\n' > "$FIFO_UEBERZUG"
 }
 
-ueberzug_resize() {
-    kill "$1"
-    tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
-}
-
 if [ "$PREVIEW_MODE" ] ; then
     if [ ! -r "$NNN_FIFO" ] ; then
         echo "No FIFO available! (\$NNN_FIFO='$NNN_FIFO')" >&2
@@ -298,9 +296,7 @@ if [ "$PREVIEW_MODE" ] ; then
     preview_file "$1"
     if [ "$USE_UEBERZUG" -ne 0 ]; then
         tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
-        fifopid=$!
     fi
-    trap 'ueberzug_resize $fifopid' WINCH
 
     # use cat instead of 'exec <' to avoid issues with dash shell
     # shellcheck disable=SC2002

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -299,6 +299,7 @@ ueberzug_remove() {
 }
 
 ueberzug_refresh() {
+    clear
     pkill -P "$$"
     pkill -f -n preview-tui
     echo > "$NNN_FIFO"

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -275,7 +275,7 @@ display_preview() {
         ueberzug_layer "$1" "$2" "$3"
     elif [ "$TERMINAL" = "kitty" ]; then
         # Kitty terminal users can use the native image preview method.
-        kitty +kitten icat --silent --transfer-mode=stream --stdin=no \
+        kitty +kitten icat --silent --place "$1"x"$2"@0x0 --transfer-mode=stream --stdin=no \
             "$3"
     elif exists catimg; then
         catimg "$3" &

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -243,7 +243,7 @@ preview_ueberzug() {
                         mkdir -p "/tmp/$3"
                         convert -coalesce "$3" "/tmp/$3/${3##*/}.png"
                     fi
-                        for frame in $(ls -1 /tmp/$3/*.png | sort -V); do
+                        for frame in $(find /tmp/$3/*.png | sort -V); do
                             ueberzug_layer "$1" "$2" "$frame"
                             sleep 0.1
                         done &
@@ -282,7 +282,7 @@ if [ "$PREVIEW_MODE" ] ; then
         tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
         fifopid=$!
     fi
-    trap 'ueberzug_resize $fifopid' SIGWINCH
+    trap 'ueberzug_resize $fifopid' 28
 
     # use cat instead of 'exec <' to avoid issues with dash shell
     # shellcheck disable=SC2002

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -16,6 +16,7 @@
 #    - unzip
 #    - tar
 #    - man
+#    - atool: for additional archive preview
 #    - optional: bat for code syntax highlighting
 #    - optional: kitty terminal, catimg, viu, or ueberzug for images
 #    - optional: scope.sh file viewer from ranger.
@@ -103,6 +104,7 @@ USE_OFFICEPREVIEW="${USE_OFFICEPREVIEW:-0}"
 USE_GIFPREVIEW="${USE_GIFPREVIEW:-0}"
 LOOP_GIFS="${LOOP_GIFS:-0}"
 PAGER="${PAGER:-less -R}"
+ARCHIVES="$(echo "$NNN_ARCHIVE" | sed 's/.*(\(.*\)).*/\1/;s/|/ /g')"
 
 if [ "$USE_UEBERZUG" -ne 0 ]; then
   FIFO_UEBERZUG="/tmp/nnn-$PPID-ueberzug-fifo"
@@ -210,12 +212,10 @@ preview_file () {
             generate_preview "$cols" "$lines" "$1" "epub"
         elif [ "$USE_FONTPREVIEW" -ne 0 ] && [ "${mimetype%%/*}" = "font" ]; then
             generate_preview "$cols" "$lines" "$1" "font"
-        elif [ "$USE_OFFICEPREVIEW" -ne 0 ]; then
-            test1="document"
-            test2="office"
-            if [ "${mimetype#*$test1}" != "$mimetype" ] || [ "${mimetype#*$test2}" != "$mimetype" ]; then
-                generate_preview "$cols" "$lines" "$1" "office"
-            fi
+        elif [ "${mimetype#*office}" != "$mimetype" ] || [ "${mimetype#*document}" != "$mimetype" ] && [ "$USE_OFFICEPREVIEW" -ne 0 ]; then
+            generate_preview "$cols" "$lines" "$1" "office"
+        elif [ "${ARCHIVES#*$ext}" != "$ARCHIVES" ] && exists atool; then
+            fifo_pager atool -l "$1"
         elif [ "$mimetype" = "application/zip" ] ; then
             fifo_pager unzip -l "$1"
         elif [ "$ext" = "gz" ] || [ "$ext" = "bz2" ] ; then

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -93,6 +93,7 @@ TERMINAL="$TERMINAL"  # same goes for the terminal
 USE_SCOPE="${USE_SCOPE:-0}"
 USE_PISTOL="${USE_PISTOL:-0}"
 USE_UEBERZUG="${USE_UEBERZUG:-0}"
+USE_IMAGEPREVIEW="${USE_IMAGEPREVIEW:-0}"
 USE_VIDEOPREVIEW="${USE_VIDEOPREVIEW:-0}"
 USE_AUDIOPREVIEW="${USE_AUDIOPREVIEW:-0}"
 USE_FONTPREVIEW="${USE_FONTPREVIEW:-0}"
@@ -195,39 +196,25 @@ preview_file () {
             fifo_pager ls --color=always
         fi
     elif [ "$encoding" = "binary" ]; then
-        if [ "$USE_UEBERZUG" -ne 0 ] && exists ueberzug; then
-            if [ "$ext" = "gif" ]; then
-                preview_ueberzug "$cols" "$lines" "$1" "gif"
-            elif [ "${mimetype%%/*}" = "image" ]; then
-                ueberzug_layer "$cols" "$lines" "$1"
-            elif [ "$USE_AUDIOPREVIEW" -ne 0 ] && [ "${mimetype%%/*}" = "audio" ]; then
-                preview_ueberzug "$cols" "$lines" "$1" "audio"
-            elif [ "$USE_VIDEOPREVIEW" -ne 0 ] && [ "${mimetype%%/*}" = "video" ]; then
-                preview_ueberzug "$cols" "$lines" "$1" "video"
-            elif [ "$USE_PDFPREVIEW" -ne 0 ] && [ "$ext" = "pdf" ]; then
-                preview_ueberzug "$cols" "$lines" "$1" "pdf"
-            elif [ "$USE_EPUBPREVIEW" -ne 0 ] && [ "$ext" = "epub" ]; then
-                preview_ueberzug "$cols" "$lines" "$1" "epub"
-            elif [ "$USE_FONTPREVIEW" -ne 0 ] && [ "${mimetype%%/*}" = "font" ]; then
-                preview_ueberzug "$cols" "$lines" "$1" "font"
-            elif [ "$USE_OFFICEPREVIEW" -ne 0 ]; then
-                test1="document"
-                test2="office"
-                if [ "${mimetype#*$test1}" != "$mimetype" ] || [ "${mimetype#*$test2}" != "$mimetype" ]; then
-                    preview_ueberzug "$cols" "$lines" "$1" "office"
-                fi
-            fi
-        elif [ "${mimetype%%/*}" = "image" ] || [ "${mimetype%%/*}" = "video" ]; then
-            if [ "$TERMINAL" = "kitty" ]; then
-                # Kitty terminal users can use the native image preview method.
-                kitty +kitten icat --silent --transfer-mode=stream --stdin=no \
-                    "$1" &
-            elif exists catimg; then
-                catimg "$1"
-            elif exists viu; then
-                viu -t "$1"
-            else
-                fifo_pager print_bin_info "$1"
+        if [ "$USE_GIFPREVIEW" -ne 0 ] && [ "$ext" = "gif" ]; then
+            generate_preview "$cols" "$lines" "$1" "gif"
+        elif [ "$USE_IMAGEPREVIEW" -ne 0 ] && [ "${mimetype%%/*}" = "image" ]; then
+            display_preview "$cols" "$lines" "$1"
+        elif [ "$USE_AUDIOPREVIEW" -ne 0 ] && [ "${mimetype%%/*}" = "audio" ]; then
+            generate_preview "$cols" "$lines" "$1" "audio"
+        elif [ "$USE_VIDEOPREVIEW" -ne 0 ] && [ "${mimetype%%/*}" = "video" ]; then
+            generate_preview "$cols" "$lines" "$1" "video"
+        elif [ "$USE_PDFPREVIEW" -ne 0 ] && [ "$ext" = "pdf" ]; then
+            generate_preview "$cols" "$lines" "$1" "pdf"
+        elif [ "$USE_EPUBPREVIEW" -ne 0 ] && [ "$ext" = "epub" ]; then
+            generate_preview "$cols" "$lines" "$1" "epub"
+        elif [ "$USE_FONTPREVIEW" -ne 0 ] && [ "${mimetype%%/*}" = "font" ]; then
+            generate_preview "$cols" "$lines" "$1" "font"
+        elif [ "$USE_OFFICEPREVIEW" -ne 0 ]; then
+            test1="document"
+            test2="office"
+            if [ "${mimetype#*$test1}" != "$mimetype" ] || [ "${mimetype#*$test2}" != "$mimetype" ]; then
+                generate_preview "$cols" "$lines" "$1" "office"
             fi
         elif [ "$mimetype" = "application/zip" ] ; then
             fifo_pager unzip -l "$1"
@@ -248,29 +235,29 @@ preview_file () {
     fi
 }
 
-preview_ueberzug() {
+generate_preview() {
     if [ ! -f "/tmp/$3.png" ]; then
         mkdir -p "/tmp/${3%/*}"
         case $4 in
             audio) ffmpeg -i "$3" "/tmp/$3.png" -y >/dev/null 2>&1 ;;
             epub) gnome-epub-thumbnailer "$3" "/tmp/$3.png" >/dev/null 2>&1 ;;
             font) fontpreview -i "$3" -o "/tmp/$3.png" >/dev/null 2>&1 ;;
-            gif) if [ "$USE_GIFPREVIEW" -ne 0 ]; then
+            gif) if [ "$USE_UEBERZUG" -ne 0 ] || [ "$TERMINAL" = "kitty" ] && [ "$USE_GIFPREVIEW" -ne 0 ]; then
                     if [ ! -d "/tmp/$3" ]; then
                         mkdir -p "/tmp/$3"
                         convert -coalesce "$3" "/tmp/$3/${3##*/}.png"
                     fi
                         while true; do
                             for frame in $(find /tmp/"$3"/*.png | sort -V); do
-                                ueberzug_layer "$1" "$2" "$frame"
+                                display_preview "$1" "$2" "$frame"
                                 sleep 0.1
                             done
                             [ "$LOOP_GIFS" -eq 0 ] && return
                         done &
-                        gifloop=$!
+                        gifpid="$!"
                         return
                  else
-                    ueberzug_layer "$1" "$2" "$3"
+                    display_preview "$1" "$2" "$3"
                     return
                  fi ;;
             office) libreoffice --convert-to png "$3" --outdir "/tmp/${3%/*}" > /dev/null 2>&1
@@ -280,7 +267,23 @@ preview_ueberzug() {
             video) ffmpegthumbnailer -i "$3" -o "/tmp/$3.png" -s 0 -q 10 >/dev/null 2>&1 ;;
         esac
     fi
-    ueberzug_layer "$1" "$2" "/tmp/$3.png"
+    display_preview "$1" "$2" "/tmp/$3.png"
+}
+
+display_preview() {
+    if [ "$USE_UEBERZUG" -ne 0 ] && exists ueberzug; then
+        ueberzug_layer "$1" "$2" "$3"
+    elif [ "$TERMINAL" = "kitty" ]; then
+        # Kitty terminal users can use the native image preview method.
+        kitty +kitten icat --silent --transfer-mode=stream --stdin=no \
+            "$3"
+    elif exists catimg; then
+        catimg "$3" &
+        gifpid="$!"
+    elif exists viu; then
+        viu -t "$3" &
+        gifpid="$!"
+    fi
 }
 
 ueberzug_layer() {
@@ -307,9 +310,9 @@ if [ "$PREVIEW_MODE" ] ; then
     # shellcheck disable=SC2002
     cat "$NNN_FIFO" |\
     while read -r selection ; do
-        if [ "$USE_UEBERZUG" -ne 0 ]; then
-            kill $gifloop
-            ueberzug_remove
+        if [ "$gifpid" -ne 0 ]; then
+            kill "$gifpid"
+            [ "$USE_UEBERZUG" -ne 0 ] && ueberzug_remove
         fi
         preview_file "$selection"
     done

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -140,6 +140,7 @@ fifo_pager() {
     mkfifo "$tmpfifopath" || return
 
     $PAGER < "$tmpfifopath" &
+    pagerpid="$!"
 
     (
         exec > "$tmpfifopath"
@@ -237,6 +238,7 @@ preview_file () {
 
 generate_preview() {
     if [ ! -f "/tmp/$3.png" ]; then
+        fifo_pager print_bin_info "$3"
         mkdir -p "/tmp/${3%/*}"
         case $4 in
             audio) ffmpeg -i "$3" "/tmp/$3.png" -y >/dev/null 2>&1 ;;
@@ -266,6 +268,7 @@ generate_preview() {
             pdf) pdftoppm -png -f 1 -singlefile "$3" "/tmp/$3" >/dev/null 2>&1 ;;
             video) ffmpegthumbnailer -i "$3" -o "/tmp/$3.png" -s 0 -q 10 >/dev/null 2>&1 ;;
         esac
+    kill "$pagerpid"
     fi
     display_preview "$1" "$2" "/tmp/$3.png"
 }
@@ -294,6 +297,26 @@ ueberzug_remove() {
     printf '{"action": "remove", "identifier": "nnn_ueberzug"}\n' > "$FIFO_UEBERZUG"
 }
 
+ueberzug_refresh() {
+    pkill -P "$$"
+    pkill -f -n preview-tui
+    tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
+    nnn_fifo &
+    wait
+}
+trap 'ueberzug_refresh' WINCH
+
+nnn_fifo() {
+    # use cat instead of 'exec <' to avoid issues with dash shell
+    # shellcheck disable=SC2002
+    cat "$NNN_FIFO" |\
+    while read -r selection ; do
+        [ "$gifpid" -ne 0 ] && kill "$gifpid"
+        [ "$USE_UEBERZUG" -ne 0 ] && ueberzug_remove
+        preview_file "$selection"
+    done
+}
+
 if [ "$PREVIEW_MODE" ] ; then
     if [ ! -r "$NNN_FIFO" ] ; then
         echo "No FIFO available! (\$NNN_FIFO='$NNN_FIFO')" >&2
@@ -306,14 +329,8 @@ if [ "$PREVIEW_MODE" ] ; then
         tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
     fi
 
-    # use cat instead of 'exec <' to avoid issues with dash shell
-    # shellcheck disable=SC2002
-    cat "$NNN_FIFO" |\
-    while read -r selection ; do
-        [ "$gifpid" -ne 0 ] && kill "$gifpid"
-        [ "$USE_UEBERZUG" -ne 0 ] && ueberzug_remove
-        preview_file "$selection"
-    done
+    nnn_fifo &
+    wait
 
     # Restoring the previous layout for kitty users. This will only work for
     # kitty >= 0.18.0.

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -265,6 +265,11 @@ ueberzug_remove() {
     printf '{"action": "remove", "identifier": "nnn_ueberzug"}\n' > "$FIFO_UEBERZUG"
 }
 
+ueberzug_resize() {
+    kill "$1"
+    tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
+}
+
 if [ "$PREVIEW_MODE" ] ; then
     if [ ! -r "$NNN_FIFO" ] ; then
         echo "No FIFO available! (\$NNN_FIFO='$NNN_FIFO')" >&2
@@ -275,7 +280,9 @@ if [ "$PREVIEW_MODE" ] ; then
     preview_file "$1"
     if [ "$USE_UEBERZUG" -ne 0 ]; then
         tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
+        fifopid=$!
     fi
+    trap 'ueberzug_resize $fifopid' SIGWINCH
 
     # use cat instead of 'exec <' to avoid issues with dash shell
     # shellcheck disable=SC2002

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -29,7 +29,27 @@
 #    - optional: ffmpegthumbnailer for video thumbnails (https://github.com/dirkvdb/ffmpegthumbnailer).
 #                To use:
 #                1. install ffmpegthumbnailer
-#                2. set/export USE_VIDEOTHUMB as 1
+#                2. set/export USE_VIDEOPREVIEW as 1
+#    - optional: convert(ImageMagick) for playing gif preview
+#                To use:
+#                1. install ImageMagick
+#                2. set/export USE_GIFPREVIEW as 1
+#    - optional: ffmpeg for audio thumbnails
+#                To use:
+#                1. install ffmpeg
+#                2. set/export USE_AUDIOPREVIEW as 1
+#    - optional: pdftoppm(poppler) for pdf thumbnails
+#                To use:
+#                1. install poppler
+#                2. set/export USE_PDFPREVIEW as 1
+#    - optional: gnome-epub-thumbnailer for epub thumbnails (https://gitlab.gnome.org/GNOME/gnome-epub-thumbnailer)
+#                To use:
+#                1. install gnome-epub-thumbnailer
+#                2. set/export USE_EPUBPREVIEW as 1
+#    - optional: fontpreview for font preview (https://github.com/sdushantha/fontpreview)
+#                To use:
+#                1. install fontpreview
+#                2. set/export USE_FONTPREVIEW as 1
 #
 # Usage:
 #   You need to set a NNN_FIFO path and a key for the plugin with NNN_PLUG,
@@ -67,8 +87,20 @@ SPLIT="$SPLIT"  # you can set a permanent split here
 TERMINAL="$TERMINAL"  # same goes for the terminal
 USE_SCOPE="${USE_SCOPE:-0}"
 USE_PISTOL="${USE_PISTOL:-0}"
-USE_VIDEOTHUMB="${USE_VIDEOTHUMB:-0}"
+USE_UEBERZUG="${USE_UEBERZUG:-0}"
+USE_VIDEOPREVIEW="${USE_VIDEOPREVIEW:-0}"
+USE_AUDIOPREVIEW="${USE_AUDIOPREVIEW:-0}"
+USE_FONTPREVIEW="${USE_FONTPREVIEW:-0}"
+USE_EPUBPREVIEW="${USE_EPUBPREVIEW:-0}"
+USE_PDFPREVIEW="${USE_PDFPREVIEW:-0}"
+USE_GIFPREVIEW="${USE_GIFPREVIEW:-0}"
 PAGER="${PAGER:-less -R}"
+
+if [ "$USE_UEBERZUG" -ne 0 ]; then
+  FIFO_UEBERZUG="/tmp/nnn-$PPID-ueberzug-fifo"
+  mkfifo "$FIFO_UEBERZUG"
+fi
+
 [ "$PAGER" = "most" ] && PAGER="less -R"
 
 if [ -e "${TMUX%%,*}" ] && tmux -V | grep -q '[ -][3456789]\.'; then
@@ -156,13 +188,19 @@ preview_file () {
             fifo_pager ls --color=always
         fi
     elif [ "$encoding" = "binary" ]; then
-        if [ "${mimetype%%/*}" = "image" ] || [ "${mimetype%%/*}" = "video" ]; then
-            if [ "${mimetype%%/*}" = "video" ] && [ "$USE_VIDEOTHUMB" -ne 0 ] && exists ffmpegthumbnailer; then
-                videothumb="/tmp/videothumb.$$.png"
-                ffmpegthumbnailer -s 512 -i "$1" -o "$videothumb" >/dev/null 2>&1
-                set "$videothumb"
-                trap 'rm "$videothumb"' EXIT
+        if [ "$USE_UEBERZUG" -ne 0 ] && exists ueberzug; then
+            if [ "$ext" = "gif" ] && [ "$USE_GIFPREVIEW" -ne 0 ]; then
+                preview_ueberzug "$cols" "$lines" "$1" "gif"
+            elif [ "${mimetype%%/*}" = "image" ]; then
+                ueberzug_layer "$cols" "$lines" "$1"
+            elif [ "${mimetype%%/*}" = "audio" ]; then
+                preview_ueberzug "$cols" "$lines" "$1" "audio"
+            elif [ "${mimetype%%/*}" = "video" ]; then
+                preview_ueberzug "$cols" "$lines" "$1" "video"
+            elif [ "${mimetype%%/*}" = "font" ]; then
+                preview_ueberzug "$cols" "$lines" "$1" "font"
             fi
+        elif [ "${mimetype%%/*}" = "image" ] || [ "${mimetype%%/*}" = "video" ]; then
             if [ "$TERMINAL" = "kitty" ]; then
                 # Kitty terminal users can use the native image preview method.
                 kitty +kitten icat --silent --transfer-mode=stream --stdin=no \
@@ -171,8 +209,6 @@ preview_file () {
                 catimg "$1"
             elif exists viu; then
                 viu -t "$1"
-            elif exists ueberzug; then
-                preview_ueberzug "$cols" "$lines" "$1"
             else
                 fifo_pager print_bin_info "$1"
             fi
@@ -196,10 +232,37 @@ preview_file () {
 }
 
 preview_ueberzug() {
-    {
-        printf '{"action": "add", "identifier": "nnn_ueberzug", "x": 0, "y": 0, "width": "%s", "height": "%s", "path": "%s"}\n' "$1" "$2" "$3"
-        read -r
-    } | ueberzug layer --parser json
+    if [ ! -f "/tmp/$3.png" ]; then
+        mkdir -p "/tmp/${3%/*}"
+        case $4 in
+            audio) ffmpeg -i "$3" "/tmp/$3.png" -y >/dev/null 2>&1 ;;
+            epub) gnome-epub-thumbnailer "$3" "/tmp/$3.png" >/dev/null 2>&1 ;;
+            font) fontpreview -i "$3" -o "/tmp/$3.png" >/dev/null 2>&1 ;;
+            gif) if [ "$USE_GIFPREVIEW" -ne 0 ]; then
+                    if [ ! -d "/tmp/$3" ]; then
+                        mkdir -p "/tmp/$3"
+                        convert -coalesce "$3" "/tmp/$3/${3##*/}.png"
+                    fi
+                        for frame in $(ls -1 /tmp/$3/*.png | sort -V); do
+                            ueberzug_layer "$1" "$2" "$frame"
+                            sleep 0.1
+                        done &
+                        gifloop=$!
+                        return
+                 fi ;;
+            pdf) pdftoppm -png -f 1 -singlefile "$3" "/tmp/$3" >/dev/null 2>&1 ;;
+            video) ffmpegthumbnailer -i "$3" -o "/tmp/$3.png" -s 0 -q 10 >/dev/null 2>&1 ;;
+        esac
+    fi
+    ueberzug_layer "$1" "$2" "/tmp/$3.png"
+}
+
+ueberzug_layer() {
+    printf '{"action": "add", "identifier": "nnn_ueberzug", "x": 0, "y": 0, "width": "%s", "height": "%s", "path": "%s"}\n' "$1" "$2" "$3" > "$FIFO_UEBERZUG"
+}
+
+ueberzug_remove() {
+    printf '{"action": "remove", "identifier": "nnn_ueberzug"}\n' > "$FIFO_UEBERZUG"
 }
 
 if [ "$PREVIEW_MODE" ] ; then
@@ -210,11 +273,18 @@ if [ "$PREVIEW_MODE" ] ; then
     fi
 
     preview_file "$1"
+    if [ "$USE_UEBERZUG" -ne 0 ]; then
+        tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
+    fi
 
     # use cat instead of 'exec <' to avoid issues with dash shell
     # shellcheck disable=SC2002
     cat "$NNN_FIFO" |\
     while read -r selection ; do
+        if [ "$USE_UEBERZUG" -ne 0 ]; then
+            kill $gifloop
+            ueberzug_remove
+        fi
         preview_file "$selection"
     done
 
@@ -224,8 +294,11 @@ if [ "$PREVIEW_MODE" ] ; then
         kitty @ last-used-layout --no-response >/dev/null 2>&1
     fi
 
+    [ "$USE_UEBERZUG" -ne 0 ] && rm "$FIFO_UEBERZUG"
     exit 0
 fi
+
+[ "$USE_UEBERZUG" -ne 0 ] && rm "$FIFO_UEBERZUG"
 
 if [ "$TERMINAL" = "tmux" ]; then
     # tmux splits are inverted

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -103,7 +103,7 @@ USE_PDFPREVIEW="${USE_PDFPREVIEW:-0}"
 USE_OFFICEPREVIEW="${USE_OFFICEPREVIEW:-0}"
 USE_GIFPREVIEW="${USE_GIFPREVIEW:-0}"
 LOOP_GIFS="${LOOP_GIFS:-0}"
-PAGER="${PAGER:-less -R}"
+PAGER="${PAGER:-less -P?n -R}"
 ARCHIVES="$(echo "$NNN_ARCHIVE" | sed 's/.*(\(.*\)).*/\1/;s/|/ /g')"
 
 if [ "$USE_UEBERZUG" -ne 0 ]; then
@@ -191,7 +191,7 @@ preview_file () {
     if [ -d "$1" ]; then
         cd "$1" || return
         if exists tree; then
-            fifo_pager tree -L 3 -F
+            fifo_pager tree -L 1 --dirsfirst -F -C
         elif exists exa; then
             fifo_pager exa -G --colour=always 2>/dev/null
         else

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -50,6 +50,10 @@
 #                To use:
 #                1. install fontpreview
 #                2. set/export USE_FONTPREVIEW as 1
+#    - optional: libreoffce for opendocument/officedocument preview
+#                To use:
+#                1. install libreoffice
+#                2. set/export USE_OFFICEPREVIEW as 1
 #
 # Usage:
 #   You need to set a NNN_FIFO path and a key for the plugin with NNN_PLUG,
@@ -94,6 +98,7 @@ USE_FONTPREVIEW="${USE_FONTPREVIEW:-0}"
 USE_EPUBPREVIEW="${USE_EPUBPREVIEW:-0}"
 USE_PDFPREVIEW="${USE_PDFPREVIEW:-0}"
 USE_GIFPREVIEW="${USE_GIFPREVIEW:-0}"
+USE_OFFICEPREVIEW="${USE_OFFICEPREVIEW:-0}"
 PAGER="${PAGER:-less -R}"
 
 if [ "$USE_UEBERZUG" -ne 0 ]; then
@@ -203,6 +208,12 @@ preview_file () {
                 preview_ueberzug "$cols" "$lines" "$1" "epub"
             elif [ "$USE_FONTPREVIEW" -ne 0 ] && [ "${mimetype%%/*}" = "font" ]; then
                 preview_ueberzug "$cols" "$lines" "$1" "font"
+            elif [ "$USE_OFFICEPREVIEW" -ne 0 ]; then
+                test1="document"
+                test2="office"
+                if [ "${mimetype#*$test1}" != "$mimetype" ] || [ "${mimetype#*$test2}" != "$mimetype" ]; then
+                    preview_ueberzug "$cols" "$lines" "$1" "office"
+                fi
             fi
         elif [ "${mimetype%%/*}" = "image" ] || [ "${mimetype%%/*}" = "video" ]; then
             if [ "$TERMINAL" = "kitty" ]; then
@@ -254,6 +265,9 @@ preview_ueberzug() {
                         gifloop=$!
                         return
                  fi ;;
+            office) libreoffice --convert-to png "$3" --outdir "/tmp/${3%/*}" > /dev/null 2>&1
+                    filename="$(echo "${3##*/}" | cut -d. -f1)"
+                    mv "/tmp/${3%/*}/$filename.png" "/tmp/$3.png" ;;
             pdf) pdftoppm -png -f 1 -singlefile "$3" "/tmp/$3" >/dev/null 2>&1 ;;
             video) ffmpegthumbnailer -i "$3" -o "/tmp/$3.png" -s 0 -q 10 >/dev/null 2>&1 ;;
         esac

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -243,7 +243,7 @@ preview_ueberzug() {
                         mkdir -p "/tmp/$3"
                         convert -coalesce "$3" "/tmp/$3/${3##*/}.png"
                     fi
-                        for frame in $(find /tmp/$3/*.png | sort -V); do
+                        for frame in $(find /tmp/"$3"/*.png | sort -V); do
                             ueberzug_layer "$1" "$2" "$frame"
                             sleep 0.1
                         done &
@@ -282,7 +282,7 @@ if [ "$PREVIEW_MODE" ] ; then
         tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
         fifopid=$!
     fi
-    trap 'ueberzug_resize $fifopid' 28
+    trap 'ueberzug_resize $fifopid' WINCH
 
     # use cat instead of 'exec <' to avoid issues with dash shell
     # shellcheck disable=SC2002

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -301,6 +301,7 @@ ueberzug_remove() {
 ueberzug_refresh() {
     pkill -P "$$"
     pkill -f -n preview-tui
+    echo > "$NNN_FIFO"
     tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
     preview_fifo &
     wait

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -105,9 +105,10 @@ USE_GIFPREVIEW="${USE_GIFPREVIEW:-0}"
 LOOP_GIFS="${LOOP_GIFS:-0}"
 PAGER="${PAGER:-less -P?n -R}"
 ARCHIVES="$(echo "$NNN_ARCHIVE" | sed 's/.*(\(.*\)).*/\1/;s/|/ /g')"
+TMPDIR="${TMPDIR:-/tmp}"
 
 if [ "$USE_UEBERZUG" -ne 0 ]; then
-  FIFO_UEBERZUG="/tmp/nnn-$PPID-ueberzug-fifo"
+  FIFO_UEBERZUG="$TMPDIR/nnn-ueberzug-fifo.$$"
   mkfifo "$FIFO_UEBERZUG"
 fi
 
@@ -136,7 +137,7 @@ fifo_pager() {
     shift
 
     # We use a FIFO to access $PAGER PID in jobs control
-    tmpfifopath="${TMPDIR:-/tmp}/nnn-preview-tui-fifo.$$"
+    tmpfifopath="$TMPDIR/nnn-preview-tui-fifo.$$"
     mkfifo "$tmpfifopath" || return
 
     $PAGER < "$tmpfifopath" &
@@ -237,20 +238,20 @@ preview_file () {
 }
 
 generate_preview() {
-    if [ ! -f "/tmp/$3.png" ]; then
+    if [ ! -f "$TMPDIR/$3.png" ]; then
         fifo_pager print_bin_info "$3"
-        mkdir -p "/tmp/${3%/*}"
+        mkdir -p "$TMPDIR/${3%/*}"
         case $4 in
-            audio) ffmpeg -i "$3" "/tmp/$3.png" -y >/dev/null 2>&1 ;;
-            epub) gnome-epub-thumbnailer "$3" "/tmp/$3.png" >/dev/null 2>&1 ;;
-            font) fontpreview -i "$3" -o "/tmp/$3.png" >/dev/null 2>&1 ;;
+            audio) ffmpeg -i "$3" "$TMPDIR/$3.png" -y >/dev/null 2>&1 ;;
+            epub) gnome-epub-thumbnailer "$3" "$TMPDIR/$3.png" >/dev/null 2>&1 ;;
+            font) fontpreview -i "$3" -o "$TMPDIR/$3.png" >/dev/null 2>&1 ;;
             gif) if [ "$USE_UEBERZUG" -ne 0 ] || [ "$TERMINAL" = "kitty" ] && [ "$USE_GIFPREVIEW" -ne 0 ]; then
-                    if [ ! -d "/tmp/$3" ]; then
-                        mkdir -p "/tmp/$3"
-                        convert -coalesce "$3" "/tmp/$3/${3##*/}.png"
+                    if [ ! -d "$TMPDIR/$3" ]; then
+                        mkdir -p "$TMPDIR/$3"
+                        convert -coalesce "$3" "$TMPDIR/$3/${3##*/}.png"
                     fi
                         while true; do
-                            for frame in $(find /tmp/"$3"/*.png | sort -V); do
+                            for frame in $(find $TMPDIR/"$3"/*.png | sort -V); do
                                 display_preview "$1" "$2" "$frame"
                                 sleep 0.1
                             done
@@ -262,15 +263,15 @@ generate_preview() {
                     display_preview "$1" "$2" "$3"
                     return
                  fi ;;
-            office) libreoffice --convert-to png "$3" --outdir "/tmp/${3%/*}" > /dev/null 2>&1
+            office) libreoffice --convert-to png "$3" --outdir "$TMPDIR/${3%/*}" > /dev/null 2>&1
                     filename="$(echo "${3##*/}" | cut -d. -f1)"
-                    mv "/tmp/${3%/*}/$filename.png" "/tmp/$3.png" ;;
-            pdf) pdftoppm -png -f 1 -singlefile "$3" "/tmp/$3" >/dev/null 2>&1 ;;
-            video) ffmpegthumbnailer -i "$3" -o "/tmp/$3.png" -s 0 -q 10 >/dev/null 2>&1 ;;
+                    mv "$TMPDIR/${3%/*}/$filename.png" "$TMPDIR/$3.png" ;;
+            pdf) pdftoppm -png -f 1 -singlefile "$3" "$TMPDIR/$3" >/dev/null 2>&1 ;;
+            video) ffmpegthumbnailer -i "$3" -o "$TMPDIR/$3.png" -s 0 -q 10 >/dev/null 2>&1 ;;
         esac
     kill "$pagerpid"
     fi
-    display_preview "$1" "$2" "/tmp/$3.png"
+    display_preview "$1" "$2" "$TMPDIR/$3.png"
 }
 
 display_preview() {
@@ -317,6 +318,7 @@ preview_fifo() {
     done
 }
 
+
 if [ "$PREVIEW_MODE" ] ; then
     if [ ! -r "$NNN_FIFO" ] ; then
         echo "No FIFO available! (\$NNN_FIFO='$NNN_FIFO')" >&2
@@ -341,8 +343,6 @@ if [ "$PREVIEW_MODE" ] ; then
     [ "$USE_UEBERZUG" -ne 0 ] && rm "$FIFO_UEBERZUG"
     exit 0
 fi
-
-[ "$USE_UEBERZUG" -ne 0 ] && rm "$FIFO_UEBERZUG"
 
 if [ "$TERMINAL" = "tmux" ]; then
     # tmux splits are inverted

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -107,11 +107,6 @@ PAGER="${PAGER:-less -P?n -R}"
 ARCHIVES="$(echo "$NNN_ARCHIVE" | sed 's/.*(\(.*\)).*/\1/;s/|/ /g')"
 TMPDIR="${TMPDIR:-/tmp}"
 
-if [ "$USE_UEBERZUG" -ne 0 ]; then
-  FIFO_UEBERZUG="$TMPDIR/nnn-ueberzug-fifo.$$"
-  mkfifo "$FIFO_UEBERZUG"
-fi
-
 [ "$PAGER" = "most" ] && PAGER="less -R"
 
 if [ -e "${TMUX%%,*}" ] && tmux -V | grep -q '[ -][3456789]\.'; then
@@ -318,6 +313,7 @@ preview_fifo() {
         [ "$USE_UEBERZUG" -ne 0 ] && ueberzug_remove
         preview_file "$selection"
     done
+    [ "$USE_UEBERZUG" -ne 0 ] && rm "$FIFO_UEBERZUG"
 }
 
 
@@ -326,6 +322,11 @@ if [ "$PREVIEW_MODE" ] ; then
         echo "No FIFO available! (\$NNN_FIFO='$NNN_FIFO')" >&2
         read -r
         exit 1
+    fi
+
+    if [ "$USE_UEBERZUG" -ne 0 ]; then
+        FIFO_UEBERZUG="$TMPDIR/nnn-ueberzug-fifo.$$"
+        mkfifo "$FIFO_UEBERZUG"
     fi
 
     preview_file "$1"
@@ -342,7 +343,6 @@ if [ "$PREVIEW_MODE" ] ; then
         kitty @ last-used-layout --no-response >/dev/null 2>&1
     fi
 
-    [ "$USE_UEBERZUG" -ne 0 ] && rm "$FIFO_UEBERZUG"
     exit 0
 fi
 

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -197,6 +197,10 @@ preview_file () {
                 preview_ueberzug "$cols" "$lines" "$1" "audio"
             elif [ "${mimetype%%/*}" = "video" ]; then
                 preview_ueberzug "$cols" "$lines" "$1" "video"
+            elif [ "$ext" = "pdf" ]; then
+                preview_ueberzug "$cols" "$lines" "$1" "pdf"
+            elif [ "$ext" = "epub" ]; then
+                preview_ueberzug "$cols" "$lines" "$1" "epub"
             elif [ "${mimetype%%/*}" = "font" ]; then
                 preview_ueberzug "$cols" "$lines" "$1" "font"
             fi

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -300,13 +300,13 @@ ueberzug_remove() {
 ueberzug_refresh() {
     pkill -P "$$"
     pkill -f -n preview-tui
-    [ "$USE_UEBERZUG" -ne 0 ] && tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
-    nnn_fifo &
+    tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
+    preview_fifo &
     wait
 }
-trap 'ueberzug_refresh' WINCH
+[ "$USE_UEBERZUG" -ne 0 ] && trap 'ueberzug_refresh' WINCH
 
-nnn_fifo() {
+preview_fifo() {
     # use cat instead of 'exec <' to avoid issues with dash shell
     # shellcheck disable=SC2002
     cat "$NNN_FIFO" |\
@@ -329,7 +329,7 @@ if [ "$PREVIEW_MODE" ] ; then
         tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
     fi
 
-    nnn_fifo &
+    preview_fifo &
     wait
 
     # Restoring the previous layout for kitty users. This will only work for

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -16,7 +16,7 @@
 #    - unzip
 #    - tar
 #    - man
-#    - atool: for additional archive preview
+#    - optional: atool for additional archive preview
 #    - optional: bat for code syntax highlighting
 #    - optional: kitty terminal, catimg, viu, or ueberzug for images
 #    - optional: scope.sh file viewer from ranger.

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -3,6 +3,7 @@
 # Description: Terminal based file previewer
 #
 # Note: This plugin needs a "NNN_FIFO" to work. See man.
+# For a more extended version of this script, including ueberzug support, see preview-tui-ext.
 #
 # Dependencies:
 #    - Supports 3 independent methods to preview with:
@@ -16,9 +17,8 @@
 #    - unzip
 #    - tar
 #    - man
-#    - optional: atool for additional archive preview
 #    - optional: bat for code syntax highlighting
-#    - optional: kitty terminal, catimg, viu, or ueberzug for images
+#    - optional: kitty terminal or catimg for images
 #    - optional: scope.sh file viewer from ranger.
 #                To use:
 #                1. drop scope.sh executable in $PATH
@@ -27,35 +27,6 @@
 #                To use:
 #                1. install pistol
 #                2. set/export $USE_PISTOL as 1
-#    - optional: ffmpegthumbnailer for video thumbnails (https://github.com/dirkvdb/ffmpegthumbnailer).
-#                To use:
-#                1. install ffmpegthumbnailer
-#                2. set/export USE_VIDEOPREVIEW as 1
-#    - optional: convert(ImageMagick) for playing gif preview
-#                To use:
-#                1. install ImageMagick
-#                2. set/export USE_GIFPREVIEW as 1
-#                3. set/export LOOP_GIF as 1 if you want to loop gif preview
-#    - optional: ffmpeg for audio thumbnails
-#                To use:
-#                1. install ffmpeg
-#                2. set/export USE_AUDIOPREVIEW as 1
-#    - optional: pdftoppm(poppler) for pdf thumbnails
-#                To use:
-#                1. install poppler
-#                2. set/export USE_PDFPREVIEW as 1
-#    - optional: gnome-epub-thumbnailer for epub thumbnails (https://gitlab.gnome.org/GNOME/gnome-epub-thumbnailer)
-#                To use:
-#                1. install gnome-epub-thumbnailer
-#                2. set/export USE_EPUBPREVIEW as 1
-#    - optional: fontpreview for font preview (https://github.com/sdushantha/fontpreview)
-#                To use:
-#                1. install fontpreview
-#                2. set/export USE_FONTPREVIEW as 1
-#    - optional: libreoffce for opendocument/officedocument preview
-#                To use:
-#                1. install libreoffice
-#                2. set/export USE_OFFICEPREVIEW as 1
 #
 # Usage:
 #   You need to set a NNN_FIFO path and a key for the plugin with NNN_PLUG,
@@ -93,20 +64,7 @@ SPLIT="$SPLIT"  # you can set a permanent split here
 TERMINAL="$TERMINAL"  # same goes for the terminal
 USE_SCOPE="${USE_SCOPE:-0}"
 USE_PISTOL="${USE_PISTOL:-0}"
-USE_UEBERZUG="${USE_UEBERZUG:-0}"
-USE_IMAGEPREVIEW="${USE_IMAGEPREVIEW:-0}"
-USE_VIDEOPREVIEW="${USE_VIDEOPREVIEW:-0}"
-USE_AUDIOPREVIEW="${USE_AUDIOPREVIEW:-0}"
-USE_FONTPREVIEW="${USE_FONTPREVIEW:-0}"
-USE_EPUBPREVIEW="${USE_EPUBPREVIEW:-0}"
-USE_PDFPREVIEW="${USE_PDFPREVIEW:-0}"
-USE_OFFICEPREVIEW="${USE_OFFICEPREVIEW:-0}"
-USE_GIFPREVIEW="${USE_GIFPREVIEW:-0}"
-LOOP_GIFS="${LOOP_GIFS:-0}"
-PAGER="${PAGER:-less -P?n -R}"
-ARCHIVES="$(echo "$NNN_ARCHIVE" | sed 's/.*(\(.*\)).*/\1/;s/|/ /g')"
-TMPDIR="${TMPDIR:-/tmp}"
-
+PAGER="${PAGER:-less -R}"
 [ "$PAGER" = "most" ] && PAGER="less -R"
 
 if [ -e "${TMUX%%,*}" ] && tmux -V | grep -q '[ -][3456789]\.'; then
@@ -132,11 +90,10 @@ fifo_pager() {
     shift
 
     # We use a FIFO to access $PAGER PID in jobs control
-    tmpfifopath="$TMPDIR/nnn-preview-tui-fifo.$$"
+    tmpfifopath="${TMPDIR:-/tmp}/nnn-preview-tui-fifo.$$"
     mkfifo "$tmpfifopath" || return
 
     $PAGER < "$tmpfifopath" &
-    pagerpid="$!"
 
     (
         exec > "$tmpfifopath"
@@ -188,31 +145,25 @@ preview_file () {
     if [ -d "$1" ]; then
         cd "$1" || return
         if exists tree; then
-            fifo_pager tree -L 1 --dirsfirst -F -C
+            fifo_pager tree -L 3 -F
         elif exists exa; then
             fifo_pager exa -G --colour=always 2>/dev/null
         else
             fifo_pager ls --color=always
         fi
     elif [ "$encoding" = "binary" ]; then
-        if [ "$USE_GIFPREVIEW" -ne 0 ] && [ "$ext" = "gif" ]; then
-            generate_preview "$cols" "$lines" "$1" "gif"
-        elif [ "$USE_IMAGEPREVIEW" -ne 0 ] && [ "${mimetype%%/*}" = "image" ]; then
-            display_preview "$cols" "$lines" "$1"
-        elif [ "$USE_AUDIOPREVIEW" -ne 0 ] && [ "${mimetype%%/*}" = "audio" ]; then
-            generate_preview "$cols" "$lines" "$1" "audio"
-        elif [ "$USE_VIDEOPREVIEW" -ne 0 ] && [ "${mimetype%%/*}" = "video" ]; then
-            generate_preview "$cols" "$lines" "$1" "video"
-        elif [ "$USE_PDFPREVIEW" -ne 0 ] && [ "$ext" = "pdf" ]; then
-            generate_preview "$cols" "$lines" "$1" "pdf"
-        elif [ "$USE_EPUBPREVIEW" -ne 0 ] && [ "$ext" = "epub" ]; then
-            generate_preview "$cols" "$lines" "$1" "epub"
-        elif [ "$USE_FONTPREVIEW" -ne 0 ] && [ "${mimetype%%/*}" = "font" ]; then
-            generate_preview "$cols" "$lines" "$1" "font"
-        elif [ "${mimetype#*office}" != "$mimetype" ] || [ "${mimetype#*document}" != "$mimetype" ] && [ "$USE_OFFICEPREVIEW" -ne 0 ]; then
-            generate_preview "$cols" "$lines" "$1" "office"
-        elif [ "${ARCHIVES#*$ext}" != "$ARCHIVES" ] && exists atool; then
-            fifo_pager atool -l "$1"
+        if [ "${mimetype%%/*}" = "image" ] ; then
+            if [ "$TERMINAL" = "kitty" ]; then
+                # Kitty terminal users can use the native image preview method.
+                kitty +kitten icat --silent --transfer-mode=stream --stdin=no \
+                    "$1" &
+            elif exists catimg; then
+                catimg "$1"
+            elif exists viu; then
+                viu -t "$1"
+            else
+                fifo_pager print_bin_info "$1"
+            fi
         elif [ "$mimetype" = "application/zip" ] ; then
             fifo_pager unzip -l "$1"
         elif [ "$ext" = "gz" ] || [ "$ext" = "bz2" ] ; then
@@ -232,91 +183,6 @@ preview_file () {
     fi
 }
 
-generate_preview() {
-    if [ ! -f "$TMPDIR/$3.png" ]; then
-        fifo_pager print_bin_info "$3"
-        mkdir -p "$TMPDIR/${3%/*}"
-        case $4 in
-            audio) ffmpeg -i "$3" "$TMPDIR/$3.png" -y >/dev/null 2>&1 ;;
-            epub) gnome-epub-thumbnailer "$3" "$TMPDIR/$3.png" >/dev/null 2>&1 ;;
-            font) fontpreview -i "$3" -o "$TMPDIR/$3.png" >/dev/null 2>&1 ;;
-            gif) if [ "$USE_UEBERZUG" -ne 0 ] || [ "$TERMINAL" = "kitty" ] && [ "$USE_GIFPREVIEW" -ne 0 ]; then
-                    if [ ! -d "$TMPDIR/$3" ]; then
-                        mkdir -p "$TMPDIR/$3"
-                        convert -coalesce "$3" "$TMPDIR/$3/${3##*/}.png"
-                    fi
-                        while true; do
-                            for frame in $(find "$TMPDIR/$3"/*.png | sort -V); do
-                                display_preview "$1" "$2" "$frame"
-                                sleep 0.1
-                            done
-                            [ "$LOOP_GIFS" -eq 0 ] && return
-                        done &
-                        gifpid="$!"
-                        return
-                 else
-                    display_preview "$1" "$2" "$3"
-                    return
-                 fi ;;
-            office) libreoffice --convert-to png "$3" --outdir "$TMPDIR/${3%/*}" > /dev/null 2>&1
-                    filename="$(echo "${3##*/}" | cut -d. -f1)"
-                    mv "$TMPDIR/${3%/*}/$filename.png" "$TMPDIR/$3.png" ;;
-            pdf) pdftoppm -png -f 1 -singlefile "$3" "$TMPDIR/$3" >/dev/null 2>&1 ;;
-            video) ffmpegthumbnailer -i "$3" -o "$TMPDIR/$3.png" -s 0 -q 10 >/dev/null 2>&1 ;;
-        esac
-    kill "$pagerpid"
-    fi
-    display_preview "$1" "$2" "$TMPDIR/$3.png"
-}
-
-display_preview() {
-    if [ "$USE_UEBERZUG" -ne 0 ] && exists ueberzug; then
-        ueberzug_layer "$1" "$2" "$3"
-    elif [ "$TERMINAL" = "kitty" ]; then
-        # Kitty terminal users can use the native image preview method.
-        kitty +kitten icat --silent --place "$1"x"$2"@0x0 --transfer-mode=stream --stdin=no \
-            "$3"
-    elif exists catimg; then
-        catimg "$3" &
-        gifpid="$!"
-    elif exists viu; then
-        viu -t "$3" &
-        gifpid="$!"
-    fi
-}
-
-ueberzug_layer() {
-    printf '{"action": "add", "identifier": "nnn_ueberzug", "x": 0, "y": 0, "width": "%s", "height": "%s", "path": "%s"}\n' "$1" "$2" "$3" > "$FIFO_UEBERZUG"
-}
-
-ueberzug_remove() {
-    printf '{"action": "remove", "identifier": "nnn_ueberzug"}\n' > "$FIFO_UEBERZUG"
-}
-
-ueberzug_refresh() {
-    clear
-    pkill -P "$$"
-    pkill -f -n preview-tui
-    echo > "$NNN_FIFO"
-    tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
-    preview_fifo &
-    wait
-}
-[ "$USE_UEBERZUG" -ne 0 ] && trap 'ueberzug_refresh' WINCH
-
-preview_fifo() {
-    # use cat instead of 'exec <' to avoid issues with dash shell
-    # shellcheck disable=SC2002
-    cat "$NNN_FIFO" |\
-    while read -r selection ; do
-        [ "$gifpid" -ne 0 ] && kill "$gifpid"
-        [ "$USE_UEBERZUG" -ne 0 ] && ueberzug_remove
-        preview_file "$selection"
-    done
-    [ "$USE_UEBERZUG" -ne 0 ] && rm "$FIFO_UEBERZUG"
-}
-
-
 if [ "$PREVIEW_MODE" ] ; then
     if [ ! -r "$NNN_FIFO" ] ; then
         echo "No FIFO available! (\$NNN_FIFO='$NNN_FIFO')" >&2
@@ -324,18 +190,14 @@ if [ "$PREVIEW_MODE" ] ; then
         exit 1
     fi
 
-    if [ "$USE_UEBERZUG" -ne 0 ]; then
-        FIFO_UEBERZUG="$TMPDIR/nnn-ueberzug-fifo.$$"
-        mkfifo "$FIFO_UEBERZUG"
-    fi
-
     preview_file "$1"
-    if [ "$USE_UEBERZUG" -ne 0 ]; then
-        tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
-    fi
 
-    preview_fifo &
-    wait
+    # use cat instead of 'exec <' to avoid issues with dash shell
+    # shellcheck disable=SC2002
+    cat "$NNN_FIFO" |\
+    while read -r selection ; do
+        preview_file "$selection"
+    done
 
     # Restoring the previous layout for kitty users. This will only work for
     # kitty >= 0.18.0.

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -300,7 +300,7 @@ ueberzug_remove() {
 ueberzug_refresh() {
     pkill -P "$$"
     pkill -f -n preview-tui
-    tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
+    [ "$USE_UEBERZUG" -ne 0 ] && tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
     nnn_fifo &
     wait
 }

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -310,10 +310,8 @@ if [ "$PREVIEW_MODE" ] ; then
     # shellcheck disable=SC2002
     cat "$NNN_FIFO" |\
     while read -r selection ; do
-        if [ "$gifpid" -ne 0 ]; then
-            kill "$gifpid"
-            [ "$USE_UEBERZUG" -ne 0 ] && ueberzug_remove
-        fi
+        [ "$gifpid" -ne 0 ] && kill "$gifpid"
+        [ "$USE_UEBERZUG" -ne 0 ] && ueberzug_remove
         preview_file "$selection"
     done
 

--- a/plugins/preview-tui-ext
+++ b/plugins/preview-tui-ext
@@ -1,0 +1,370 @@
+#!/usr/bin/env sh
+
+# Description: Terminal based file previewer
+#
+# Note: This plugin needs a "NNN_FIFO" to work. See man.
+#
+# Dependencies:
+#    - Supports 3 independent methods to preview with:
+#        - tmux (>=3.0), or
+#        - kitty with allow_remote_control on, or
+#        - $TERMINAL set to a terminal (it's xterm by default).
+#    - less or $PAGER
+#    - tree or exa or ls
+#    - mediainfo or file
+#    - mktemp
+#    - unzip
+#    - tar
+#    - man
+#    - optional: atool for additional archive preview
+#    - optional: bat for code syntax highlighting
+#    - optional: kitty terminal, catimg, viu, or ueberzug for images
+#    - optional: scope.sh file viewer from ranger.
+#                To use:
+#                1. drop scope.sh executable in $PATH
+#                2. set/export $USE_SCOPE as 1
+#    - optional: pistol file viewer (https://github.com/doronbehar/pistol).
+#                To use:
+#                1. install pistol
+#                2. set/export $USE_PISTOL as 1
+#    - optional: ffmpegthumbnailer for video thumbnails (https://github.com/dirkvdb/ffmpegthumbnailer).
+#                To use:
+#                1. install ffmpegthumbnailer
+#                2. set/export USE_VIDEOPREVIEW as 1
+#    - optional: convert(ImageMagick) for playing gif preview
+#                To use:
+#                1. install ImageMagick
+#                2. set/export USE_GIFPREVIEW as 1
+#                3. set/export LOOP_GIF as 1 if you want to loop gif preview
+#    - optional: ffmpeg for audio thumbnails
+#                To use:
+#                1. install ffmpeg
+#                2. set/export USE_AUDIOPREVIEW as 1
+#    - optional: pdftoppm(poppler) for pdf thumbnails
+#                To use:
+#                1. install poppler
+#                2. set/export USE_PDFPREVIEW as 1
+#    - optional: gnome-epub-thumbnailer for epub thumbnails (https://gitlab.gnome.org/GNOME/gnome-epub-thumbnailer)
+#                To use:
+#                1. install gnome-epub-thumbnailer
+#                2. set/export USE_EPUBPREVIEW as 1
+#    - optional: fontpreview for font preview (https://github.com/sdushantha/fontpreview)
+#                To use:
+#                1. install fontpreview
+#                2. set/export USE_FONTPREVIEW as 1
+#    - optional: libreoffce for opendocument/officedocument preview
+#                To use:
+#                1. install libreoffice
+#                2. set/export USE_OFFICEPREVIEW as 1
+#
+# Usage:
+#   You need to set a NNN_FIFO path and a key for the plugin with NNN_PLUG,
+#   then start `nnn`:
+#
+#     $ nnn -a
+#
+#   or
+#
+#     $ NNN_FIFO=/tmp/nnn.fifo nnn
+#
+#   Then in `nnn`, launch the `preview-tui` plugin.
+#
+#   If you provide the same NNN_FIFO to all nnn instances, there will be a
+#   single common preview window. If you provide different FIFO path (e.g.
+#   with -a), they will be independent.
+#
+#   The previews will be shown in a tmux split. If that isn't possible, it
+#   will try to use a kitty terminal split. And as a final fallback, a
+#   different terminal window will be used ($TERMINAL).
+#
+#   Tmux and kitty users can configure $SPLIT to either "h" or "v" to set a
+#   'h'orizontal split or a 'v'ertical split (as in, the line that splits the
+#   windows will be horizontal or vertical).
+#
+#   Kitty users need `allow_remote_control` set to `yes`. To customize the
+#   window split, `enabled_layouts` has to be set to `all` or `splits` (the
+#   former is the default value). This terminal is also able to show images
+#   without extra dependencies.
+#
+# Shell: POSIX compliant
+# Authors: Todd Yamakawa, Léo Villeveygoux, @Recidiviste, Mario Ortiz Manero
+
+SPLIT="$SPLIT"  # you can set a permanent split here
+TERMINAL="$TERMINAL"  # same goes for the terminal
+USE_SCOPE="${USE_SCOPE:-0}"
+USE_PISTOL="${USE_PISTOL:-0}"
+USE_UEBERZUG="${USE_UEBERZUG:-0}"
+USE_IMAGEPREVIEW="${USE_IMAGEPREVIEW:-0}"
+USE_VIDEOPREVIEW="${USE_VIDEOPREVIEW:-0}"
+USE_AUDIOPREVIEW="${USE_AUDIOPREVIEW:-0}"
+USE_FONTPREVIEW="${USE_FONTPREVIEW:-0}"
+USE_EPUBPREVIEW="${USE_EPUBPREVIEW:-0}"
+USE_PDFPREVIEW="${USE_PDFPREVIEW:-0}"
+USE_OFFICEPREVIEW="${USE_OFFICEPREVIEW:-0}"
+USE_GIFPREVIEW="${USE_GIFPREVIEW:-0}"
+LOOP_GIFS="${LOOP_GIFS:-0}"
+PAGER="${PAGER:-less -P?n -R}"
+ARCHIVES="$(echo "$NNN_ARCHIVE" | sed 's/.*(\(.*\)).*/\1/;s/|/ /g')"
+TMPDIR="${TMPDIR:-/tmp}"
+
+[ "$PAGER" = "most" ] && PAGER="less -R"
+
+if [ -e "${TMUX%%,*}" ] && tmux -V | grep -q '[ -][3456789]\.'; then
+    TERMINAL=tmux
+elif [ -n "$KITTY_WINDOW_ID" ] && kitty @ ls >/dev/null 2>&1; then
+    TERMINAL=kitty
+else
+    TERMINAL="${TERMINAL:-xterm}"
+fi
+
+if [ -z "$SPLIT" ] && [ $(($(tput lines) * 2)) -gt "$(tput cols)" ]; then
+    SPLIT='h'
+elif [ "$SPLIT" != 'h' ]; then
+    SPLIT='v'
+fi
+
+exists() {
+    which "$1" >/dev/null 2>&1
+}
+
+fifo_pager() {
+    cmd="$1"
+    shift
+
+    # We use a FIFO to access $PAGER PID in jobs control
+    tmpfifopath="$TMPDIR/nnn-preview-tui-fifo.$$"
+    mkfifo "$tmpfifopath" || return
+
+    $PAGER < "$tmpfifopath" &
+    pagerpid="$!"
+
+    (
+        exec > "$tmpfifopath"
+        "$cmd" "$@" &
+    )
+
+    rm "$tmpfifopath"
+}
+
+# Binary file: show file info inside the pager
+print_bin_info() {
+    printf -- "-------- \033[1;31mBinary file\033[0m --------\n"
+    if exists mediainfo; then
+        mediainfo "$1" 2>/dev/null
+    else
+        file -b "$1"
+    fi
+}
+
+preview_file () {
+    kill %- %+ 2>/dev/null && wait %- %+ 2>/dev/null
+    clear
+
+    # Trying to use pistol if it's available.
+    if [ "$USE_PISTOL" -ne 0 ] && exists pistol; then
+        fifo_pager pistol "$1"
+        return
+    fi
+
+    # Trying to use scope.sh if it's available.
+    if [ "$USE_SCOPE" -ne 0 ] && exists scope.sh; then
+        fifo_pager scope.sh "$1" "$cols" "$lines" "$(mktemp -d)" \
+            "True" 2>/dev/null
+        return
+    fi
+
+    # Detecting the exact type of the file: the encoding, mime type, and
+    # extension in lowercase.
+    encoding="$(file -Lb --mime-encoding -- "$1")"
+    mimetype="$(file -Lb --mime-type -- "$1")"
+    ext="${1##*.}"
+    if [ -n "$ext" ]; then
+        ext="$(printf "%s" "${ext}" | tr '[:upper:]' '[:lower:]')"
+    fi
+    lines=$(($(tput lines)-1))
+    cols=$(tput cols)
+
+    # Otherwise, falling back to the defaults.
+    if [ -d "$1" ]; then
+        cd "$1" || return
+        if exists tree; then
+            fifo_pager tree -L 1 --dirsfirst -F -C
+        elif exists exa; then
+            fifo_pager exa -G --colour=always 2>/dev/null
+        else
+            fifo_pager ls --color=always
+        fi
+    elif [ "$encoding" = "binary" ]; then
+        if [ "$USE_GIFPREVIEW" -ne 0 ] && [ "$ext" = "gif" ]; then
+            generate_preview "$cols" "$lines" "$1" "gif"
+        elif [ "$USE_IMAGEPREVIEW" -ne 0 ] && [ "${mimetype%%/*}" = "image" ]; then
+            display_preview "$cols" "$lines" "$1"
+        elif [ "$USE_AUDIOPREVIEW" -ne 0 ] && [ "${mimetype%%/*}" = "audio" ]; then
+            generate_preview "$cols" "$lines" "$1" "audio"
+        elif [ "$USE_VIDEOPREVIEW" -ne 0 ] && [ "${mimetype%%/*}" = "video" ]; then
+            generate_preview "$cols" "$lines" "$1" "video"
+        elif [ "$USE_PDFPREVIEW" -ne 0 ] && [ "$ext" = "pdf" ]; then
+            generate_preview "$cols" "$lines" "$1" "pdf"
+        elif [ "$USE_EPUBPREVIEW" -ne 0 ] && [ "$ext" = "epub" ]; then
+            generate_preview "$cols" "$lines" "$1" "epub"
+        elif [ "$USE_FONTPREVIEW" -ne 0 ] && [ "${mimetype%%/*}" = "font" ]; then
+            generate_preview "$cols" "$lines" "$1" "font"
+        elif [ "${mimetype#*office}" != "$mimetype" ] || [ "${mimetype#*document}" != "$mimetype" ] && [ "$USE_OFFICEPREVIEW" -ne 0 ]; then
+            generate_preview "$cols" "$lines" "$1" "office"
+        elif [ "${ARCHIVES#*$ext}" != "$ARCHIVES" ] && exists atool; then
+            fifo_pager atool -l "$1"
+        elif [ "$mimetype" = "application/zip" ]; then
+            fifo_pager unzip -l "$1"
+        elif [ "$ext" = "gz" ] || [ "$ext" = "bz2" ]; then
+            fifo_pager tar -tvf "$1"
+        else
+            fifo_pager print_bin_info "$1"
+        fi
+    elif [ "$mimetype" = "text/troff" ]; then
+        fifo_pager man -Pcat -l "$1"
+    else
+        if exists bat; then
+            fifo_pager bat --terminal-width="$cols" --paging=never --decorations=always --color=always \
+                "$1" 2>/dev/null
+        else
+            $PAGER "$1" &
+        fi
+    fi
+}
+
+generate_preview() {
+    if [ ! -f "$TMPDIR/$3.png" ]; then
+        fifo_pager print_bin_info "$3"
+        mkdir -p "$TMPDIR/${3%/*}"
+        case $4 in
+            audio) ffmpeg -i "$3" "$TMPDIR/$3.png" -y >/dev/null 2>&1 ;;
+            epub) gnome-epub-thumbnailer "$3" "$TMPDIR/$3.png" >/dev/null 2>&1 ;;
+            font) fontpreview -i "$3" -o "$TMPDIR/$3.png" >/dev/null 2>&1 ;;
+            gif) if [ "$USE_UEBERZUG" -ne 0 ] || [ "$TERMINAL" = "kitty" ] && [ "$USE_GIFPREVIEW" -ne 0 ]; then
+                    if [ ! -d "$TMPDIR/$3" ]; then
+                        mkdir -p "$TMPDIR/$3"
+                        convert -coalesce "$3" "$TMPDIR/$3/${3##*/}.png"
+                    fi
+                        while true; do
+                            for frame in $(find "$TMPDIR/$3"/*.png | sort -V); do
+                                display_preview "$1" "$2" "$frame"
+                                sleep 0.1
+                            done
+                            [ "$LOOP_GIFS" -eq 0 ] && return
+                        done &
+                        gifpid="$!"
+                        return
+                 else
+                    display_preview "$1" "$2" "$3"
+                    return
+                 fi ;;
+            office) libreoffice --convert-to png "$3" --outdir "$TMPDIR/${3%/*}" > /dev/null 2>&1
+                    filename="$(echo "${3##*/}" | cut -d. -f1)"
+                    mv "$TMPDIR/${3%/*}/$filename.png" "$TMPDIR/$3.png" ;;
+            pdf) pdftoppm -png -f 1 -singlefile "$3" "$TMPDIR/$3" >/dev/null 2>&1 ;;
+            video) ffmpegthumbnailer -i "$3" -o "$TMPDIR/$3.png" -s 0 -q 10 >/dev/null 2>&1 ;;
+        esac
+    kill "$pagerpid"
+    fi
+    display_preview "$1" "$2" "$TMPDIR/$3.png"
+}
+
+display_preview() {
+    if [ "$USE_UEBERZUG" -ne 0 ] && exists ueberzug; then
+        ueberzug_layer "$1" "$2" "$3"
+    elif [ "$TERMINAL" = "kitty" ]; then
+        # Kitty terminal users can use the native image preview method.
+        kitty +kitten icat --silent --place "$1"x"$2"@0x0 --transfer-mode=stream --stdin=no \
+            "$3"
+    elif exists catimg; then
+        catimg "$3" &
+        gifpid="$!"
+    elif exists viu; then
+        viu -t "$3" &
+        gifpid="$!"
+    fi
+}
+
+ueberzug_layer() {
+    printf '{"action": "add", "identifier": "nnn_ueberzug", "x": 0, "y": 0, "width": "%s", "height": "%s", "path": "%s"}\n' "$1" "$2" "$3" > "$FIFO_UEBERZUG"
+}
+
+ueberzug_remove() {
+    printf '{"action": "remove", "identifier": "nnn_ueberzug"}\n' > "$FIFO_UEBERZUG"
+}
+
+ueberzug_refresh() {
+    clear
+    pkill -P "$$"
+    pkill -f -n preview-tui
+    echo > "$NNN_FIFO"
+    tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
+    preview_fifo &
+    wait
+}
+[ "$USE_UEBERZUG" -ne 0 ] && trap 'ueberzug_refresh' WINCH
+
+preview_fifo() {
+    # use cat instead of 'exec <' to avoid issues with dash shell
+    # shellcheck disable=SC2002
+    cat "$NNN_FIFO" |\
+    while read -r selection ; do
+        [ "$gifpid" -ne 0 ] && kill "$gifpid"
+        [ "$USE_UEBERZUG" -ne 0 ] && ueberzug_remove
+        preview_file "$selection"
+    done
+    [ "$USE_UEBERZUG" -ne 0 ] && rm "$FIFO_UEBERZUG"
+}
+
+
+if [ "$PREVIEW_MODE" ]; then
+    if [ ! -r "$NNN_FIFO" ]; then
+        echo "No FIFO available! (\$NNN_FIFO='$NNN_FIFO')" >&2
+        read -r
+        exit 1
+    fi
+
+    if [ "$USE_UEBERZUG" -ne 0 ]; then
+        FIFO_UEBERZUG="$TMPDIR/nnn-ueberzug-fifo.$$"
+        mkfifo "$FIFO_UEBERZUG"
+    fi
+
+    preview_file "$1"
+    if [ "$USE_UEBERZUG" -ne 0 ]; then
+        tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
+    fi
+
+    preview_fifo &
+    wait
+
+    # Restoring the previous layout for kitty users. This will only work for
+    # kitty >= 0.18.0.
+    if [ "$TERMINAL" = "kitty" ]; then
+        kitty @ last-used-layout --no-response >/dev/null 2>&1
+    fi
+
+    exit 0
+fi
+
+if [ "$TERMINAL" = "tmux" ]; then
+    # tmux splits are inverted
+    if [ "$SPLIT" = "v" ]; then SPLIT="h"; else SPLIT="v"; fi
+
+    tmux split-window -e "NNN_FIFO=$NNN_FIFO" -e "PREVIEW_MODE=1" -d"$SPLIT" "$0" "$1"
+elif [ "$TERMINAL" = "kitty" ]; then
+    # Setting the layout for the new window. It will be restored after the
+    # script ends.
+    kitty @ goto-layout splits >/dev/null
+
+    # Trying to use kitty's integrated window management as the split window.
+    # All environmental variables that will be used in the new window must
+    # be explicitly passed.
+    kitty @ launch --no-response --title "nnn preview" --keep-focus \
+          --cwd "$PWD" --env "PATH=$PATH" --env "NNN_FIFO=$NNN_FIFO" \
+          --env "PREVIEW_MODE=1" --env "PAGER=$PAGER" \
+          --env "USE_SCOPE=$USE_SCOPE" --env "SPLIT=$SPLIT" \
+          --env "USE_PISTOL=$USE_PISTOL" \
+          --location "${SPLIT}split" "$0" "$1" >/dev/null
+else
+    PREVIEW_MODE=1 $TERMINAL -e "$0" "$1" &
+fi


### PR DESCRIPTION
While waiting for a response in #851 I took it upon myself to improve the ueberzug integration more akin to [vifmimg](https://github.com/cirala/vifmimg). 

As far as I can tell, the drawing problem I mentioned in #851, as well as the bashism are fixed. Besides that I added moving gif, pdf, audio, video, epub, and font preview. 

One issue is that in using the FIFO to keep the image on the screen without a `read -r`(which the other PR used and which caused the next image to not be drawn), is that when resizing the window the image origin stays at the original location when the ueberzug FIFO queue was opened.
 
The only way I can see to fix this is to let nnn pass the SIGWINCH to its children, which I believe should be sent by ncurses on window resize. I think SIGWINCH could then be trapped in `preview-tui` to close/reopen the ueberzug FIFO causing the image to be drawn correctly.

I did my best to adhere by the current modality of the script although I am not sure about the factoring. I suppose the gif/pdf etc preview can be refactored to be included in the other image drawing methods as well although I guess only kitty would be useful for pdf/epub preview. Feel free to refactor however you like if you are interested in merging this.