### PR TITLE
nerdicon/preview fixes

### DIFF
--- a/plugins/.iconlookup
+++ b/plugins/.iconlookup
@@ -19,27 +19,27 @@ icon_lookup() {
 awk 'BEGIN {
 # Set your ANSI colorscheme below (https://en.wikipedia.org/wiki/ANSI_escape_code#Colors).
 # Default uses standard nnn icon colors, 8 and 24-bit nord themes are commented out.
-colordepth=8      #colordepth=8        #colordepth=24
-color_dirtxt=39   #color_dirtxt=111    #color_dirtxt="129;161;193"
-color_filetxt=15  #color_filetxt=111   #color_filetxt="129;161;193"
-color_default=39  #color_default=111   #color_default="129;161;193"
-color_video=93    #color_video=110     #color_video="136;192;208"
-color_audio=220   #color_audio=150     #color_audio="163;190;140"
-color_image=82    #color_image=150     #color_image="163;190;140"
-color_docs=202    #color_docs=173      #color_docs="208;135;112"
-color_archive=209 #color_archive=179   #color_archive="235;203;139"
-color_c=81        #color_c=150         #color_c="163;190;140"
-color_java=32     #color_java=139      #color_java="180;142;173"
-color_js=47       #color_js=109        #color_js="143;188;187"
-color_react=39    #color_react=111     #color_react="129;161;193"
-color_css=199     #color_css=110       #color_css="136;192;208"
-color_python=227  #color_python=68     #color_python="94;129;172"
-color_lua=19      #color_lua=167       #color_lua="191;97;106"
-color_document=15 #color_document=173  #color_document="208;135;112"
-color_fsharp=31   #color_fsharp=179    #color_fsharp="180;142;173"
-color_ruby=160    #color_ruby=150      #color_ruby="163;190;140"
-color_scala=196   #color_scala=139     #color_scala="143;188;187"
-color_vim=28      #color_vim=109       #color_vim="143;188;187"
+    colordepth=8      #colordepth=8        #colordepth=24
+    color_dirtxt=39   #color_dirtxt=111    #color_dirtxt="129;161;193"
+    color_filetxt=15  #color_filetxt=111   #color_filetxt="129;161;193"
+    color_default=39  #color_default=111   #color_default="129;161;193"
+    color_video=93    #color_video=110     #color_video="136;192;208"
+    color_audio=220   #color_audio=150     #color_audio="163;190;140"
+    color_image=82    #color_image=150     #color_image="163;190;140"
+    color_docs=202    #color_docs=173      #color_docs="208;135;112"
+    color_archive=209 #color_archive=179   #color_archive="235;203;139"
+    color_c=81        #color_c=150         #color_c="163;190;140"
+    color_java=32     #color_java=139      #color_java="180;142;173"
+    color_js=47       #color_js=109        #color_js="143;188;187"
+    color_react=39    #color_react=111     #color_react="129;161;193"
+    color_css=199     #color_css=110       #color_css="136;192;208"
+    color_python=227  #color_python=68     #color_python="94;129;172"
+    color_lua=19      #color_lua=167       #color_lua="191;97;106"
+    color_document=15 #color_document=173  #color_document="208;135;112"
+    color_fsharp=31   #color_fsharp=179    #color_fsharp="180;142;173"
+    color_ruby=160    #color_ruby=150      #color_ruby="163;190;140"
+    color_scala=196   #color_scala=139     #color_scala="143;188;187"
+    color_vim=28      #color_vim=109       #color_vim="143;188;187"
 
 # icons[][1] contains icon and icons[][2] contains color
     icons["directory"][1] = ""; icons["directory"][2] = color_default
@@ -68,7 +68,7 @@ color_vim=28      #color_vim=109       #color_vim="143;188;187"
     icons["configure"][1] = ""; icons["configure"][2] = color_default
     icons["license"][1] = ""; icons["license"][2] = color_docs
     icons["makefile"][1] = ""; icons["makefile"][2] = color_default
-    icons["archive"][1] = "遲"; icons["archive"][2] = color_archive
+    icons["archive"][1] = ""; icons["archive"][2] = color_archive
     icons["script"][1] = ""; icons["script"][2] = color_default
     icons["cplusplus"][1] = ""; icons["cplusplus"][2] = color_c
     icons["java"][1] = ""; icons["java"][2] = color_java
@@ -127,7 +127,7 @@ color_vim=28      #color_vim=109       #color_vim="143;188;187"
 # d
     icons["db"][1] = icons["database"][1]; icons["db"][2] = icons["database"][2]
     icons["deb"][1] = ""; icons["deb"][2] = color_archive
-    icons["diff"][1] = "繁"; icons["diff"][2] = color_default
+    icons["diff"][1] = ""; icons["diff"][2] = color_default
     icons["dll"][1] = icons["script"][1]; icons["dll"][2] = icons["script"][2]
     icons["doc"][1] = icons["worddoc"][1]; icons["doc"][2] = icons["worddoc"][2]
     icons["docx"][1] = icons["worddoc"][1]; icons["docx"][2] = icons["worddoc"][2]
@@ -200,7 +200,7 @@ color_vim=28      #color_vim=109       #color_vim="143;188;187"
     icons["mp4"][1] = icons["videofile"][1]; icons["mp4"][2] = icons["videofile"][2]
     icons["mpeg"][1] = icons["videofile"][1]; icons["mpeg"][2] = icons["videofile"][2]
     icons["mpg"][1] = icons["videofile"][1]; icons["mpg"][2] = icons["videofile"][2]
-    icons["msi"][1] = "者"; icons["msi"][2] = color_default
+    icons["msi"][1] = ""; icons["msi"][2] = color_default
 
 # n
 
@@ -212,7 +212,7 @@ color_vim=28      #color_vim=109       #color_vim="143;188;187"
 
 # p
     icons["part"][1] = icons["download"][1]; icons["part"][2] = icons["download"][2]
-    icons["patch"][1] = "繁"; icons["patch"][2] = color_default
+    icons["patch"][1] = icons["diff"][1]; icons["patch"][2] = icons["diff"][2]
     icons["pdf"][1] = ""; icons["pdf"][2] = color_docs
     icons["php"][1] = ""; icons["php"][2] = color_default
     icons["png"][1] = icons["picturefile"][1]; icons["png"][2] = icons["picturefile"][2]
@@ -297,6 +297,7 @@ color_vim=28      #color_vim=109       #color_vim="143;188;187"
             escape="\033[38;2;"
             break;
     }
+    bstr = ENVIRON["beforestr"]
 }
 {
     # dont print cwd . and leading ./ from tree -f
@@ -304,25 +305,26 @@ color_vim=28      #color_vim=109       #color_vim="143;188;187"
         next
     ent = ($0 ~/^\.\//) ? substr($0, 3, length($0) - 2) : $0
     ext = $NF
+
     # Print icons, set color and bold directories by using ansi escape codes
     if (ext in icons)
         printcolor(icons[ext][1], icons[ext][2], color_filetxt, ent, "10")
     else
         switch (substr(ent, length(ent), 1)) {
             case "/":
-                printcolor(icons["directory"][1], color_default, color_dirtxt, ent, "1")
+                printcolor(icons["directory"][1], color_default, color_dirtxt, substr(ent, 1, length(ent) - 1), "1")
                 break;
             case "*":
-                printcolor(icons["exe"][1], color_default, color_filetxt, ent, "10")
+                printcolor(icons["exe"][1], color_default, color_filetxt, substr(ent, 1, length(ent) - 1), "10")
                 break;
             case "|":
-                printcolor(icons["pipe"][1], color_default, color_filetxt, ent, "10")
+                printcolor(icons["pipe"][1], color_default, color_filetxt, substr(ent, 1, length(ent) - 1), "10")
                 break;
             case "=":
-                printcolor(icons["socket"][1], color_default, color_filetxt, ent, "10")
+                printcolor(icons["socket"][1], color_default, color_filetxt, substr(ent, 1, length(ent) - 1), "10")
                 break;
             case ">":
-                printcolor(icons["door"][1], color_default, color_filetxt, ent, "10")
+                printcolor(icons["door"][1], color_default, color_filetxt, substr(ent, 1, length(ent) - 1), "10")
                 break;
             default:
                 printcolor(icons["file"][1], color_default, color_filetxt, ent, "10")
@@ -332,16 +334,16 @@ function printcolor(i, c, d, n, b) {
     if (limit != "" && length(n) + 2 > limit)
         n = substr(n, 1, limit - 2)
     printf "\033[0m"
-    printf "%s%s;%sm%s %s%sm%s\n", escape, c, b, i, escape, d, n
+    printf "%s%s%s;%sm%s %s%sm%s\n", bstr, escape, c, b, i, escape, d, n
 }'
 printf '\033[0m'
 }
 
-print_before() {
+print_begin() {
     printf '%s\n' "$1" | sed 's/\\n/\n/g'
 }
 
-print_after() {
+print_end() {
     printf '%s\n' "$1" | sed 's/\\n/\n/g'
 }
 
@@ -349,8 +351,7 @@ print_help() {
     printf 'Icon Lookup\n
 Usage:
     iconlookup [options]
-    iconlookup -b [string]
-    iconlookup -a [string]
+    iconlookup [-bBe] [string]
     iconlookup -l [number]
     iconlookup (-h | --help)
 
@@ -358,8 +359,9 @@ Usage:
 
 Options:
     -h --help -?         Show this screen.
-    -a --after           Append string after output.
-    -b --before          Prepend string before output.
+    -b --before          Prepend str before icon.
+    -B --begin           Prepend str before output.
+    -e --end             Append str after output.
     -l --limit           Limit line length to [number] characters.'
 }
 
@@ -368,23 +370,22 @@ while :; do
         -h|-\?|--help)
             print_help
             exit ;;
+        -B|--begin)
+            if [ -n "$2" ]; then
+                print_begin "$2"
+            fi
+            shift ;;
+        -e|--end)
+            if [ -n "$2" ]; then
+                end=1
+                endstr="$2"
+            fi
+            shift ;;
         -b|--before)
             if [ -n "$2" ]; then
-                print_before "$2"
-                shift
-            else
-                printf 'ERROR: "--before" requires a non-empty option argument.\n'
-                exit
-            fi ;;
-        -a|--after)
-            if [ -n "$2" ]; then
-                after=1
-                afterstring="$2"
-                shift
-            else
-                printf 'ERROR: "--after" requires a non-empty option argument.\n'
-                exit
-            fi ;;
+                export beforestr="$2"
+            fi
+            shift ;;
         -l|--limit)
             if [ -n "$2" ]; then
                 export limit="$2"
@@ -404,11 +405,12 @@ while :; do
 done
 
 if [ ! -t 0 ]; then
+    [ -n "$beforestr" ] && limit="$((limit - ${#beforestr}))"
     icon_lookup
 else
     printf 'ERROR: no data provided...\nExpecting a directory listing in stdin\n'
 fi
 
-if [ -n "$after" ]; then
-    print_after "$afterstring"
+if [ -n "$end" ]; then
+    print_end "$endstr"
 fi

--- a/plugins/.iconlookup
+++ b/plugins/.iconlookup
@@ -312,19 +312,19 @@ awk 'BEGIN {
     else
         switch (substr(ent, length(ent), 1)) {
             case "/":
-                printcolor(icons["directory"][1], color_default, color_dirtxt, substr(ent, 1, length(ent) - 1), "1")
+                printcolor(icons["directory"][1], color_default, color_dirtxt, ent, "1")
                 break;
             case "*":
-                printcolor(icons["exe"][1], color_default, color_filetxt, substr(ent, 1, length(ent) - 1), "10")
+                printcolor(icons["exe"][1], color_default, color_filetxt, ent, "10")
                 break;
             case "|":
-                printcolor(icons["pipe"][1], color_default, color_filetxt, substr(ent, 1, length(ent) - 1), "10")
+                printcolor(icons["pipe"][1], color_default, color_filetxt, ent, "10")
                 break;
             case "=":
-                printcolor(icons["socket"][1], color_default, color_filetxt, substr(ent, 1, length(ent) - 1), "10")
+                printcolor(icons["socket"][1], color_default, color_filetxt, ent, "10")
                 break;
             case ">":
-                printcolor(icons["door"][1], color_default, color_filetxt, substr(ent, 1, length(ent) - 1), "10")
+                printcolor(icons["door"][1], color_default, color_filetxt, ent, "10")
                 break;
             default:
                 printcolor(icons["file"][1], color_default, color_filetxt, ent, "10")

--- a/plugins/.iconlookup
+++ b/plugins/.iconlookup
@@ -84,7 +84,7 @@ awk 'BEGIN {
     icons["database"][1] = ""; icons["database"][2] = color_default
     icons["worddoc"][1] = ""; icons["worddoc"][2] = color_document
     icons["playlist"][1] = "蘿"; icons["playlist"][2] = color_audio
-    icons["opticaldisk"][1] = "ﴞ"; icons["opticaldisk"][2] = color_archive
+    icons["opticaldisk"][1] = ""; icons["opticaldisk"][2] = color_archive
 
 # numbers
     icons["1"][1] = icons["manual"][1]; icons["1"][2] = icons["manual"][2]
@@ -165,7 +165,7 @@ awk 'BEGIN {
 
 # i
     icons["ico"][1] = icons["picturefile"][1]; icons["ico"][2] = icons["picturefile"][2]
-    icons["img"][1] = icons["picturefile"][1]; icons["img"][2] = icons["picturefile"][2]
+    icons["img"][1] = icons["opticaldisc"][1]; icons["img"][2] = icons["opticaldisc"][2]
     icons["ini"][1] = icons["configure"][1]; icons["ini"][2] = icons["configure"][2]
     icons["iso"][1] = icons["opticaldisc"][1]; icons["iso"][2] = icons["opticaldisc"][2]
 
@@ -271,7 +271,8 @@ awk 'BEGIN {
     icons["wmv"][1] = icons["videofile"][1]; icons["wmv"][2] = icons["videofile"][2]
 
 # x
-    icons["xbps"][1] = icons["archive"][1]" " color_archive
+    icons["xbps"][1] = icons["archive"][1]; icons["xbps"][2] = color_archive
+    icons["xcf"][1] = icons["imagefile"][1]; icons["xcf"][2] = color_image
     icons["xhtml"][1] = icons["htm"][1]; icons["xhtml"][2] = icons["htm"][2]
     icons["xls"][1] = ""; icons["xls"][2] = color_default
     icons["xlsx"][1] = ""; icons["xlsx"][2] = color_default

--- a/plugins/preview-tui-ext
+++ b/plugins/preview-tui-ext
@@ -169,7 +169,8 @@ preview_file() {
         cd "$1" || return
         if exists tree; then
             if [ "$ICONLOOKUP" -ne 0 ]; then
-                tree -L 1 --dirsfirst -F --noreport -i | head -n "$((lines - 3))" | "$(dirname "$0")"/.iconlookup -l "$cols" -b "\n"
+                [ "$SPLIT" = h ] && BSTR="\n"
+                tree -L 1 --dirsfirst -F --noreport -i | head -n "$((lines - 3))" | "$(dirname "$0")"/.iconlookup -l "$cols" -B "$BSTR" -b " "
             else
                 fifo_pager tree -L 1 --dirsfirst -C -F --noreport -i
             fi;
@@ -178,7 +179,7 @@ preview_file() {
         else
             fifo_pager ls --color=always
         fi
-    elif [ "$encoding" = "binary" ]; then
+    elif [ "${encoding#*)}" = "binary" ]; then
         if [ "${mimetype%%/*}" = "image" ]; then
             if [ "${mimetype#*/}" = "gif" ] && exists convert; then
                 generate_preview "$cols" "$lines" "$1" "gif"
@@ -365,7 +366,7 @@ if [ "$TERMINAL" = "tmux" ]; then
     # tmux splits are inverted
     if [ "$SPLIT" = "v" ]; then SPLIT="h"; else SPLIT="v"; fi
 
-    tmux split-window -e "NNN_FIFO=$NNN_FIFO" -e "PREVIEW_MODE=1" -d"$SPLIT" "$0" "$1"
+    tmux split-window -e "NNN_FIFO=$NNN_FIFO" -e "PREVIEW_MODE=1" -e "SPLIT=$SPLIT" -d"$SPLIT" "$0" "$1"
 elif [ "$TERMINAL" = "kitty" ]; then
     # Setting the layout for the new window. It will be restored after the
     # script ends.

--- a/src/icons-nerdfont.h
+++ b/src/icons-nerdfont.h
@@ -44,7 +44,7 @@
 #define ICON_DATABASE      "\uf6b7"
 #define ICON_WORDDOC       "\uf72b"
 #define ICON_PLAYLIST      "\uf910"
-#define ICON_OPTICALDISK   "\ufd1e"
+#define ICON_OPTICALDISK   "\ue271"
 
 
 /* Numbers */
@@ -126,7 +126,7 @@
 
 /* I */
 #define ICON_EXT_ICO       ICON_PICTUREFILE
-#define ICON_EXT_IMG       ICON_PICTUREFILE
+#define ICON_EXT_IMG       ICON_OPTICALDISK
 #define ICON_EXT_INI       ICON_CONFIGURE
 #define ICON_EXT_ISO       ICON_OPTICALDISK
 
@@ -232,6 +232,7 @@
 
 /* X */
 #define ICON_EXT_XBPS      ICON_ARCHIVE
+#define ICON_EXT_XCF       ICON_PICTUREFILE
 #define ICON_EXT_XHTML     ICON_HTML
 #define ICON_EXT_XLS       "\uf71a"
 #define ICON_EXT_XLSX      "\uf71a"

--- a/src/icons-nerdfont.h
+++ b/src/icons-nerdfont.h
@@ -28,7 +28,7 @@
 #define ICON_CONFIGURE     "\uf423"
 #define ICON_LICENSE       "\uf718"
 #define ICON_MAKEFILE      "\uf68c"
-#define ICON_ARCHIVE       "\ufac3"
+#define ICON_ARCHIVE       "\uf53b"
 #define ICON_SCRIPT        "\ue795"
 #define ICON_CPLUSPLUS     "\ue61d"
 #define ICON_JAVA          "\ue738"
@@ -88,7 +88,7 @@
 /* D */
 #define ICON_EXT_DB        ICON_DATABASE
 #define ICON_EXT_DEB       "\ue77d"
-#define ICON_EXT_DIFF      "\ufa59"
+#define ICON_EXT_DIFF      "\uf440"
 #define ICON_EXT_DLL       ICON_SCRIPT
 #define ICON_EXT_DOC       ICON_WORDDOC
 #define ICON_EXT_DOCX      ICON_WORDDOC
@@ -160,7 +160,7 @@
 #define ICON_EXT_MP4       ICON_VIDEOFILE
 #define ICON_EXT_MPEG      ICON_VIDEOFILE
 #define ICON_EXT_MPG       ICON_VIDEOFILE
-#define ICON_EXT_MSI       "\ufab2"
+#define ICON_EXT_MSI       "\uf871"
 
 /* N */
 
@@ -172,7 +172,7 @@
 
 /* P */
 #define ICON_EXT_PART      ICON_DOWNLOADS
-#define ICON_EXT_PATCH     "\ufa59"
+#define ICON_EXT_PATCH     "\uf440"
 #define ICON_EXT_PDF       "\uf724"
 #define ICON_EXT_PHP       "\ue73d"
 #define ICON_EXT_PNG       ICON_PICTUREFILE

--- a/src/icons.h
+++ b/src/icons.h
@@ -180,7 +180,7 @@ static const struct icon_pair icons_ext[] = {
 
 	/* I */
 	{"ico",      FA_FILE_IMAGE_O,      COLOR_IMAGE},
-	{"img",      FA_FILE_ARCHIVE_O,    COLOR_ARCHIVE},
+	{"img",      LINEA_MUSIC_CD,       COLOR_ARCHIVE},
 	{"ini",      FA_COGS,              0},
 	{"iso",      LINEA_MUSIC_CD,       COLOR_ARCHIVE},
 
@@ -286,6 +286,7 @@ static const struct icon_pair icons_ext[] = {
 
 	/* X */
 	{"xbps",     FA_FILE_ARCHIVE_O,    COLOR_ARCHIVE},
+	{"xcf",      FA_FILE_IMAGE_O,      COLOR_IMAGE},
 	{"xhtml",    FA_FILE_CODE_O,       0},
 	{"xls",      FILE_EXCEL,           0},
 	{"xlsx",     FILE_EXCEL,           0},
@@ -488,6 +489,7 @@ static const struct icon_pair icons_ext[] = {
 
 	/* X */
 	{"xbps",       ICON_EXT_XBPS,      COLOR_ARCHIVE},
+	{"xcf",        ICON_EXT_XCF,       COLOR_IMAGE},
 	{"xhtml",      ICON_EXT_XHTML,     0},
 	{"xls",        ICON_EXT_XLS,       0},
 	{"xlsx",       ICON_EXT_XLSX,      0},


### PR DESCRIPTION
Changes:
* Remove double width glyphs from `icons-nerdfont.h` and `.iconlookup`.
* Add option to prepend string to icon in `.iconlookup` to align with `nnn` output.
* Don't prepend newline when `SPLIT != h` in `.iconlookup`
* Fix preview for `mime-encoding` of the form:
```
file -bL --mime-encoding abstract3.jpg
(null)binary
```
Old:
![image](https://user-images.githubusercontent.com/31730729/114164031-221e8100-992b-11eb-811e-ff08afe9a090.png)
New:
![image](https://user-images.githubusercontent.com/31730729/114163524-9278d280-992a-11eb-9084-0becec96f7df.png)

Old:
![image](https://user-images.githubusercontent.com/31730729/114164111-36fb1480-992b-11eb-8536-e6855ad4e568.png)
New:
![image](https://user-images.githubusercontent.com/31730729/114163629-b3d9be80-992a-11eb-8fce-7ebbf329400c.png)