### PR TITLE
Merge and simplify unescape

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3415,58 +3415,33 @@ static void resetdircolor(int flags)
  * Adjust string length to maxcols if > 0;
  * Max supported str length: NAME_MAX;
  */
-#ifndef NOLOCALE
+#ifdef NOLOCALE
+static char *unescape(const char *str, uint_t maxcols)
+{
+	char * const wbuf = g_buf;
+	char *buf = wbuf;
+
+	xstrsncpy(wbuf, str, maxcols);
+#else
 static wchar_t *unescape(const char *str, uint_t maxcols)
 {
 	wchar_t * const wbuf = (wchar_t *)g_buf;
 	wchar_t *buf = wbuf;
-	size_t lencount = 0;
 
 	/* Convert multi-byte to wide char */
-	size_t len = mbstowcs(wbuf, str, NAME_MAX);
+	mbstowcs(wbuf, str, maxcols);
+	wbuf[maxcols] = '\0';
+#endif
 
-	len = wcswidth(wbuf, len);
+	while (*buf) {
+		if (*buf <= '\x1f' || *buf == '\x7f')
+			*buf = '\?';
 
-	/* Reduce number of wide chars to max columns */
-	if (len > maxcols) {
-		while (*buf && lencount <= maxcols) {
-			if (*buf <= '\x1f' || *buf == '\x7f')
-				*buf = '\?';
-
-			++buf;
-			++lencount;
-		}
-
-		lencount = maxcols + 1;
-
-		/* Reduce wide chars one by one till it fits */
-		do
-			len = wcswidth(wbuf, --lencount);
-		while (len > maxcols);
-
-		wbuf[lencount] = L'\0';
-	} else {
-		do { /* We do not expect a NULL string */
-			if (*buf <= '\x1f' || *buf == '\x7f')
-				*buf = '\?';
-		} while (*++buf);
+		++buf;
 	}
 
 	return wbuf;
 }
-#else
-static char *unescape(const char *str, uint_t maxcols)
-{
-	ssize_t len = (ssize_t)xstrsncpy(g_buf, str, maxcols);
-
-	--len;
-	while (--len >= 0)
-		if (g_buf[len] <= '\x1f' || g_buf[len] == '\x7f')
-			g_buf[len] = '\?';
-
-	return g_buf;
-}
-#endif
 
 static off_t get_size(off_t size, off_t *pval, uint_t comp)
 {


### PR DESCRIPTION
While considering to implement the suggestion in https://github.com/jarun/nnn/issues/935#issuecomment-835291032 for my fork and looking at `unescape()` I thought the while loop to reduce the number of wide chars to max columns seemed unnecessary.

This merges `unescape()` for the default and `NOLOCALE` case and adjusts the number wide chars to `maxcols` in the same call to `mbstowcs()` by providing `maxcols` instead of `NAME_MAX` as the character limit, avoiding the extra while loop.

Also came across the issue mentioned in #989 while testing this. Without #989 applied `wbuf[maxcols] = '\0';` results in a segfault with icons enabled and `maxcols < 2`.