### PR TITLE
Fix adjust_cols for icons

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -5705,6 +5705,9 @@ static void statusbar(char *path)
 static int adjust_cols(int n)
 {
 	/* Calculate the number of cols available to print entry name */
+#ifdef ICONS_ENABLED
+	n -= (g_state.oldcolor ? 0 : 1 + xstrlen(ICON_PADDING_LEFT) + xstrlen(ICON_PADDING_RIGHT));
+#endif
 	if (cfg.showdetail) {
 		/* Fallback to light mode if less than 35 columns */
 		if (n < 36) {
@@ -5717,12 +5720,7 @@ static int adjust_cols(int n)
 	}
 
 	/* 3 = Preceding space, indicator, newline */
-#ifdef ICONS_ENABLED
-	return (n - (g_state.oldcolor ? 3
-			: 3 + xstrlen(ICON_PADDING_LEFT) + xstrlen(ICON_PADDING_RIGHT) + 1));
-#else
 	return (n - 3);
-#endif
 }
 
 static void draw_line(char *path, int ncols)


### PR DESCRIPTION
Account for the icon length when determining when to fall back to light mode to avoid
![image](https://user-images.githubusercontent.com/31730729/117553971-08b94380-b055-11eb-8396-320cbac43ac8.png)
