### PR TITLE
cleanup fifo

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -209,7 +209,10 @@ ueberzug_refresh() {
     preview_fifo &
     wait
 }
-[ "$TERMINAL" != "kitty" ] && [ "$PREVIEW_MODE" ] && exists ueberzug && trap 'ueberzug_refresh' WINCH
+if [ "$TERMINAL" != "kitty" ] && [ "$PREVIEW_MODE" ] && exists ueberzug; then
+    trap 'ueberzug_refresh' WINCH
+    trap 'rm "$FIFO_UEBERZUG"' INT HUP EXIT
+fi
 
 preview_fifo() {
     # use cat instead of 'exec <' to avoid issues with dash shell

--- a/plugins/preview-tui-ext
+++ b/plugins/preview-tui-ext
@@ -272,7 +272,10 @@ ueberzug_refresh() {
     preview_fifo &
     wait
 }
-[ "$TERMINAL" != "kitty" ] && [ "$PREVIEW_MODE" ] && exists ueberzug && trap 'ueberzug_refresh' WINCH
+if [ "$TERMINAL" != "kitty" ] && [ "$PREVIEW_MODE" ] && exists ueberzug; then
+    trap 'ueberzug_refresh' WINCH
+    trap 'rm "$FIFO_UEBERZUG"' INT HUP EXIT
+fi
 
 preview_fifo() {
     # use cat instead of 'exec <' to avoid issues with dash shell


### PR DESCRIPTION
I noticed leftover fifo files in `TMPDIR`. Not sure how important since its in `TMPDIR` anyways but this cleans up the fifo for `ueberzug` when closing the preview pane.