### PR TITLE
Save/load the terminal window title using xterm esc sequences

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -7587,6 +7587,8 @@ static bool set_tmp_path(void)
 
 static void cleanup(void)
 {
+	printf("\033[23;0t"); /* reset terminal window title */
+	fflush(stdout);
 	free(selpath);
 	free(plgpath);
 	free(cfgpath);
@@ -8000,6 +8002,10 @@ int main(int argc, char *argv[])
 		read_history(g_buf);
 	}
 #endif
+
+	/* Save terminal window title */
+	printf("\033[22;0t");
+	fflush(stdout);
 
 #ifndef NOMOUSE
 	if (!initcurses(&mask))


### PR DESCRIPTION
Restores the previous terminal window title on some xterm compatible terminal emulators (e.g. kitty and Apple's Terminal).

Following report from @salutis in #912.