### PR TITLE
Exchange nerd-font shell icon

### DIFF
--- a/src/icons-nerdfont.h
+++ b/src/icons-nerdfont.h
@@ -29,7 +29,7 @@
 #define ICON_LICENSE       "\uf718"
 #define ICON_MAKEFILE      "\uf68c"
 #define ICON_ARCHIVE       "\ufac3"
-#define ICON_SCRIPT        "\uf977"
+#define ICON_SCRIPT        "\ue795"
 #define ICON_CPLUSPLUS     "\ue61d"
 #define ICON_JAVA          "\ue738"
 #define ICON_CLOJURE       "\ue76a"


### PR DESCRIPTION
Fixes incorrect spacing for shell scripts with nerd font icons enabled.

Old:
![image](https://user-images.githubusercontent.com/31730729/112750711-7c821e00-8fca-11eb-88df-45e6daef1249.png)

New:
![image](https://user-images.githubusercontent.com/31730729/112750734-93c10b80-8fca-11eb-8179-dda3148dbf48.png)


