### PR TITLE
new config: detail column order

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3894,7 +3894,7 @@ static void printent_long(const struct entry *ent, uint_t namecols, bool sel)
 				len = sizes.maxsizeln + 2 - (sizeind ? 1 : xstrlen(size));
 				break;
 			case 'n':
-				len = sizes.maxnameln + (!nameind ? 1 : 0)  - xstrlen(ent->name);
+				len = MIN(namecols,sizes.maxnameln) + (!nameind ? 1 : 0)  - MIN(namecols,xstrlen(ent->name));
 				break;
 #ifndef NOUG
 			case 'o':

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3891,17 +3891,19 @@ static void printent_long(const struct entry *ent, uint_t namecols, bool sel)
 					addstr("  ");
 				break;
 			case 's':
-				len = sizes.maxsizeln + 3 - (sizeind ? 1 : xstrlen(size));
+				len = sizes.maxsizeln + 2 - (sizeind ? 1 : xstrlen(size));
 				break;
 			case 'n':
 				len = sizes.maxnameln + (!nameind ? 1 : 0)  - xstrlen(ent->name);
 				break;
 #ifndef NOUG
 			case 'o':
-				len = sizes.maxownln + 1 - xstrlen(pws ? pws : uidbuf) - xstrlen(grs ? grs : gidbuf);
+				len = sizes.maxownln + 2 - xstrlen(pws ? pws : uidbuf) - xstrlen(grs ? grs : gidbuf);
 				break;
 #endif
 			}
+				if (i < ndcols - 1 && dcols[i+1] == 'n' && len > 0)
+					len--;
 				if (len)
 					while(len--)
 						addch(' ');

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3884,12 +3884,12 @@ static void printent_long(const struct entry *ent, uint_t namecols, bool sel)
 					addstr("  ");
 				break;
 			case 's':
-				len = sizes.maxsizeln + 3 - (sizeind ? 1 : (uint_t)xstrlen(size));
+				len = sizes.maxsizeln + 3 - (sizeind ? 1 : xstrlen(size));
 				while(--len)
 					addch(' ');
 				break;
 			case 'n':
-				len = sizes.maxnameln + (!nameind ? 2 : 1)  - (uint_t)xstrlen(ent->name);
+				len = sizes.maxnameln + (!nameind ? 2 : 1)  - xstrlen(ent->name);
 				while(--len)
 					addch(' ');
 				break;
@@ -3897,9 +3897,9 @@ static void printent_long(const struct entry *ent, uint_t namecols, bool sel)
 			case 'o':
 				len = sizes.maxownln + 2;
 				if (pws)
-					len -= (uint)xstrlen(pws);
+					len -= xstrlen(pws);
 				if (grs)
-					len -= (uint)xstrlen(grs);
+					len -= xstrlen(grs);
 				while(--len)
 					addch(' ');
 				break;

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -5949,25 +5949,19 @@ static void redraw(char *path)
 	}
 
 #ifndef NOUG
-	struct passwd *pw;
-	struct group  *gr;
-	size_t uidlen;
-	size_t gidlen;
+	struct passwd *pw = getpwuid(pdents[i].uid);
+	struct group *gr = getgrgid(pdents[i].gid);
+	size_t uidlen = 0;
+	size_t gidlen = 0;
+		if (pw)
+			uidlen = strlen(pw->pw_name);
+		if (gr)
+			gidlen = strlen(gr->gr_name);
 #endif
+
 	sizes.maxnameln = sizes.maxsizeln = sizes.maxownln = 0;
 	for (i = curscroll; i < ndents && i < curscroll + onscreen; ++i)
 	{
-#ifndef NOUG
-		pw = getpwuid(pdents[i].uid);
-		if (pw)
-			uidlen = strlen(pw->pw_name);
-		else
-			uidlen = 0;
-		if (gr)
-			gidlen = strlen(gr->gr_name);
-		else
-			uidlen = 0;
-#endif
 		sizes.maxnameln = pdents[i].nlen > sizes.maxnameln ? pdents[i].nlen : sizes.maxnameln;
 	  sizes.maxsizeln = strlen(coolsize(cfg.blkorder ? pdents[i].blocks << blk_shift : pdents[i].size)) > sizes.maxsizeln
 			? strlen(coolsize(cfg.blkorder ? pdents[i].blocks << blk_shift : pdents[i].size)) : sizes.maxsizeln;

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3591,7 +3591,7 @@ static void print_time(const time_t *timep)
 	struct tm *t = localtime(timep);
 
 	printw("%d-%02d-%02d %02d:%02d",
-	       t->tm_year + 1900, t->tm_mon + 1, t->tm_mday, t->tm_hour, t->tm_min);
+	       t->tm_year - 100, t->tm_mon + 1, t->tm_mday, t->tm_hour, t->tm_min);
 }
 
 static void printent(const struct entry *ent, uint_t namecols, bool sel)
@@ -5968,7 +5968,7 @@ static void redraw(char *path)
 		sizes.maxnameln = pdents[i].nlen > sizes.maxnameln ? pdents[i].nlen : sizes.maxnameln;
 	  sizes.maxsizeln = strlen(coolsize(cfg.blkorder ? pdents[i].blocks << blk_shift : pdents[i].size)) > sizes.maxsizeln
 			? strlen(coolsize(cfg.blkorder ? pdents[i].blocks << blk_shift : pdents[i].size)) : sizes.maxsizeln;
-    sizes.maxownln = (uidlen ? uidlen : 1) + gidlen ? gidlen : 1;
+    sizes.maxownln = (uidlen ? uidlen : 1) + (gidlen ? gidlen : 1);
 	}
 	sizes.maxentln = sizes.maxnameln + sizes.maxownln + sizes.maxsizeln + 20;
 

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -5954,7 +5954,7 @@ static void redraw(char *path)
 #ifndef NOUG
 	struct passwd *pw;
 	struct group *gr;
-	size_t uidlen, gidlen;
+	size_t uidlen = 0, gidlen = 0;
 #endif
 
 	sizes.maxnameln = sizes.maxsizeln = sizes.maxownln = 0;

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3591,7 +3591,7 @@ static void print_time(const time_t *timep)
 	struct tm *t = localtime(timep);
 
 	printw("%d-%02d-%02d %02d:%02d",
-	       t->tm_year - 100, t->tm_mon + 1, t->tm_mday, t->tm_hour, t->tm_min);
+	       t->tm_year + 1900, t->tm_mon + 1, t->tm_mday, t->tm_hour, t->tm_min);
 }
 
 static void printent(const struct entry *ent, uint_t namecols, bool sel)

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -5961,8 +5961,8 @@ static void redraw(char *path)
 	for (i = curscroll; i < ndents && i < curscroll + onscreen; ++i)
 	{
 #ifndef NOUG
-		getpwuid(pdents[i].uid);
-		getgrgid(pdents[i].gid);
+		pw = getpwuid(pdents[i].uid);
+		gr = getgrgid(pdents[i].gid);
 		if (pw)
 			uidlen = strlen(pw->pw_name);
 		if (gr)

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -5952,19 +5952,22 @@ static void redraw(char *path)
 	}
 
 #ifndef NOUG
-	struct passwd *pw = getpwuid(pdents[i].uid);
-	struct group *gr = getgrgid(pdents[i].gid);
-	size_t uidlen = 0;
-	size_t gidlen = 0;
-		if (pw)
-			uidlen = strlen(pw->pw_name);
-		if (gr)
-			gidlen = strlen(gr->gr_name);
+	struct passwd *pw;
+	struct group *gr;
+	size_t uidlen, gidlen;
 #endif
 
 	sizes.maxnameln = sizes.maxsizeln = sizes.maxownln = 0;
 	for (i = curscroll; i < ndents && i < curscroll + onscreen; ++i)
 	{
+#ifndef NOUG
+		getpwuid(pdents[i].uid);
+		getgrgid(pdents[i].gid);
+		if (pw)
+			uidlen = strlen(pw->pw_name);
+		if (gr)
+			gidlen = strlen(gr->gr_name);
+#endif
 		sizes.maxnameln = pdents[i].nlen > sizes.maxnameln ? pdents[i].nlen : sizes.maxnameln;
 	  sizes.maxsizeln = strlen(coolsize(cfg.blkorder ? pdents[i].blocks << blk_shift : pdents[i].size)) > sizes.maxsizeln
 			? strlen(coolsize(cfg.blkorder ? pdents[i].blocks << blk_shift : pdents[i].size)) : sizes.maxsizeln;

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3833,6 +3833,9 @@ static void printent_long(const struct entry *ent, uint_t namecols, bool sel)
 
 				if (pair && fcolors[pair])
 					nattrs |= COLOR_PAIR(pair);
+
+				if (!nameind)
+					++namecols;
 #ifdef ICONS_ENABLED
 				attroff(nattrs);
 				addstr(selgap);
@@ -3846,9 +3849,9 @@ static void printent_long(const struct entry *ent, uint_t namecols, bool sel)
 			}
 
 #ifndef NOLOCALE
-			addwstr(unescape(ent->name, sizes.maxnameln));
+			addwstr(unescape(ent->name, namecols));
 #else
-			addstr(unescape(ent->name, MIN(sizes.maxnameln, ent->nlen) + 1));
+			addstr(unescape(ent->name, MIN(namecols, ent->nlen) + 1));
 #endif
 
 			if (nameind) {


### PR DESCRIPTION
This is my attempt to implement a new config variable to allow setting the order of the columns in detail mode.

Introduces a new environment variable `NNN_DCOLUMNS` to be set by user preferred order of the following characters:
- "n": entry name
- "o": owner:group
- "p": permission bits
- "P": `ls -l` style permissions
- "t": time

I'm not sure about the quality of the code as I had never worked with `ncurses` before. Was hard to wrap my head around the `attr` bitmasks in `printent_long` but I seem to have made it work properly. Although there might be some redundant `attroff`/`attron` calls, not sure.

I did come across #267 (after implementing this) so I'm curious to know if you think this implementation is acceptable. As you said for smaller terminal sizes the name needs to be cropped (could also consider falling back to "p" first when using "P") which is not working properly in this PR.

If that is required before merging I'll take another look at it and any other remarks.