### PR TITLE
preview-tui: fix preview dir

### DIFF
--- a/plugins/preview-tui-ext
+++ b/plugins/preview-tui-ext
@@ -79,8 +79,8 @@ USE_PISTOL="${USE_PISTOL:-0}"
 ICONLOOKUP="${ICONLOOKUP:-0}"
 PAGER="${PAGER:-less -P?n -R}"
 TMPDIR="${TMPDIR:-/tmp}"
-# Consider setting NNN_PREVIEWDIR to $XDG_CACHE_DIR if you want to keep previews on disk between reboots
-NNN_PREVIEWDIR="${NNN_PREVIEWDIR:-$TMPDIR}/nnn/previews"
+# Consider setting NNN_PREVIEWDIR to $XDG_CACHE_HOME/nnn/previews if you want to keep previews on disk between reboots
+NNN_PREVIEWDIR="${NNN_PREVIEWDIR:-$TMPDIR/nnn/previews}"
 NNN_PREVIEWWIDTH="${NNN_PREVIEWWIDTH:-1920}"
 NNN_PREVIEWHEIGHT="${NNN_PREVIEWHEIGHT:-1080}"
 


### PR DESCRIPTION
Generated previews were being placed in `$NNN_PREVIEWDIR/nnn/previews/nnn/previews` with `NNN_PREVIEWDIR` set due to `preview-tui` being called recursively.

Fix and suggest setting to `$XDG_CACHE_HOME/nnn/previews` instead.