### PR TITLE
preview-tui: directory preview/iconlookup

### DIFF
--- a/plugins/.iconlookup
+++ b/plugins/.iconlookup
@@ -165,9 +165,9 @@ awk 'BEGIN {
 
 # i
     icons["ico"][1] = icons["picturefile"][1]; icons["ico"][2] = icons["picturefile"][2]
-    icons["img"][1] = icons["opticaldisc"][1]; icons["img"][2] = icons["opticaldisc"][2]
+    icons["img"][1] = icons["opticaldisk"][1]; icons["img"][2] = icons["opticaldisk"][2]
     icons["ini"][1] = icons["configure"][1]; icons["ini"][2] = icons["configure"][2]
-    icons["iso"][1] = icons["opticaldisc"][1]; icons["iso"][2] = icons["opticaldisc"][2]
+    icons["iso"][1] = icons["opticaldisk"][1]; icons["iso"][2] = icons["opticaldisk"][2]
 
 # j
     icons["jar"][1] = icons["java"][1]; icons["jar"][2] = icons["java"][2]
@@ -272,7 +272,7 @@ awk 'BEGIN {
 
 # x
     icons["xbps"][1] = icons["archive"][1]; icons["xbps"][2] = color_archive
-    icons["xcf"][1] = icons["imagefile"][1]; icons["xcf"][2] = color_image
+    icons["xcf"][1] = icons["picturefile"][1]; icons["xcf"][2] = color_image
     icons["xhtml"][1] = icons["htm"][1]; icons["xhtml"][2] = icons["htm"][2]
     icons["xls"][1] = ""; icons["xls"][2] = color_default
     icons["xlsx"][1] = ""; icons["xlsx"][2] = color_default

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -150,9 +150,9 @@ preview_file () {
     if [ -d "$1" ]; then
         cd "$1" || return
         if exists tree; then
-            fifo_pager tree -L 1 --dirsfirst -F -C
+            fifo_pager tree -L 3 --dirsfirst -C -F --noreport -i
         elif exists exa; then
-            fifo_pager exa -G --colour=always 2>/dev/null
+            exa -G --colour=always 2>/dev/null
         else
             fifo_pager ls --color=always
         fi

--- a/plugins/preview-tui-ext
+++ b/plugins/preview-tui-ext
@@ -167,17 +167,16 @@ preview_file() {
     # Otherwise, falling back to the defaults.
     if [ -d "$1" ]; then
         cd "$1" || return
-        if exists tree; then
-            if [ "$ICONLOOKUP" -ne 0 ] && [ -f "$(dirname "$0")"/.iconlookup ]; then
-                [ "$SPLIT" = h ] && BSTR="\n"
-                tree -L 1 --dirsfirst -F --noreport -i | head -n "$((lines - 3))" | "$(dirname "$0")"/.iconlookup -l "$cols" -B "$BSTR" -b " "
-            else
-                fifo_pager tree -L 1 --dirsfirst -C -F --noreport -i
-            fi;
+        if [ "$ICONLOOKUP" -ne 0 ] && [ -f "$(dirname "$0")"/.iconlookup ]; then
+            [ "$SPLIT" = h ] && BSTR="\n"
+            # shellcheck disable=SC2012
+            ls -F --group-directories-first | head -n "$((lines - 3))" | "$(dirname "$0")"/.iconlookup -l "$cols" -B "$BSTR" -b " "
+        elif exists tree; then
+            fifo_pager tree -L 3 --dirsfirst -C -F --noreport -i
         elif exists exa; then
-            fifo_pager exa -G --colour=always 2>/dev/null
+            exa -G --group-directories-first --colour=always 2>/dev/null
         else
-            fifo_pager ls --color=always
+            fifo_pager ls --group-directories-first --color=always
         fi
     elif [ "${encoding#*)}" = "binary" ]; then
         if [ "${mimetype%%/*}" = "image" ]; then

--- a/plugins/preview-tui-ext
+++ b/plugins/preview-tui-ext
@@ -16,7 +16,8 @@
 #    - unzip
 #    - tar
 #    - man
-#    - optional: bsdtar or atool for additional archive preview
+#    - optional: bsdtar or atool for additional archive preview (make sure to export NNN_ARCHIVE
+#                as suggested in the wiki: https://github.com/jarun/nnn/wiki/Usage#configuration)
 #    - optional: bat for code syntax highlighting
 #    - optional: ueberzug, kitty terminal, viu or catimg for images
 #    - optional: convert(ImageMagick) for playing gif preview


### PR DESCRIPTION
* Switch to `ls` for `ICONLOOKUP` case
* Remove `fifo_pager` from `exa` command to actually show grid (`-G` flag)
* Restore `tree` depth 3
* Fix `.iconlookup` typos
* Add note regard `NNN_ARCHIVE` (#955)