### PR TITLE
change ^ v to unicode arrows

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -5865,7 +5865,7 @@ static void redraw(char *path)
 	/* Go to first entry */
 	if (curscroll > 0) {
 		move(1, 0);
-		addch('^');
+		addstr("↑");
 	}
 
 	move(2, 0);
@@ -5888,7 +5888,7 @@ static void redraw(char *path)
 	/* Go to first entry */
 	if (i < ndents) {
 		move(xlines - 2, 0);
-		addch('v');
+		addstr("↓");
 	}
 
 	statusbar(path);


### PR DESCRIPTION
Wondering if this can be done harmlessly. I tested ~20 fonts on my system which all included this unicode character, including linux tty font.