### PR TITLE
nerdfont support for chess files(pgn,fen) haskell(hs,lhs) files and hpp

### DIFF
--- a/src/icons-nerdfont.h
+++ b/src/icons-nerdfont.h
@@ -118,6 +118,7 @@
 /* H */
 #define ICON_EXT_H         ICON_C
 #define ICON_EXT_HH        ICON_CPLUSPLUS
+#define ICON_EXT_HS        "\ue777"
 #define ICON_EXT_HTACCESS  ICON_CONFIGURE
 #define ICON_EXT_HTPASSWD  ICON_CONFIGURE
 #define ICON_EXT_HTM       ICON_HTML
@@ -174,6 +175,7 @@
 #define ICON_EXT_PART      ICON_DOWNLOADS
 #define ICON_EXT_PATCH     "\uf440"
 #define ICON_EXT_PDF       "\uf724"
+#define ICON_EXT_PGN       "\uf639"
 #define ICON_EXT_PHP       "\ue73d"
 #define ICON_EXT_PNG       ICON_PICTUREFILE
 #define ICON_EXT_PPT       "\uf726"

--- a/src/icons.h
+++ b/src/icons.h
@@ -356,6 +356,7 @@ static const struct icon_pair icons_ext[] = {
 
 	/* F */
 	{"f#",         ICON_EXT_FSHARP,    COLOR_FSHARP},
+	{"fen",        ICON_EXT_PGN,       0},
 	{"flac",       ICON_EXT_FLAC,      COLOR_AUDIO},
 	{"flv",        ICON_EXT_FLV,       COLOR_VIDEO},
 	{"fs",         ICON_EXT_FS,        COLOR_FSHARP},
@@ -373,6 +374,8 @@ static const struct icon_pair icons_ext[] = {
 	/* H */
 	{"h",          ICON_EXT_H,         COLOR_C},
 	{"hh",         ICON_EXT_HH,        COLOR_C},
+	{"hpp",        ICON_EXT_HH,        COLOR_C},
+	{"hs",         ICON_EXT_HS,        COLOR_VIM},
 	{"htaccess",   ICON_EXT_HTACCESS,  0},
 	{"htpasswd",   ICON_EXT_HTPASSWD,  0},
 	{"htm",        ICON_EXT_HTM,       0},
@@ -399,6 +402,7 @@ static const struct icon_pair icons_ext[] = {
 
 	/* L */
 	{"lha",        ICON_EXT_LHA,       COLOR_ARCHIVE},
+	{"lhs",        ICON_EXT_HS,        COLOR_VIM},
 	{"log",        ICON_EXT_LOG,       0},
 	{"lua",        ICON_EXT_LUA,       0},
 	{"lzh",        ICON_EXT_LZH,       COLOR_ARCHIVE},
@@ -430,6 +434,7 @@ static const struct icon_pair icons_ext[] = {
 	{"part",       ICON_EXT_PART,      0},
 	{"patch",      ICON_EXT_PATCH,     0},
 	{"pdf",        ICON_EXT_PDF,       COLOR_DOCS},
+	{"pgn",        ICON_EXT_PGN,       0},
 	{"php",        ICON_EXT_PHP,       0},
 	{"png",        ICON_EXT_PNG,       COLOR_IMAGE},
 	{"ppt",        ICON_EXT_PPT,       0},


### PR DESCRIPTION
If this pr is accepted, do you like if a provide some other changes to nerdfont icons?
Also, i would like to ask .....
I really like more the previous current item and selection indicators, if I provide a pr to reintroduce them with a compiler flag, will it be accepted, or have you decided to stick with the current method?