### PR TITLE
Show path in terminal title

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -5994,7 +5994,7 @@ begin:
 	}
 
 	/* Set terminal window title */
-	printf("\033]2;%s\007", path);
+	printf("\033]2;%s (%s)\007", xbasename(path), path);
 	fflush(stdout);
 
 	if (g_state.selmode && lastdir[0])

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -5993,6 +5993,10 @@ begin:
 		setdirwatch();
 	}
 
+	/* Set terminal window title */
+	printf("\033]2;%s\007", path);
+	fflush(stdout);
+
 	if (g_state.selmode && lastdir[0])
 		lastappendpos = selbufpos;
 


### PR DESCRIPTION
This is the straightforward way, there is no check on the compatibility of terminals (though I didn't see any issue in linux framebuffer terminal which obviously doesn't implement this feature).

I don't do any cleanup on exit, but it seems to get cleared anyways.

Fixes #911