### PR TITLE
preview-tui: kitty gif/pager fallback

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -193,6 +193,12 @@ preview_file () {
         return
     fi
 
+    # Use QuickLook if it's available.
+    if [ -n "$QUICKLOOK" ]; then
+        stat "$1" >/dev/null 2>&1 && f="$(wslpath -w "$1" 2>&1)" && "$QLPATH" "$f" &
+        return
+    fi
+
     # Detecting the exact type of the file: the encoding, mime type, and
     # extension in lowercase.
     encoding="$(file -bL --mime-encoding -- "$1")"
@@ -205,9 +211,7 @@ preview_file () {
     cols=$(tput cols)
 
     # Otherwise, falling back to the defaults.
-    if [ -n "$QUICKLOOK" ] && stat "$1" >/dev/null 2>&1; then
-        f="$(wslpath -w "$1" 2>&1)" && "$QLPATH" "$f" &
-    elif [ -d "$1" ]; then
+    if [ -d "$1" ]; then
         cd "$1" || return
         if exists tree; then
             fifo_pager tree --filelimit "$(find . -maxdepth 1 | wc -l)" -L 3 -C -F --dirsfirst --noreport

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -146,14 +146,23 @@ fifo_pager() {
     shift
 
     # We use a FIFO to access $PAGER PID in jobs control
-    tmpfifopath="${TMPDIR:-/tmp}/nnn-preview-tui-fifo.$$"
+    tmpfifopath="$TMPDIR/nnn-preview-tui-fifo.$$"
     mkfifo "$tmpfifopath" || return
 
     $PAGER < "$tmpfifopath" &
+    printf "%s" "$!" > "$PAGERPID"
 
     (
         exec > "$tmpfifopath"
-        "$cmd" "$@" &
+        if [ "$cmd" = "pager" ]; then
+            if exists bat; then
+                bat --terminal-width="$(tput cols)" --paging=never --decorations=always --color=always "$@" &
+            else
+                $PAGER "$@" &
+            fi
+        else
+            "$cmd" "$@" &
+        fi
     )
 
     rm "$tmpfifopath"
@@ -218,14 +227,13 @@ preview_file () {
             fifo_pager print_bin_info "$1"
         fi
     elif [ "$mimetype" = "text/troff" ]; then
-        fifo_pager man -Pcat -l "$1"
-    else
-        if exists bat; then
-            fifo_pager bat --terminal-width="$cols" --paging=never --decorations=always --color=always \
-                "$1" 2>/dev/null
+        if exists man; then
+            fifo_pager man -Pcat -l "$1"
         else
-            $PAGER "$1" &
+            fifo_pager pager "$1"
         fi
+    else
+        fifo_pager pager "$1"
     fi
 }
 

--- a/plugins/preview-tui-ext
+++ b/plugins/preview-tui-ext
@@ -174,7 +174,15 @@ fifo_pager() {
 
     (
         exec > "$tmpfifopath"
-        "$cmd" "$@" &
+        if [ "$cmd" = "pager" ]; then
+            if exists bat; then
+                bat --terminal-width="$(tput cols)" --paging=never --decorations=always --color=always "$@" &
+            else
+                $PAGER "$@" &
+            fi
+        else
+            "$cmd" "$@" &
+        fi
     )
 
     rm "$tmpfifopath"
@@ -274,7 +282,9 @@ preview_file() {
         if exists glow; then
             fifo_pager glow -s dark "$1"
         elif exists lowdown; then
-            lowdown -Tterm "$1"
+            fifo_pager lowdown -Tterm "$1"
+        else
+            fifo_pager pager "$1"
         fi
     elif [ "$ext" = "htm" ] || [ "$ext" = "html" ] || [ "$ext" = "xhtml" ]; then
         if exists w3m; then
@@ -283,16 +293,17 @@ preview_file() {
             fifo_pager lynx "$1"
         elif exists elinks; then
             fifo_pager elinks "$1"
+        else
+            fifo_pager pager "$1"
         fi
     elif [ "$mimetype" = "text/troff" ]; then
-        fifo_pager man -Pcat -l "$1"
-    else
-        if exists bat; then
-            fifo_pager bat --terminal-width="$cols" --paging=never --decorations=always --color=always \
-                "$1" 2>/dev/null
+        if exists man; then
+            fifo_pager man -Pcat -l "$1"
         else
-            $PAGER "$1" &
+            fifo_pager pager "$1"
         fi
+    else
+        fifo_pager pager "$1"
     fi
 }
 
@@ -305,7 +316,7 @@ generate_preview() {
             audio) ffmpeg -i "$3" -filter_complex "scale=iw*min(1\,min($NNN_PREVIEWWIDTH/iw\,ih)):-1" "$NNN_PREVIEWDIR/$3.jpg" -y >/dev/null 2>&1 ;;
             epub) gnome-epub-thumbnailer "$3" "$NNN_PREVIEWDIR/$3.jpg" >/dev/null 2>&1 ;;
             font) fontpreview -i "$3" -o "$NNN_PREVIEWDIR/$3.jpg" >/dev/null 2>&1 ;;
-            gif) if exists ueberzug && exists convert || [ "$TERMINAL" = "kitty" ]; then
+            gif) if exists ueberzug && exists convert && [ "$TERMINAL" != "kitty" ]; then
                     if [ ! -d "$NNN_PREVIEWDIR/$3" ]; then
                         mkdir -p "$NNN_PREVIEWDIR/$3"
                         convert -coalesce -resize "$NNN_PREVIEWWIDTH"x"$NNN_PREVIEWHEIGHT"\> "$3" "$NNN_PREVIEWDIR/$3/${3##*/}.jpg"
@@ -315,7 +326,6 @@ generate_preview() {
                                 image_preview "$1" "$2" "$frame"
                                 sleep 0.1
                             done
-                            [ "$LOOP_GIFS" -eq 0 ] && return
                         done &
                         printf "%s" "$!" > "$GIFPID"
                         return

--- a/plugins/preview-tui-ext
+++ b/plugins/preview-tui-ext
@@ -213,6 +213,12 @@ preview_file() {
         return
     fi
 
+    # Use QuickLook if it's available.
+    if [ -n "$QUICKLOOK" ]; then
+        stat "$1" >/dev/null 2>&1 && f="$(wslpath -w "$1" 2>&1)" && "$QLPATH" "$f" &
+        return
+    fi
+
     # Detecting the exact type of the file: the encoding, mime type, and
     # extension in lowercase.
     encoding="$(file -bL --mime-encoding -- "$1")"
@@ -225,9 +231,7 @@ preview_file() {
     cols=$(tput cols)
 
     # Otherwise, falling back to the defaults.
-    if [ -n "$QUICKLOOK" ] && stat "$1" >/dev/null 2>&1; then
-        f="$(wslpath -w "$1" 2>&1)" && "$QLPATH" "$f" &
-    elif [ -d "$1" ]; then
+    if [ -d "$1" ]; then
         cd "$1" || return
         if [ "$ICONLOOKUP" -ne 0 ] && [ -f "$(dirname "$0")"/.iconlookup ]; then
             [ "$SPLIT" = h ] && [ "$TERMINAL" != "kitty" ] && BSTR="\n"


### PR DESCRIPTION
* Avoid gif loop for `kitty` terminal since `icat` displays them natively
* Add pager fallback for matched text extensions