### PR TITLE
plugin: cleanfilename: clean filename to be more shell-friendly

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -20,6 +20,7 @@ Plugins extend the capabilities of `nnn`. They are _executable_ scripts (or bina
 | [bookmarks](bookmarks) | Use named bookmarks managed with symlinks | sh | fzf |
 | [boom](boom) | Play random music from dir | sh | [moc](http://moc.daper.net/) |
 | [bulknew](bulknew) | Create multiple files/dirs at once | bash | sed, xargs, mktemp |
+| [cleanfilename](cleanfilename) | Clean filename to be more shell-friendly | sh | sed |
 | [dups](dups) | List non-empty duplicate files in current dir | bash | find, md5sum,<br>sort uniq xargs |
 | [chksum](chksum) | Create and verify checksums | sh | md5sum,<br>sha256sum |
 | [diffs](diffs) | Diff for selection (limited to 2 for directories) | sh | vimdiff, mktemp |

--- a/plugins/cleanfilename
+++ b/plugins/cleanfilename
@@ -1,13 +1,14 @@
 #!/usr/bin/env sh
 
-# Description: Clean filename to be more shell-friendly.
-#              This basically replacing any non A-Za-z0-9._- char
-#              to underscore (_).
+# Description: Clean filename (either hovered or selections)
+#              to be more shell-friendly.
+#              This script replaces any non A-Za-z0-9._- char
+#              with underscore (_).
 #
-#              Although the name is cleanfilename, but it should work
+#              Although the name is 'cleanfilename', but it should work
 #              on directories too.
 #
-# Dependencies: -
+# Dependencies: sed
 #
 # Shell: POSIX compliant
 # Author: Benawi Adha

--- a/plugins/cleanfilename
+++ b/plugins/cleanfilename
@@ -3,7 +3,7 @@
 # Description: Clean filename to be more shell-friendly.
 #              This basically replacing any non A-Za-z0-9._- char
 #              to underscore (_).
-# 
+#
 #              Although the name is cleanfilename, but it should work
 #              on directories too.
 #
@@ -24,7 +24,7 @@ cleanup() {
 
 if [ -f "$sel" ]; then
     targets=$(sed -e 's/\x0/\n/g;$a\' "$sel" | \
-        while read i; do
+        while read -r i; do
             basename "$i";
         done)
 else

--- a/plugins/cleanfilename
+++ b/plugins/cleanfilename
@@ -23,7 +23,7 @@ cleanup() {
 }
 
 if [ -f "$sel" ]; then
-    targets=$(sed -e 's/\x0/\n/g;$a\' "$sel" | \
+    targets=$(sed -e "s/\\x0/\\n/g;\$a\\" "$sel" | \
         while read -r i; do
             basename "$i";
         done)

--- a/plugins/cleanfilename
+++ b/plugins/cleanfilename
@@ -20,7 +20,6 @@ IFS='
 
 cleanup() {
     printf "%s" "$1" | sed -e 's/[^A-Za-z0-9._-]/_/g'
-    echo
 }
 
 if [ -f "$sel" ]; then

--- a/plugins/cleanfilename
+++ b/plugins/cleanfilename
@@ -1,0 +1,56 @@
+#!/usr/bin/env sh
+
+# Description: Clean filename to be more shell-friendly.
+#              This basically replacing any non A-Za-z0-9._- char
+#              to underscore (_).
+# 
+#              Although the name is cleanfilename, but it should work
+#              on directories too.
+#
+# Dependencies: -
+#
+# Shell: POSIX compliant
+# Author: Benawi Adha
+
+prompt=true
+sel=${NNN_SEL:-${XDG_CONFIG_HOME:-$HOME/.config}/nnn/.selection}
+IFS='
+'
+
+cleanup() {
+    printf "%s" "$1" | sed -e 's/[^A-Za-z0-9._-]/_/g'
+    echo
+}
+
+if [ -f "$sel" ]; then
+    targets=$(sed -e 's/\x0/\n/g;$a\' "$sel" | \
+        while read i; do
+            basename "$i";
+        done)
+else
+    targets=$1
+fi
+
+for i in $targets; do
+    printf "%s --> %s\n" "$i" "$(cleanup "$i")";
+done
+
+if $prompt; then
+    echo
+    printf "Proceed [Yn]? "
+    read -r input
+    case "$input" in
+        y|Y|'')
+            ;;
+        *)
+            echo "Canceled"
+            exit
+            ;;
+    esac
+fi
+
+for i in $targets; do
+    if [ "$i" != "$(cleanup "$i")" ]; then
+        mv "$i" "$(cleanup "$i")";
+    fi
+done


### PR DESCRIPTION
Basically renaming file/dir to be more shell friendly by replacing spaces and any other non-A-Za-z0-9.- char with underscore ().

eg. '[qwer] sfasdf.txt' --> '_qwer__sfasdf.txt'