### PR TITLE
Make batchrename interactive

### DIFF
--- a/plugins/.nmv
+++ b/plugins/.nmv
@@ -120,7 +120,7 @@ while read -r num name; do
 		if [ ! -d "$dir" ] && ! mkdir -p "$dir"; then
 			printf "%s: failed to create directory tree %s\n" "$0" "$dir" > /dev/stderr
 			exit_status=1
-		elif ! mv "$src" "$name"; then
+		elif ! mv -i "$src" "$name"; then
 			printf "%s: failed to rename %s to %s: %s\n" "$0" "$name" "$tmp" "$!" > /dev/stderr
 			exit_status=1
 		else

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -2194,7 +2194,7 @@ static bool batch_rename(void)
 	bool dir = FALSE, ret = FALSE;
 	char foriginal[TMP_LEN_MAX] = {0};
 	static const char batchrenamecmd[] = "paste -d'\n' %s %s | "SED" 'N; /^\\(.*\\)\\n\\1$/!p;d' | "
-					     "tr '\n' '\\0' | xargs -0 -n2 mv 2>/dev/null";
+					     "tr '\n' '\\0' | xargs -0 -n2 sh -c 'mv -i \"$0\" \"$@\" < /dev/tty'";
 	char buf[sizeof(batchrenamecmd) + (PATH_MAX << 1)];
 	int i = get_cur_or_sel();
 


### PR DESCRIPTION
 Added the requested improvement. We no longer ignore `stderr` output from `mv` as that is what is used to display the overwrite prompts.

Please confirm that it works as expected.