### PR TITLE
preview-tui: close previewer

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -273,6 +273,15 @@ if [ "$PREVIEW_MODE" ]; then
     exit 0
 fi
 
+if pgrep -f "cat $NNN_FIFO" >/dev/null; then
+    if exists QuickLook.exe && stat "$1" >/dev/null 2>&1; then
+        f="$(wslpath -w "$1" 2>&1)" && QuickLook.exe "$f" &
+    elif exists Bridge.exe && stat "$1" >/dev/null 2>&1; then
+        f="$(wslpath -w "$1" 2>&1)" && Bridge.exe "$f" &
+    fi
+    pkill -f "cat $NNN_FIO"
+    exit 0
+fi
 if [ "$TERMINAL" = "tmux" ]; then
     # tmux splits are inverted
     if [ "$SPLIT" = "v" ]; then SPLIT="h"; else SPLIT="v"; fi

--- a/plugins/preview-tui-ext
+++ b/plugins/preview-tui-ext
@@ -374,6 +374,15 @@ if [ "$PREVIEW_MODE" ]; then
     exit 0
 fi
 
+if pgrep -f "cat $NNN_FIFO" >/dev/null; then
+    if exists QuickLook.exe && stat "$1" >/dev/null 2>&1; then
+        f="$(wslpath -w "$1" 2>&1)" && QuickLook.exe "$f" &
+    elif exists Bridge.exe && stat "$1" >/dev/null 2>&1; then
+        f="$(wslpath -w "$1" 2>&1)" && Bridge.exe "$f" &
+    fi
+    pkill -f "cat $NNN_FIO"
+    exit 0
+fi
 if [ "$TERMINAL" = "tmux" ]; then
     # tmux splits are inverted
     if [ "$SPLIT" = "v" ]; then SPLIT="h"; else SPLIT="v"; fi


### PR DESCRIPTION
Closes the previewer (all 4 options) on second invocation of the plugin key by killing the previewer fifo. Also assumes the `QuickLook` previewer is open and closes it by running it a second time with the same argument(https://github.com/QL-Win/QuickLook/issues/557#issuecomment-540130609).