### PR TITLE
plugins: cleanfilename: fixed to not overwrite existing file

### DIFF
--- a/plugins/cleanfilename
+++ b/plugins/cleanfilename
@@ -51,7 +51,7 @@ fi
 for i in $targets; do
     if [ "$i" != "$(cleanup "$i")" ]; then
         tmp=''
-        if [ -f "$(cleanup "$i")" ]; then
+        if [ -e "$(cleanup "$i")" ]; then
             tmp='_'
         fi
         mv "$i" "$tmp$(cleanup "$i")";

--- a/plugins/cleanfilename
+++ b/plugins/cleanfilename
@@ -1,12 +1,11 @@
 #!/usr/bin/env sh
 
-# Description: Clean filename (either hovered or selections)
+# Description: Clean filename or dirname (either hovered or selections)
 #              to be more shell-friendly.
 #              This script replaces any non A-Za-z0-9._- char
 #              with underscore (_).
 #
-#              Although the name is 'cleanfilename', but it should work
-#              on directories too.
+#              LIMITATION: Won't work with filename that contains newline
 #
 # Dependencies: sed
 #
@@ -51,6 +50,10 @@ fi
 
 for i in $targets; do
     if [ "$i" != "$(cleanup "$i")" ]; then
-        mv "$i" "$(cleanup "$i")";
+        tmp=''
+        if [ -f "$(cleanup "$i")" ]; then
+            tmp='_'
+        fi
+        mv "$i" "$tmp$(cleanup "$i")";
     fi
 done


### PR DESCRIPTION
When trying to clean filename `qwer[ty` while there is already file named `qwer_ty`, then the new cleaned file will be prepended by '_' become `_qwer_ty` so not to overwrite existing `qwer_ty`.