### PR TITLE
Add chess/haskell icons to .iconlookup

### DIFF
--- a/plugins/.iconlookup
+++ b/plugins/.iconlookup
@@ -78,6 +78,8 @@ awk 'BEGIN {
     icons["fsharp"][1] = ""; icons["fsharp"][2] = color_fsharp
     icons["ruby"][1] = ""; icons["ruby"][2] = color_ruby
     icons["c"][1] = ""; icons["c"][2] = color_c
+    icons["chess"][1] = ""; icons["chess"][2] = color_default
+    icons["haskell"][1] = ""; icons["haskell"][2] = color_vim
     icons["html"][1] = ""; icons["html"][2] = color_default
     icons["react"][1] = ""; icons["react"][2] = color_react
     icons["python"][1] = ""; icons["python"][2] = color_python
@@ -104,7 +106,6 @@ awk 'BEGIN {
     icons["bz2"][1] = icons["archive"][1]; icons["bz2"][2] = icons["archive"][2]
 
 # c
-    icons["c"][1] = icons["c"][1]; icons["c"][2] = icons["c"][2]
     icons["cplusplus"][1] = icons["cplusplus"][1]; icons["cplusplus"][2] = icons["cplusplus"][2]
     icons["cab"][1] = icons["archive"][1]; icons["cab"][2] = icons["archive"][2]
     icons["cbr"][1] = icons["archive"][1]; icons["cbr"][2] = icons["archive"][2]
@@ -141,6 +142,7 @@ awk 'BEGIN {
 # f
     icons["fsharp"][1] = icons["fsharp"][1]; icons["fsharp"][2] = icons["fsharp"][2]
     icons["flac"][1] = icons["musicfile"][1]; icons["flac"][2] = icons["musicfile"][2]
+    icons["fen"][1] = icons["chess"]; icons["fen"][2] = icons["chess"][2]
     icons["flv"][1] = icons["videofile"][1]; icons["flv"][2] = icons["videofile"][2]
     icons["fs"][1] = icons["fsharp"][1]; icons["fs"][2] = icons["fsharp"][2]
     icons["fsi"][1] = icons["fsharp"][1]; icons["fsi"][2] = icons["fsharp"][2]
@@ -157,10 +159,11 @@ awk 'BEGIN {
 # h
     icons["h"][1] = icons["c"][1]; icons["h"][2] = icons["c"][2]
     icons["hh"][1] = icons["cplusplus"][1]; icons["hh"][2] = icons["cplusplus"][2]
+    icons["hpp"][1] = icons["cplusplus"][1]; icons["hpp"][2] = icons["cplusplus"][2]
+    icons["hs"][1] = icons["haskell"]; icons["hs"][2] = icons["haskell"][2]
     icons["htaccess"][1] = icons["configure"][1]; icons["htaccess"][2] = icons["configure"][2]
     icons["htpasswd"][1] = icons["configure"][1]; icons["htpasswd"][2] = icons["configure"][2]
-    icons["htm"][1] = icons["htm"][1]; icons["htm"][2] = icons["htm"][2]
-    icons["html"][1] = icons["htm"][1]; icons["html"][2] = icons["htm"][2]
+    icons["htm"][1] = icons["html"][1]; icons["htm"][2] = icons["html"][2]
     icons["hxx"][1] = icons["cplusplus"][1]; icons["hxx"][2] = icons["cplusplus"][2]
 
 # i
@@ -175,7 +178,6 @@ awk 'BEGIN {
     icons["jl"][1] = icons["configure"][1]; icons["jl"][2] = icons["configure"][2]
     icons["jpeg"][1] = icons["picturefile"][1]; icons["jpeg"][2] = icons["picturefile"][2]
     icons["jpg"][1] = icons["picturefile"][1]; icons["jpg"][2] = icons["picturefile"][2]
-    icons["js"][1] = icons["js"][1]; icons["js"][2] = icons["js"][2]
     icons["json"][1] = "ﬥ"; icons["json"][2] = color_js
     icons["jsx"][1] = icons["react"][1]; icons["jsx"][2] = icons["react"][2]
 
@@ -183,6 +185,7 @@ awk 'BEGIN {
 
 # l
     icons["lha"][1] = icons["archive"][1]; icons["lha"][2] = icons["archive"][2]
+    icons["lhs"][1] = icons["haskell"][1]; icons["lhs"][2] = icons["haskell"][2]
     icons["ilog"][1] = icons["document"][1]; icons["ilog"][2] = icons["document"][2]
     icons["lua"][1] = ""; icons["lua"][2] = color_default
     icons["lzh"][1] = icons["archive"][1]; icons["lzh"][2] = icons["archive"][2]
@@ -214,6 +217,7 @@ awk 'BEGIN {
     icons["part"][1] = icons["download"][1]; icons["part"][2] = icons["download"][2]
     icons["patch"][1] = icons["diff"][1]; icons["patch"][2] = icons["diff"][2]
     icons["pdf"][1] = ""; icons["pdf"][2] = color_docs
+    icons["pgn"][1] = icons["chess"][1]; icons["pgn"][2] = icons["chess"][2]
     icons["php"][1] = ""; icons["php"][2] = color_default
     icons["png"][1] = icons["picturefile"][1]; icons["png"][2] = icons["picturefile"][2]
     icons["ppt"][1] = ""; icons["ppt"][2] = color_default
@@ -273,7 +277,7 @@ awk 'BEGIN {
 # x
     icons["xbps"][1] = icons["archive"][1]; icons["xbps"][2] = color_archive
     icons["xcf"][1] = icons["picturefile"][1]; icons["xcf"][2] = color_image
-    icons["xhtml"][1] = icons["htm"][1]; icons["xhtml"][2] = icons["htm"][2]
+    icons["xhtml"][1] = icons["html"][1]; icons["xhtml"][2] = icons["html"][2]
     icons["xls"][1] = ""; icons["xls"][2] = color_default
     icons["xlsx"][1] = ""; icons["xlsx"][2] = color_default
     icons["xml"][1] = icons["html"][1]; icons["xml"][2] = icons["html"][2]

--- a/src/icons-nerdfont.h
+++ b/src/icons-nerdfont.h
@@ -38,6 +38,8 @@
 #define ICON_FSHARP        "\ue7a7"
 #define ICON_RUBY          "\ue23e"
 #define ICON_C             "\ue61e"
+#define ICON_CHESS         "\uf639"
+#define ICON_HASKELL       "\ue777"
 #define ICON_HTML          "\uf72d"
 #define ICON_REACT         "\ue625"
 #define ICON_PYTHON        "\ue235"
@@ -100,6 +102,7 @@
 #define ICON_EXT_EXE       ICON_EXEC
 
 /* F */
+#define ICON_EXT_FEN       ICON_CHESS
 #define ICON_EXT_FSHARP    ICON_FSHARP
 #define ICON_EXT_FLAC      ICON_MUSICFILE
 #define ICON_EXT_FLV       ICON_VIDEOFILE
@@ -118,7 +121,8 @@
 /* H */
 #define ICON_EXT_H         ICON_C
 #define ICON_EXT_HH        ICON_CPLUSPLUS
-#define ICON_EXT_HS        "\ue777"
+#define ICON_EXT_HPP       ICON_CPLUSPLUS
+#define ICON_EXT_HS        ICON_HASKELL
 #define ICON_EXT_HTACCESS  ICON_CONFIGURE
 #define ICON_EXT_HTPASSWD  ICON_CONFIGURE
 #define ICON_EXT_HTM       ICON_HTML
@@ -145,6 +149,7 @@
 
 /* L */
 #define ICON_EXT_LHA       ICON_ARCHIVE
+#define ICON_EXT_LHS       ICON_HASKELL
 #define ICON_EXT_LOG       ICON_DOCUMENT
 #define ICON_EXT_LUA       "\ue620"
 #define ICON_EXT_LZH       ICON_ARCHIVE
@@ -175,7 +180,7 @@
 #define ICON_EXT_PART      ICON_DOWNLOADS
 #define ICON_EXT_PATCH     "\uf440"
 #define ICON_EXT_PDF       "\uf724"
-#define ICON_EXT_PGN       "\uf639"
+#define ICON_EXT_PGN       ICON_CHESS
 #define ICON_EXT_PHP       "\ue73d"
 #define ICON_EXT_PNG       ICON_PICTUREFILE
 #define ICON_EXT_PPT       "\uf726"

--- a/src/icons.h
+++ b/src/icons.h
@@ -356,7 +356,7 @@ static const struct icon_pair icons_ext[] = {
 
 	/* F */
 	{"f#",         ICON_EXT_FSHARP,    COLOR_FSHARP},
-	{"fen",        ICON_EXT_PGN,       0},
+	{"fen",        ICON_EXT_FEN,       0},
 	{"flac",       ICON_EXT_FLAC,      COLOR_AUDIO},
 	{"flv",        ICON_EXT_FLV,       COLOR_VIDEO},
 	{"fs",         ICON_EXT_FS,        COLOR_FSHARP},
@@ -374,7 +374,7 @@ static const struct icon_pair icons_ext[] = {
 	/* H */
 	{"h",          ICON_EXT_H,         COLOR_C},
 	{"hh",         ICON_EXT_HH,        COLOR_C},
-	{"hpp",        ICON_EXT_HH,        COLOR_C},
+	{"hpp",        ICON_EXT_HPP,       COLOR_C},
 	{"hs",         ICON_EXT_HS,        COLOR_VIM},
 	{"htaccess",   ICON_EXT_HTACCESS,  0},
 	{"htpasswd",   ICON_EXT_HTPASSWD,  0},
@@ -402,7 +402,7 @@ static const struct icon_pair icons_ext[] = {
 
 	/* L */
 	{"lha",        ICON_EXT_LHA,       COLOR_ARCHIVE},
-	{"lhs",        ICON_EXT_HS,        COLOR_VIM},
+	{"lhs",        ICON_EXT_LHS,       COLOR_VIM},
 	{"log",        ICON_EXT_LOG,       0},
 	{"lua",        ICON_EXT_LUA,       0},
 	{"lzh",        ICON_EXT_LZH,       COLOR_ARCHIVE},


### PR DESCRIPTION
Define grouping macros for chess/haskell icons added in #1001 as we have done for other icons used for multiple file extensions. Also add them to `.iconlookup`.