### PR TITLE
preview-tui(-ext) subshell job control

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -55,6 +55,7 @@ Plugins extend the capabilities of `nnn`. They are _executable_ scripts (or bina
 | [picker](picker) | Pick files and list one per line (to pipe) | sh | nnn |
 | [preview-tabbed](preview-tabbed) | Tabbed/xembed based file previewer | bash | _see in-file docs_ |
 | [preview-tui](preview-tui) | Tmux/kitty/xterm/`$TERMINAL` based file previewer | sh | _see in-file docs_ |
+| [preview-tui-ext](preview-tui-ext) | Meant to be an exhaustive version of [preview-tui](preview-tui) | sh | _see in-file docs_ |
 | [pskill](pskill) | Fuzzy list by name and kill process or zombie | sh | fzf, ps, sudo/doas |
 | [renamer](renamer) | Batch rename selection or files in dir | sh | [qmv](https://www.nongnu.org/renameutils/)/[vidir](https://joeyh.name/code/moreutils/) |
 | [ringtone](ringtone) | Create a variable bitrate mp3 ringtone from file | sh | date, ffmpeg |

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -120,6 +120,7 @@ print_bin_info() {
 }
 
 preview_file () {
+    clear
     # Trying to use pistol if it's available.
     if [ "$USE_PISTOL" -ne 0 ] && exists pistol; then
         fifo_pager pistol "$1"

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -58,7 +58,7 @@
 #   without extra dependencies.
 #
 # Shell: POSIX compliant
-# Authors: Todd Yamakawa, Léo Villeveygoux, @Recidiviste, Mario Ortiz Manero
+# Authors: Todd Yamakawa, Léo Villeveygoux, @Recidiviste, Mario Ortiz Manero, Luuk van Baal
 
 SPLIT="$SPLIT"  # you can set a permanent split here
 TERMINAL="$TERMINAL"  # same goes for the terminal
@@ -66,6 +66,11 @@ USE_SCOPE="${USE_SCOPE:-0}"
 USE_PISTOL="${USE_PISTOL:-0}"
 PAGER="${PAGER:-less -R}"
 TMPDIR="${TMPDIR:-/tmp}"
+NUMPREVIEWTUI="$(($(find "$TMPDIR" -maxdepth 1 -name 'nnn-preview-tui-pagerpid*' 2>/dev/null | wc -l) + 1))"
+PAGERPID="$TMPDIR/nnn-preview-tui-pagerpid.$NUMPREVIEWTUI"
+GIFPID="$TMPDIR/nnn-preview-tui-gifpid.$NUMPREVIEWTUI"
+FIFO_UEBERZUG="$TMPDIR/nnn-preview-tui-ueberzug-fifo.$NUMPREVIEWTUI"
+
 [ "$PAGER" = "most" ] && PAGER="less -R"
 
 if [ -e "${TMUX%%,*}" ] && tmux -V | grep -q '[ -][3456789]\.'; then
@@ -115,9 +120,6 @@ print_bin_info() {
 }
 
 preview_file () {
-    kill %- %+ 2>/dev/null && wait %- %+ 2>/dev/null
-    clear
-
     # Trying to use pistol if it's available.
     if [ "$USE_PISTOL" -ne 0 ] && exists pistol; then
         fifo_pager pistol "$1"
@@ -183,10 +185,10 @@ image_preview() {
         ueberzug_layer "$1" "$2" "$3"
     elif exists catimg; then
         catimg "$3" &
-        gifpid="$!"
+        echo "$!" > "$GIFPID"
     elif exists viu; then
         viu -t "$3" &
-        gifpid="$!"
+        echo "$!" > "$GIFPID"
     else
         fifo_pager print_bin_info "$1"
     fi
@@ -202,8 +204,10 @@ ueberzug_remove() {
 
 ueberzug_refresh() {
     clear
-    pkill -P "$$"
-    pkill -f -n preview-tui
+    pkill -P "$$" >/dev/null 2>&1
+    pkill -f -n preview-tui-ext >/dev/null 2>&1
+    kill "$(cat "$PAGERPID" 2>/dev/null)" >/dev/null 2>&1
+    kill "$(cat "$GIFPID" 2>/dev/null)" >/dev/null 2>&1
     echo > "$NNN_FIFO"
     tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
     preview_fifo &
@@ -211,7 +215,7 @@ ueberzug_refresh() {
 }
 if [ "$TERMINAL" != "kitty" ] && [ "$PREVIEW_MODE" ] && exists ueberzug; then
     trap 'ueberzug_refresh' WINCH
-    trap 'rm "$FIFO_UEBERZUG"' INT HUP EXIT
+    trap 'rm "$FIFO_UEBERZUG" "$PAGERPID" "$GIFPID"' INT HUP EXIT
 fi
 
 preview_fifo() {
@@ -219,11 +223,13 @@ preview_fifo() {
     # shellcheck disable=SC2002
     cat "$NNN_FIFO" |\
     while read -r selection; do
-        [ "$gifpid" -ne 0 ] && kill "$gifpid"
+        kill "$(cat "$GIFPID" 2>/dev/null)" >/dev/null 2>&1
+        kill "$(cat "$PAGERPID" 2>/dev/null)" >/dev/null 2>&1
         [ "$TERMINAL" != "kitty" ] && exists ueberzug && ueberzug_remove
         preview_file "$selection"
     done
     [ "$TERMINAL" != "kitty" ] && exists ueberzug && rm "$FIFO_UEBERZUG"
+    rm "$PAGERPID" "$GIFPID" >/dev/null 2>&1
 }
 
 if [ "$PREVIEW_MODE" ]; then

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -206,8 +206,6 @@ ueberzug_refresh() {
     clear
     pkill -P "$$" >/dev/null 2>&1
     pkill -f -n preview-tui-ext >/dev/null 2>&1
-    kill "$(cat "$PAGERPID" 2>/dev/null)" >/dev/null 2>&1
-    kill "$(cat "$GIFPID" 2>/dev/null)" >/dev/null 2>&1
     echo > "$NNN_FIFO"
     tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
     preview_fifo &

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -3,7 +3,7 @@
 # Description: Terminal based file previewer
 #
 # Note: This plugin needs a "NNN_FIFO" to work. See man.
-# For a more extended version of this script, including ueberzug support, see preview-tui-ext.
+# For a more extended version of this script with additional optional dependencies, see preview-tui-ext.
 #
 # Dependencies:
 #    - Supports 3 independent methods to preview with:
@@ -64,7 +64,7 @@ SPLIT="$SPLIT"  # you can set a permanent split here
 TERMINAL="$TERMINAL"  # same goes for the terminal
 USE_SCOPE="${USE_SCOPE:-0}"
 USE_PISTOL="${USE_PISTOL:-0}"
-PAGER="${PAGER:-less -R}"
+PAGER="${PAGER:-less -P?n -R}"
 TMPDIR="${TMPDIR:-/tmp}"
 NUMPREVIEWTUI="$(($(find "$TMPDIR" -maxdepth 1 -name 'nnn-preview-tui-pagerpid*' 2>/dev/null | wc -l) + 1))"
 PAGERPID="$TMPDIR/nnn-preview-tui-pagerpid.$NUMPREVIEWTUI"
@@ -148,7 +148,7 @@ preview_file () {
     if [ -d "$1" ]; then
         cd "$1" || return
         if exists tree; then
-            fifo_pager tree -L 3 -F
+            fifo_pager tree -L 1 --dirsfirst -F -C
         elif exists exa; then
             fifo_pager exa -G --colour=always 2>/dev/null
         else

--- a/plugins/preview-tui-ext
+++ b/plugins/preview-tui-ext
@@ -129,6 +129,7 @@ print_bin_info() {
 }
 
 preview_file () {
+    clear
     # Trying to use pistol if it's available.
     if [ "$USE_PISTOL" -ne 0 ] && exists pistol; then
         fifo_pager pistol "$1"

--- a/plugins/preview-tui-ext
+++ b/plugins/preview-tui-ext
@@ -65,7 +65,7 @@
 #   without extra dependencies.
 #
 # Shell: POSIX compliant
-# Authors: Todd Yamakawa, Léo Villeveygoux, @Recidiviste, Mario Ortiz Manero
+# Authors: Todd Yamakawa, Léo Villeveygoux, @Recidiviste, Mario Ortiz Manero, Luuk van Baal
 
 SPLIT="$SPLIT"  # you can set a permanent split here
 TERMINAL="$TERMINAL"  # same goes for the terminal
@@ -74,6 +74,10 @@ USE_PISTOL="${USE_PISTOL:-0}"
 PAGER="${PAGER:-less -P?n -R}"
 ARCHIVES="$(echo "$NNN_ARCHIVE" | sed 's/.*(\(.*\)).*/\1/;s/|/ /g')"
 TMPDIR="${TMPDIR:-/tmp}"
+NUMPREVIEWTUI="$(($(find "$TMPDIR" -maxdepth 1 -name 'nnn-preview-tui-pagerpid*' 2>/dev/null | wc -l) + 1))"
+PAGERPID="$TMPDIR/nnn-preview-tui-pagerpid.$NUMPREVIEWTUI"
+GIFPID="$TMPDIR/nnn-preview-tui-gifpid.$NUMPREVIEWTUI"
+FIFO_UEBERZUG="$TMPDIR/nnn-preview-tui-ueberzug-fifo.$NUMPREVIEWTUI"
 
 [ "$PAGER" = "most" ] && PAGER="less -R"
 
@@ -104,7 +108,7 @@ fifo_pager() {
     mkfifo "$tmpfifopath" || return
 
     $PAGER < "$tmpfifopath" &
-    pagerpid="$!"
+    echo "$!" > "$PAGERPID"
 
     (
         exec > "$tmpfifopath"
@@ -125,9 +129,6 @@ print_bin_info() {
 }
 
 preview_file () {
-    kill %- %+ 2>/dev/null && wait %- %+ 2>/dev/null
-    clear
-
     # Trying to use pistol if it's available.
     if [ "$USE_PISTOL" -ne 0 ] && exists pistol; then
         fifo_pager pistol "$1"
@@ -202,7 +203,7 @@ preview_file () {
 
 generate_preview() {
     if [ ! -f "$TMPDIR/$3.png" ]; then
-        fifo_pager print_bin_info "$3"
+        [ "$4" != gif ] && fifo_pager print_bin_info "$3"
         mkdir -p "$TMPDIR/${3%/*}"
         case $4 in
             audio) ffmpeg -i "$3" "$TMPDIR/$3.png" -y >/dev/null 2>&1 ;;
@@ -220,7 +221,7 @@ generate_preview() {
                             done
                             [ "$LOOP_GIFS" -eq 0 ] && return
                         done &
-                        gifpid="$!"
+                        echo "$!" > "$GIFPID"
                         return
                  else
                     image_preview "$1" "$2" "$3"
@@ -232,12 +233,12 @@ generate_preview() {
             pdf) pdftoppm -png -f 1 -singlefile "$3" "$TMPDIR/$3" >/dev/null 2>&1 ;;
             video) ffmpegthumbnailer -i "$3" -o "$TMPDIR/$3.png" -s 0 -q 10 >/dev/null 2>&1 ;;
         esac
-    kill "$pagerpid"
     fi
     image_preview "$1" "$2" "$TMPDIR/$3.png"
 }
 
 image_preview() {
+    clear
     if [ "$TERMINAL" = "kitty" ]; then
         # Kitty terminal users can use the native image preview method.
         kitty +kitten icat --silent --place "$1"x"$2"@0x0 --transfer-mode=stream --stdin=no \
@@ -246,10 +247,10 @@ image_preview() {
         ueberzug_layer "$1" "$2" "$3"
     elif exists catimg; then
         catimg "$3" &
-        gifpid="$!"
+        echo "$!" > "$GIFPID"
     elif exists viu; then
         viu -t "$3" &
-        gifpid="$!"
+        echo "$!" > "$GIFPID"
     else
         fifo_pager print_bin_info "$1"
     fi
@@ -265,8 +266,10 @@ ueberzug_remove() {
 
 ueberzug_refresh() {
     clear
-    pkill -P "$$"
-    pkill -f -n preview-tui-ext
+    pkill -P "$$" >/dev/null 2>&1
+    pkill -f -n preview-tui-ext >/dev/null 2>&1
+    kill "$(cat "$PAGERPID" 2>/dev/null)" >/dev/null 2>&1
+    kill "$(cat "$GIFPID" 2>/dev/null)" >/dev/null 2>&1
     echo > "$NNN_FIFO"
     tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
     preview_fifo &
@@ -274,7 +277,7 @@ ueberzug_refresh() {
 }
 if [ "$TERMINAL" != "kitty" ] && [ "$PREVIEW_MODE" ] && exists ueberzug; then
     trap 'ueberzug_refresh' WINCH
-    trap 'rm "$FIFO_UEBERZUG"' INT HUP EXIT
+    trap 'rm "$FIFO_UEBERZUG" "$PAGERPID" "$GIFPID"' INT HUP EXIT
 fi
 
 preview_fifo() {
@@ -282,11 +285,13 @@ preview_fifo() {
     # shellcheck disable=SC2002
     cat "$NNN_FIFO" |\
     while read -r selection ; do
-        [ "$gifpid" -ne 0 ] && kill "$gifpid"
+        kill "$(cat "$GIFPID" 2>/dev/null)" >/dev/null 2>&1
+        kill "$(cat "$PAGERPID" 2>/dev/null)" >/dev/null 2>&1
         [ "$TERMINAL" != "kitty" ] && exists ueberzug && ueberzug_remove
         preview_file "$selection"
     done
     [ "$TERMINAL" != "kitty" ] && exists ueberzug && rm "$FIFO_UEBERZUG"
+    rm "$PAGERPID" "$GIFPID" >/dev/null 2>&1
 }
 
 
@@ -298,7 +303,6 @@ if [ "$PREVIEW_MODE" ]; then
     fi
 
     if [ "$TERMINAL" != "kitty" ] && exists ueberzug; then
-        FIFO_UEBERZUG="$TMPDIR/nnn-ueberzug-fifo.$$"
         mkfifo "$FIFO_UEBERZUG"
         tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
     fi

--- a/plugins/preview-tui-ext
+++ b/plugins/preview-tui-ext
@@ -268,8 +268,6 @@ ueberzug_refresh() {
     clear
     pkill -P "$$" >/dev/null 2>&1
     pkill -f -n preview-tui-ext >/dev/null 2>&1
-    kill "$(cat "$PAGERPID" 2>/dev/null)" >/dev/null 2>&1
-    kill "$(cat "$GIFPID" 2>/dev/null)" >/dev/null 2>&1
     echo > "$NNN_FIFO"
     tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
     preview_fifo &


### PR DESCRIPTION
Fixes pager manipulation in `preview-tui(-ext)`. The job control added in https://github.com/jarun/nnn/commit/2acc7bd3246674c8f1cc039e36d1afb5b4287824 was non-functional for me in `dash`, only working in `bash`. I assume it was supposed to work in `dash` as well @leovilok, any idea why it doesn't? The `%- %+` seems to be POSIX compliant so I'm not sure but running that version of the script results in an extra pager spawning whenever the selection changes when ran in `dash`, not killing the previous pager. 
```
luuk       65256    3383  0 21:17 pts/6    00:00:00  \_ sh /home/luuk/.config/nnn/plugins/preview-tui
luuk       65265   65256  0 21:17 pts/6    00:00:00      \_ less -R
luuk       65276   65256  0 21:17 pts/6    00:00:00      \_ less -R
luuk       65291   65256  0 21:17 pts/6    00:00:00      \_ less -R
luuk       65302   65256  0 21:17 pts/6    00:00:00      \_ less -R
luuk       65313   65256  0 21:17 pts/6    00:00:00      \_ less -R
luuk       65324   65256  0 21:17 pts/6    00:00:00      \_ less -R
luuk       65335   65256  0 21:17 pts/6    00:00:00      \_ less -R
luuk       65348   65256  0 21:17 pts/6    00:00:00      \_ less -R
```
This leaves the preview window irresponsive to input as it has multiple pagers running inside. 

Anyways it becomes even more difficult to keep track of the PIDs with the subshells introduced by the `ueberzug` integration. 
This is the only way I could come up with to keep track of the previewer PIDs. If anyone knows of a way to do this without writing to disk(`$TMPDIR`), do tell.