### PR TITLE
Preview-tui cleanup

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -61,20 +61,21 @@
 # Shell: POSIX compliant
 # Authors: Todd Yamakawa, Léo Villeveygoux, @Recidiviste, Mario Ortiz Manero, Luuk van Baal
 
-SPLIT="$SPLIT"  # you can set a permanent split here
-TERMINAL="$TERMINAL"  # same goes for the terminal
+#SPLIT="$SPLIT"  # you can set a permanent split here
+#TERMINAL="$TERMINAL"  # same goes for the terminal
 USE_SCOPE="${USE_SCOPE:-0}"
 USE_PISTOL="${USE_PISTOL:-0}"
 PAGER="${PAGER:-less -P?n -R}"
 TMPDIR="${TMPDIR:-/tmp}"
+BAT_STYLE="${BAT_STYLE:-numbers}"
+NNN_PARENT="${NNN_FIFO#*.}"
+FIFOPID="$TMPDIR/nnn-preview-tui-fifopid.$NNN_PARENT"
+PAGERPID="$TMPDIR/nnn-preview-tui-pagerpid.$NNN_PARENT"
+IMGPID="$TMPDIR/nnn-preview-tui-imgpid.$NNN_PARENT"
+CURSEL="$TMPDIR/nnn-preview-tui-selection.$NNN_PARENT"
+FIFO_UEBERZUG="$TMPDIR/nnn-preview-tui-ueberzug-fifo.$NNN_PARENT"
 
-startpreview() {
-    NUMPREVIEWTUI="$(($(find "$TMPDIR" -maxdepth 1 -name 'nnn-preview-tui-pagerpid*' 2>/dev/null | wc -l) + 1))"
-    PAGERPID="$TMPDIR/nnn-preview-tui-pagerpid.$NUMPREVIEWTUI"
-    IMGPID="$TMPDIR/nnn-preview-tui-gifpid.$NUMPREVIEWTUI"
-    CURSEL="$TMPDIR/nnn-preview-tui-selection.$NUMPREVIEWTUI"
-    FIFO_UEBERZUG="$TMPDIR/nnn-preview-tui-ueberzug-fifo.$NUMPREVIEWTUI"
-
+start_preview() {
     [ "$PAGER" = "most" ] && PAGER="less -R"
 
     if [ -e "${TMUX%%,*}" ] && tmux -V | grep -q '[ -][3456789]\.'; then
@@ -91,55 +92,51 @@ startpreview() {
         SPLIT='v'
     fi
 
-    if [ "$TERMINAL" = "tmux" ]; then
-        # tmux splits are inverted
-        if [ "$SPLIT" = "v" ]; then SPLIT="h"; else SPLIT="v"; fi
+    case "$TERMINAL" in
+        tmux) # tmux splits are inverted
+            if [ "$SPLIT" = "v" ]; then DSPLIT="h"; else DSPLIT="v"; fi
+            tmux split-window -e "NNN_FIFO=$NNN_FIFO" -e "PREVIEW_MODE=1" -e "PAGER=$PAGER" \
+                -e "USE_SCOPE=$USE_SCOPE" -e "SPLIT=$SPLIT" -e "USE_PISTOL=$USE_PISTOL" \
+                -e "BAT_STYLE=$BAT_STYLE" -e "PAGERPID=$PAGERPID" -e "FIFOPID=$FIFOPID" \
+                -e "IMGPID=$IMGPID" -e "CURSEL=$CURSEL" -e "TMPDIR=$TMPDIR" \
+                -e "FIFO_UEBERZUG=$FIFO_UEBERZUG" -e "QLPATH=$QLPATH" -d"$DSPLIT" "$0" "$1" ;;
+        kitty) # Setting the layout for the new window. It will be restored after the script ends.
+            kitty @ goto-layout splits
+            # Trying to use kitty's integrated window management as the split window. All
+            # environmental variables that will be used in the new window must be explicitly passed.
+            kitty @ launch --no-response --title "nnn preview" --keep-focus \
+                --cwd "$PWD" --env "PATH=$PATH" --env "NNN_FIFO=$NNN_FIFO" --env "FIFOPID=$FIFOPID" \
+                --env "PREVIEW_MODE=1" --env "PAGER=$PAGER" --env "TMPDIR=$TMPDIR" \
+                --env "USE_SCOPE=$USE_SCOPE" --env "SPLIT=$SPLIT" --env "TERMINAL=$TERMINAL"\
+                --env "USE_PISTOL=$USE_PISTOL" --env "BAT_STYLE=${BAT_STYLE:-numbers}" \
+                --env "PAGERPID=$PAGERPID" --env "IMGPID=$IMGPID" --env "FIFO_UEBERZUG=$FIFO_UEBERZUG" \
+                --env "CURSEL=$CURSEL" --location "${SPLIT}split" "$0" "$1" ;;
+        *)  if [ -n "$2" ]; then
+                QUICKLOOK=1 QLPATH="$2" PREVIEW_MODE=1 "$0" "$1" &
+            else
+                PAGERPID="$PAGERPID" IMGPID="$IMGPID" CURSEL="$CURSEL" PREVIEW_MODE=1 \
+                     FIFOPID="$FIFOPID" FIFO_UEBERZUG="$FIFO_UEBERZUG" $TERMINAL -e "$0" "$1" &
+            fi ;;
+    esac
+} >/dev/null 2>&1
 
-        tmux split-window -e "NNN_FIFO=$NNN_FIFO" -e "PREVIEW_MODE=1" -e "PAGER=$PAGER" \
-            -e "USE_SCOPE=$USE_SCOPE" -e "SPLIT=$SPLIT" -e "USE_PISTOL=$USE_PISTOL" \
-            -e "BAT_STYLE=${BAT_STYLE:-numbers}" -e "PAGERPID=$PAGERPID" \
-            -e "IMGPID=$IMGPID" -e "CURSEL=$CURSEL" -e "TMPDIR=$TMPDIR" \
-            -e "FIFO_UEBERZUG=$FIFO_UEBERZUG" -e "QLPATH=$QLPATH" -d"$SPLIT" "$0" "$1"
-    elif [ "$TERMINAL" = "kitty" ]; then
-        # Setting the layout for the new window. It will be restored after the
-        # script ends.
-        kitty @ goto-layout splits >/dev/null
-
-        # Trying to use kitty's integrated window management as the split window.
-        # All environmental variables that will be used in the new window must
-        # be explicitly passed.
-        kitty @ launch --no-response --title "nnn preview" --keep-focus \
-            --cwd "$PWD" --env "PATH=$PATH" --env "NNN_FIFO=$NNN_FIFO" \
-            --env "PREVIEW_MODE=1" --env "PAGER=$PAGER" --env "TMPDIR=$TMPDIR" \
-            --env "USE_SCOPE=$USE_SCOPE" --env "SPLIT=$SPLIT" --env "TERMINAL=$TERMINAL"\
-            --env "USE_PISTOL=$USE_PISTOL" --env "BAT_STYLE=${BAT_STYLE:-numbers}" \
-            --env "PAGERPID=$PAGERPID" --env "IMGPID=$IMGPID" --env "FIFO_UEBERZUG=$FIFO_UEBERZUG" \
-            --env "CURSEL=$CURSEL" --location "${SPLIT}split" "$0" "$1" >/dev/null
-    elif [ -n "$2" ]; then
-        QUICKLOOK=1 QLPATH="$2" PREVIEW_MODE=1 "$0" "$1" >/dev/null &
-    else
-        PAGERPID="$PAGERPID" IMGPID="$IMGPID" CURSEL="$CURSEL" PREVIEW_MODE=1 \
-            FIFO_UEBERZUG="$FIFO_UEBERZUG" $TERMINAL -e "$0" "$1" 2>/dev/null &
-    fi
-}
-
-togglepreview() {
+toggle_preview() {
     if exists QuickLook.exe; then
         QLPATH="QuickLook.exe"
     elif exists Bridge.exe; then
         QLPATH="Bridge.exe"
     fi
-    if pkill -fx "cat $NNN_FIFO" >/dev/null; then
-        if [ -n "$QLPATH" ] && stat "$1" >/dev/null 2>&1; then
-            f="$(wslpath -w "$1" 2>&1)" && "$QLPATH" "$f" &
+    if pkill -P "$(cat "$FIFOPID")"; then
+        if [ -n "$QLPATH" ] && stat "$1"; then
+            f="$(wslpath -w "$1")" && "$QLPATH" "$f" &
         fi
     else
-        startpreview "$1" "$QLPATH"
+        start_preview "$1" "$QLPATH"
     fi
-}
+} >/dev/null 2>&1
 
 exists() {
-    type "$1" >/dev/null 2>&1
+    type "$1" >/dev/null
 }
 
 fifo_pager() {
@@ -158,7 +155,7 @@ fifo_pager() {
         if [ "$cmd" = "pager" ]; then
             if exists bat; then
                 bat --terminal-width="$(tput cols)" --decorations=always --color=always \
-                    --paging=never --style="${BAT_STYLE:-numbers}" "$@" 2>/dev/null &
+                    --paging=never --style="$BAT_STYLE" "$@" &
             else
                 $PAGER "$@" &
             fi
@@ -168,17 +165,17 @@ fifo_pager() {
     )
 
     rm "$tmpfifopath"
-}
+} 2>/dev/null
 
 # Binary file: show file info inside the pager
 print_bin_info() {
     printf -- "-------- \033[1;31mBinary file\033[0m --------\n"
     if exists mediainfo; then
-        mediainfo "$1" 2>/dev/null
+        mediainfo "$1"
     else
         file -b "$1"
     fi
-}
+} 2>/dev/null
 
 handle_mime() {
     case "$2" in
@@ -215,25 +212,21 @@ preview_file () {
 
     # Trying to use scope.sh if it's available.
     if [ "$USE_SCOPE" -ne 0 ] && exists scope.sh; then
-        fifo_pager scope.sh "$1" "$cols" "$lines" "$(mktemp -d)" \
-            "True" 2>/dev/null
+        fifo_pager scope.sh "$1" "$cols" "$lines" "$(mktemp -d)" "True"
         return
     fi
 
     # Use QuickLook if it's available.
     if [ -n "$QUICKLOOK" ]; then
-        stat "$1" >/dev/null 2>&1 && f="$(wslpath -w "$1" 2>&1)" && "$QLPATH" "$f" &
+        stat "$1" && f="$(wslpath -w "$1")" && "$QLPATH" "$f" &
         return
     fi
 
-    # Detecting the exact type of the file: the encoding, mime type, and
-    # extension in lowercase.
+    # Detecting the exact type of the file: the encoding, mime type, and extension in lowercase.
     encoding="$(file -bL --mime-encoding -- "$1")"
     mimetype="$(file -bL --mime-type -- "$1")"
     ext="${1##*.}"
-    if [ -n "$ext" ]; then
-        ext="$(printf "%s" "${ext}" | tr '[:upper:]' '[:lower:]')"
-    fi
+    [ -n "$ext" ] && ext="$(printf "%s" "${ext}" | tr '[:upper:]' '[:lower:]')"
     lines=$(tput lines)
     cols=$(tput cols)
 
@@ -243,40 +236,37 @@ preview_file () {
         if exists tree; then
             fifo_pager tree --filelimit "$(find . -maxdepth 1 | wc -l)" -L 3 -C -F --dirsfirst --noreport
         elif exists exa; then
-            exa -G --colour=always 2>/dev/null
+            exa -G --group-directories-first --colour=always
         else
-            fifo_pager ls -F --directories-first --color=always
+            fifo_pager ls -F --group-directories-first --color=always
         fi
     elif [ "${encoding#*)}" = "binary" ]; then
         handle_mime "$1" "$mimetype" "$ext" "bin"
     else
         handle_mime "$1" "$mimetype" "$ext"
     fi
-}
+} 2>/dev/null
 
 image_preview() {
     if [ "$TERMINAL" = "kitty" ]; then
-        # Kitty terminal users can use the native image preview method although one might consider
-        # installing ueberzug and moving the ueberzug clause to the top since it performs alot better.
+        # Kitty terminal users can use the native image preview method
         kitty +kitten icat --silent --place "$1"x"$2"@0x0 --transfer-mode=stream --stdin=no "$3" &
-        printf "%s" "$!" > "$IMGPID"
     elif [ -n "$QLPATH" ] && stat "$3" >/dev/null 2>&1; then
-        f="$(wslpath -w "$3" 2>&1)" && "$QLPATH" "$f" &
+        f="$(wslpath -w "$3")" && "$QLPATH" "$f" && return
     elif exists ueberzug; then
-        ueberzug_layer "$1" "$2" "$3"
+        ueberzug_layer "$1" "$2" "$3" && return
     elif exists catimg; then
         catimg "$3" &
-        printf "%s" "$!" > "$IMGPID"
     elif exists viu; then
         viu -t "$3" &
-        printf "%s" "$!" > "$IMGPID"
     else
-        fifo_pager print_bin_info "$3"
+        fifo_pager print_bin_info "$3" && return
     fi
-}
+    printf "%s" "$!" > "$IMGPID"
+} 2>/dev/null
 
 ueberzug_layer() {
-    printf '{"action": "add", "identifier": "nnn_ueberzug", "x": 0, "y": 0, "width": "%s", "height": "%s", "scaler": "fit_contain", "path": "%s"}\n' "$1" "$2" "$3" > "$FIFO_UEBERZUG"
+    printf '{"action": "add", "identifier": "nnn_ueberzug", "x": 0, "y": 0, "width": "%d", "height": "%d", "scaler": "fit_contain", "path": "%s"}\n' "$1" "$2" "$3" > "$FIFO_UEBERZUG"
 }
 
 ueberzug_remove() {
@@ -285,46 +275,40 @@ ueberzug_remove() {
 
 ueberzug_refresh() {
     clear
-    kill "$(cat "$IMGPID" 2>/dev/null)" >/dev/null 2>&1
-    pkill -P "$$" >/dev/null 2>&1
-    pkill -f -n preview-tui-ext >/dev/null 2>&1
+    kill "$(cat "$IMGPID")"
+    kill "$(cat "$PAGERPID")"
+    pkill -P "$$"
     tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
-    printf "\n" > "$NNN_FIFO"
-    preview_fifo 2>/dev/null &
+    cat "$CURSEL" > "$NNN_FIFO"
+    preview_fifo &
     preview_file "$(cat "$CURSEL")"
-    wait
-}
+    wait "$!"
+} 2>/dev/null
 
 preview_fifo() {
-    # use cat instead of 'exec <' to avoid issues with dash shell
-    # shellcheck disable=SC2002
-    cat "$NNN_FIFO" |\
+    printf "%s" "$$" > "$FIFOPID"
     while read -r selection; do
-        kill "$(cat "$IMGPID" 2>/dev/null)" >/dev/null 2>&1
-        kill "$(cat "$PAGERPID" 2>/dev/null)" >/dev/null 2>&1
+        kill "$(cat "$IMGPID")"
+        kill "$(cat "$PAGERPID")"
         [ "$TERMINAL" != "kitty" ] && exists ueberzug && ueberzug_remove
         preview_file "$selection"
         printf "%s" "$selection" > "$CURSEL"
-    done
-    kill "$(cat "$IMGPID" 2>/dev/null)" >/dev/null 2>&1
-    kill "$(cat "$PAGERPID" 2>/dev/null)" >/dev/null 2>&1
-    [ "$TERMINAL" != "kitty" ] && exists ueberzug && ueberzug_remove
-    rm "$PAGERPID" "$IMGPID" "$CURSEL" "$FIFO_UEBERZUG" >/dev/null 2>&1
-    pkill -P "$$" >/dev/null 2>&1
-}
+    done < "$NNN_FIFO"
+} 2>/dev/null
 
 if [ "$PREVIEW_MODE" ]; then
     if [ "$TERMINAL" != "kitty" ] && exists ueberzug; then
         mkfifo "$FIFO_UEBERZUG"
-        trap 'ueberzug_refresh; rm "$FIFO_UEBERZUG"' WINCH
+        trap 'ueberzug_refresh' WINCH
         tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
     fi
-    trap 'rm "$PAGERPID" "$IMGPID" "$CURSEL" "$FIFO_UEBERZUG" 2>/dev/null' INT HUP EXIT
 
+    printf "%s" "$PWD/$1" > "$CURSEL"
     preview_file "$PWD/$1"
-    printf "%s" "$PWD/$1" > "$CURSEL" &
-    preview_fifo 2>/dev/null &
-    wait
+    preview_fifo &
+    wait "$!"
+    rm "$PAGERPID" "$IMGPID" "$CURSEL" "$FIFO_UEBERZUG" "$FIFOPID" 2>/dev/null
+    pkill -P "$$"
 else
     if [ ! -r "$NNN_FIFO" ]; then
         clear
@@ -335,6 +319,6 @@ else
         printf "\$KITTY_LISTEN_ON not set!\nPlease read Usage in preview-tui."
         cfg=$(stty -g); stty raw -echo; head -c 1; stty "$cfg"
     else
-        togglepreview "$1" &
+        toggle_preview "$1" &
     fi
 fi

--- a/plugins/preview-tui-ext
+++ b/plugins/preview-tui-ext
@@ -72,25 +72,26 @@
 # Shell: POSIX compliant
 # Authors: Todd Yamakawa, Léo Villeveygoux, @Recidiviste, Mario Ortiz Manero, Luuk van Baal
 
-SPLIT="$SPLIT"  # you can set a permanent split here
-TERMINAL="$TERMINAL"  # same goes for the terminal
+#SPLIT="$SPLIT"  # you can set a permanent split here
+#TERMINAL="$TERMINAL"  # same goes for the terminal
 USE_SCOPE="${USE_SCOPE:-0}"
 USE_PISTOL="${USE_PISTOL:-0}"
 ICONLOOKUP="${ICONLOOKUP:-0}"
 PAGER="${PAGER:-less -P?n -R}"
 TMPDIR="${TMPDIR:-/tmp}"
+BAT_STYLE="${BAT_STYLE:-numbers}"
 # Consider setting NNN_PREVIEWDIR to $XDG_CACHE_HOME/nnn/previews if you want to keep previews on disk between reboots
 NNN_PREVIEWDIR="${NNN_PREVIEWDIR:-$TMPDIR/nnn/previews}"
 NNN_PREVIEWWIDTH="${NNN_PREVIEWWIDTH:-1920}"
 NNN_PREVIEWHEIGHT="${NNN_PREVIEWHEIGHT:-1080}"
+NNN_PARENT="${NNN_FIFO#*.}"
+FIFOPID="$TMPDIR/nnn-preview-tui-fifopid.$NNN_PARENT"
+PAGERPID="$TMPDIR/nnn-preview-tui-pagerpid.$NNN_PARENT"
+IMGPID="$TMPDIR/nnn-preview-tui-imgpid.$NNN_PARENT"
+CURSEL="$TMPDIR/nnn-preview-tui-selection.$NNN_PARENT"
+FIFO_UEBERZUG="$TMPDIR/nnn-preview-tui-ueberzug-fifo.$NNN_PARENT"
 
-startpreview() {
-    NUMPREVIEWTUI="$(($(find "$TMPDIR" -maxdepth 1 -name 'nnn-preview-tui-pagerpid*' 2>/dev/null | wc -l) + 1))"
-    PAGERPID="$TMPDIR/nnn-preview-tui-pagerpid.$NUMPREVIEWTUI"
-    IMGPID="$TMPDIR/nnn-preview-tui-gifpid.$NUMPREVIEWTUI"
-    CURSEL="$TMPDIR/nnn-preview-tui-selection.$NUMPREVIEWTUI"
-    FIFO_UEBERZUG="$TMPDIR/nnn-preview-tui-ueberzug-fifo.$NUMPREVIEWTUI"
-
+start_preview() {
     [ "$PAGER" = "most" ] && PAGER="less -R"
 
     if [ -e "${TMUX%%,*}" ] && tmux -V | grep -q '[ -][3456789]\.'; then
@@ -107,59 +108,56 @@ startpreview() {
         SPLIT='v'
     fi
 
-    if [ "$TERMINAL" = "tmux" ]; then
-        # tmux splits are inverted
-        if [ "$SPLIT" = "v" ]; then SPLIT="h"; else SPLIT="v"; fi
+    case "$TERMINAL" in
+        tmux) # tmux splits are inverted
+            if [ "$SPLIT" = "v" ]; then DSPLIT="h"; else DSPLIT="v"; fi
+            tmux split-window -e "NNN_FIFO=$NNN_FIFO" -e "PREVIEW_MODE=1" -e "PAGER=$PAGER" \
+                -e "USE_SCOPE=$USE_SCOPE" -e "SPLIT=$SPLIT" -e "USE_PISTOL=$USE_PISTOL" \
+                -e "BAT_STYLE=$BAT_STYLE" -e "PAGERPID=$PAGERPID" -e "FIFOPID=$FIFOPID" \
+                -e "IMGPID=$IMGPID" -e "CURSEL=$CURSEL" -e "TMPDIR=$TMPDIR" \
+                -e "ICONLOOKUP=$ICONLOOKUP" -e "NNN_PREVIEWDIR=$NNN_PREVIEWDIR" \
+                -e "NNN_PREVIEWWIDTH=$NNN_PREVIEWWIDTH" -e "NNN_PREVIEWHEIGHT=$NNN_PREVIEWHEIGHT" \
+                -e "FIFO_UEBERZUG=$FIFO_UEBERZUG" -e "QLPATH=$2" -d"$DSPLIT" "$0" "$1" ;;
+        kitty) # Setting the layout for the new window. It will be restored after the script ends.
+            kitty @ goto-layout splits
+            # Trying to use kitty's integrated window management as the split window.
+            # All environmental variables that will be used in the new window must
+            # be explicitly passed.
+            kitty @ launch --no-response --title "nnn preview" --keep-focus \
+                --cwd "$PWD" --env "PATH=$PATH" --env "NNN_FIFO=$NNN_FIFO" \
+                --env "PREVIEW_MODE=1" --env "PAGER=$PAGER" --env "TMPDIR=$TMPDIR" \
+                --env "USE_SCOPE=$USE_SCOPE" --env "SPLIT=$SPLIT" --env "TERMINAL=$TERMINAL"\
+                --env "USE_PISTOL=$USE_PISTOL" --env "BAT_STYLE=$BAT_STYLE" --env "FIFOPID=$FIFOPID" \
+                --env "PAGERPID=$PAGERPID" --env "IMGPID=$IMGPID" --env "FIFO_UEBERZUG=$FIFO_UEBERZUG" \
+                --env "ICONLOOKUP=$ICONLOOKUP" --env "NNN_PREVIEWDIR=$NNN_PREVIEWDIR" \
+                --env "NNN_PREVIEWWIDTH=$NNN_PREVIEWWIDTH" --env "NNN_PREVIEWHEIGHT=$NNN_PREVIEWHEIGHT" \
+                --env "CURSEL=$CURSEL" --location "${SPLIT}split" "$0" "$1" ;;
+        *)  if [ -n "$2" ]; then
+                QUICKLOOK=1 QLPATH="$2" PREVIEW_MODE=1 "$0" "$1" &
+            else
+                PAGERPID="$PAGERPID" IMGPID="$IMGPID" CURSEL="$CURSEL" PREVIEW_MODE=1 \
+                     FIFOPID="$FIFOPID" FIFO_UEBERZUG="$FIFO_UEBERZUG" $TERMINAL -e "$0" "$1" &
+            fi ;;
+    esac
+} >/dev/null 2>&1
 
-        tmux split-window -e "NNN_FIFO=$NNN_FIFO" -e "PREVIEW_MODE=1" -e "PAGER=$PAGER" \
-            -e "USE_SCOPE=$USE_SCOPE" -e "SPLIT=$SPLIT" -e "USE_PISTOL=$USE_PISTOL" \
-            -e "BAT_STYLE=${BAT_STYLE:-numbers}" -e "PAGERPID=$PAGERPID" \
-            -e "IMGPID=$IMGPID" -e "CURSEL=$CURSEL" -e "TMPDIR=$TMPDIR" \
-            -e "ICONLOOKUP=$ICONLOOKUP" -e "NNN_PREVIEWDIR=$NNN_PREVIEWDIR" \
-            -e "NNN_PREVIEWWIDTH=$NNN_PREVIEWWIDTH" -e "NNN_PREVIEWHEIGHT=$NNN_PREVIEWHEIGHT" \
-            -e "FIFO_UEBERZUG=$FIFO_UEBERZUG" -e "QLPATH=$2" -d"$SPLIT" "$0" "$1"
-    elif [ "$TERMINAL" = "kitty" ]; then
-        # Setting the layout for the new window. It will be restored after the
-        # script ends.
-        kitty @ goto-layout splits >/dev/null
-
-        # Trying to use kitty's integrated window management as the split window.
-        # All environmental variables that will be used in the new window must
-        # be explicitly passed.
-        kitty @ launch --no-response --title "nnn preview" --keep-focus \
-            --cwd "$PWD" --env "PATH=$PATH" --env "NNN_FIFO=$NNN_FIFO" \
-            --env "PREVIEW_MODE=1" --env "PAGER=$PAGER" --env "TMPDIR=$TMPDIR" \
-            --env "USE_SCOPE=$USE_SCOPE" --env "SPLIT=$SPLIT" --env "TERMINAL=$TERMINAL"\
-            --env "USE_PISTOL=$USE_PISTOL" --env "BAT_STYLE=${BAT_STYLE:-numbers}" \
-            --env "PAGERPID=$PAGERPID" --env "IMGPID=$IMGPID" --env "FIFO_UEBERZUG=$FIFO_UEBERZUG" \
-            --env "ICONLOOKUP=$ICONLOOKUP" --env "NNN_PREVIEWDIR=$NNN_PREVIEWDIR" \
-            --env "NNN_PREVIEWWIDTH=$NNN_PREVIEWWIDTH" --env "NNN_PREVIEWHEIGHT=$NNN_PREVIEWHEIGHT" \
-            --env "CURSEL=$CURSEL" --location "${SPLIT}split" "$0" "$1" >/dev/null
-    elif [ -n "$2" ]; then
-        QUICKLOOK=1 QLPATH="$2" PREVIEW_MODE=1 "$0" "$1" >/dev/null &
-    else
-        PAGERPID="$PAGERPID" IMGPID="$IMGPID" CURSEL="$CURSEL" PREVIEW_MODE=1 \
-            FIFO_UEBERZUG="$FIFO_UEBERZUG" $TERMINAL -e "$0" "$1" 2>/dev/null &
-    fi
-}
-
-togglepreview() {
+toggle_preview() {
     if exists QuickLook.exe; then
         QLPATH="QuickLook.exe"
     elif exists Bridge.exe; then
         QLPATH="Bridge.exe"
     fi
-    if pkill -fx "cat $NNN_FIFO" >/dev/null; then
-        if [ -n "$QLPATH" ] && stat "$1" >/dev/null 2>&1; then
-            f="$(wslpath -w "$1" 2>&1)" && "$QLPATH" "$f" &
+    if pkill -P "$(cat "$FIFOPID")"; then
+        if [ -n "$QLPATH" ] && stat "$1"; then
+            f="$(wslpath -w "$1")" && "$QLPATH" "$f" &
         fi
     else
-        startpreview "$1" "$QLPATH"
+        start_preview "$1" "$QLPATH"
     fi
-}
+} >/dev/null 2>&1
 
 exists() {
-    type "$1" >/dev/null 2>&1
+    type "$1" >/dev/null
 }
 
 fifo_pager() {
@@ -178,7 +176,7 @@ fifo_pager() {
         if [ "$cmd" = "pager" ]; then
             if exists bat; then
                 bat --terminal-width="$(tput cols)" --decorations=always --color=always \
-                    --paging=never --style="${BAT_STYLE:-numbers}" "$@" 2>/dev/null &
+                    --paging=never --style="$BAT_STYLE" "$@" &
             else
                 $PAGER "$@" &
             fi
@@ -188,13 +186,13 @@ fifo_pager() {
     )
 
     rm "$tmpfifopath"
-}
+} 2>/dev/null
 
 # Binary file: show file info inside the pager
 print_bin_info() {
     printf -- "-------- \033[1;31mBinary file\033[0m --------\n"
     if exists mediainfo; then
-        mediainfo "$1" 2>/dev/null
+        mediainfo "$1"
     else
         file -b "$1"
     fi
@@ -267,19 +265,17 @@ preview_file() {
 
     # Trying to use scope.sh if it's available.
     if [ "$USE_SCOPE" -ne 0 ] && exists scope.sh; then
-        fifo_pager scope.sh "$1" "$cols" "$lines" "$(mktemp -d)" \
-            "True" 2>/dev/null
+        fifo_pager scope.sh "$1" "$cols" "$lines" "$(mktemp -d)" "True"
         return
     fi
 
     # Use QuickLook if it's available.
     if [ -n "$QUICKLOOK" ]; then
-        stat "$1" >/dev/null 2>&1 && f="$(wslpath -w "$1" 2>&1)" && "$QLPATH" "$f" &
+        stat "$1" && f="$(wslpath -w "$1")" && "$QLPATH" "$f" &
         return
     fi
 
-    # Detecting the exact type of the file: the encoding, mime type, and
-    # extension in lowercase.
+    # Detecting the exact exists of the file: the encoding, mime type, and extension in lowercase.
     encoding="$(file -bL --mime-encoding -- "$1")"
     mimetype="$(file -bL --mime-type -- "$1")"
     ext="${1##*.}"
@@ -291,14 +287,13 @@ preview_file() {
     if [ -d "$1" ]; then
         cd "$1" || return
         if [ "$ICONLOOKUP" -ne 0 ] && [ -f "$(dirname "$0")"/.iconlookup ]; then
-            [ "$SPLIT" = h ] && [ "$TERMINAL" != "kitty" ] && BSTR="\n"
-            [ "$SPLIT" = v ] && [ "$TERMINAL" = "kitty" ] && BSTR="\n"
+            [ "$SPLIT" = v ] && BSTR="\n"
             # shellcheck disable=SC2012
             ls -F --group-directories-first | head -n "$((lines - 3))" | "$(dirname "$0")"/.iconlookup -l "$cols" -B "$BSTR" -b " "
         elif exists tree; then
             fifo_pager tree --filelimit "$(find . -maxdepth 1 | wc -l)" -L 3 -C -F --dirsfirst --noreport
         elif exists exa; then
-            exa -G --group-directories-first --colour=always 2>/dev/null
+            exa -G --group-directories-first --colour=always
         else
             fifo_pager ls -F --group-directories-first --color=always
         fi
@@ -307,17 +302,17 @@ preview_file() {
     else
         handle_mime "$1" "$mimetype" "$ext"
     fi
-}
+} 2>/dev/null
 
 generate_preview() {
-  if [ -n "$QLPATH" ] && stat "$3" >/dev/null 2>&1; then
-        f="$(wslpath -w "$3" 2>&1)" && "$QLPATH" "$f" &
+  if [ -n "$QLPATH" ] && stat "$3"; then
+        f="$(wslpath -w "$3")" && "$QLPATH" "$f" &
   elif [ ! -f "$NNN_PREVIEWDIR/$3.jpg" ] || [ -n "$(find -L "$3" -newer "$NNN_PREVIEWDIR/$3.jpg")" ]; then
         mkdir -p "$NNN_PREVIEWDIR/${3%/*}"
         case $4 in
-            audio) ffmpeg -i "$3" -filter_complex "scale=iw*min(1\,min($NNN_PREVIEWWIDTH/iw\,ih)):-1" "$NNN_PREVIEWDIR/$3.jpg" -y >/dev/null 2>&1 ;;
-            epub) gnome-epub-thumbnailer "$3" "$NNN_PREVIEWDIR/$3.jpg" >/dev/null 2>&1 ;;
-            font) fontpreview -i "$3" -o "$NNN_PREVIEWDIR/$3.jpg" >/dev/null 2>&1 ;;
+            audio) ffmpeg -i "$3" -filter_complex "scale=iw*min(1\,min($NNN_PREVIEWWIDTH/iw\,ih)):-1" "$NNN_PREVIEWDIR/$3.jpg" -y ;;
+            epub) gnome-epub-thumbnailer "$3" "$NNN_PREVIEWDIR/$3.jpg" ;;
+            font) fontpreview -i "$3" -o "$NNN_PREVIEWDIR/$3.jpg" ;;
             gif) if exists ueberzug && exists convert && [ "$TERMINAL" != "kitty" ]; then
                     if [ ! -d "$NNN_PREVIEWDIR/$3" ]; then
                         mkdir -p "$NNN_PREVIEWDIR/$3"
@@ -336,11 +331,11 @@ generate_preview() {
                     return
                  fi ;;
             image) convert "$3" -flatten -resize "$NNN_PREVIEWWIDTH"x"$NNN_PREVIEWHEIGHT"\> "$NNN_PREVIEWDIR/$3.jpg" ;;
-            office) libreoffice --convert-to jpg "$3" --outdir "$NNN_PREVIEWDIR/${3%/*}" > /dev/null 2>&1
+            office) libreoffice --convert-to jpg "$3" --outdir "$NNN_PREVIEWDIR/${3%/*}"
                     filename="$(printf "%s" "${3##*/}" | cut -d. -f1)"
                     mv "$NNN_PREVIEWDIR/${3%/*}/$filename.jpg" "$NNN_PREVIEWDIR/$3.jpg" ;;
-            pdf) pdftoppm -jpeg -f 1 -singlefile "$3" "$NNN_PREVIEWDIR/$3" >/dev/null 2>&1 ;;
-            video) ffmpegthumbnailer -s0 -i "$3" -o "$NNN_PREVIEWDIR/$3.jpg" >/dev/null 2>&1 || rm "$NNN_PREVIEWDIR/$3.jpg" ;;
+            pdf) pdftoppm -jpeg -f 1 -singlefile "$3" "$NNN_PREVIEWDIR/$3" ;;
+            video) ffmpegthumbnailer -s0 -i "$3" -o "$NNN_PREVIEWDIR/$3.jpg" || rm "$NNN_PREVIEWDIR/$3.jpg" ;;
         esac
     fi
     if [ -f "$NNN_PREVIEWDIR/$3.jpg" ]; then
@@ -348,30 +343,27 @@ generate_preview() {
     else
         fifo_pager print_bin_info "$3"
     fi
-}
+} >/dev/null 2>&1
 
 image_preview() {
     clear
     if [ "$TERMINAL" = "kitty" ]; then
-        # Kitty terminal users can use the native image preview method although one might consider
-        # installing ueberzug and moving the ueberzug clause to the top since it performs alot better.
+        # Kitty terminal users can use the native image preview method
         kitty +kitten icat --silent --place "$1"x"$2"@0x0 --transfer-mode=stream --stdin=no "$3" &
-        printf "%s" "$!" > "$IMGPID"
     elif exists ueberzug; then
-        ueberzug_layer "$1" "$2" "$3"
+        ueberzug_layer "$1" "$2" "$3" && return
     elif exists catimg; then
         catimg "$3" &
-        printf "%s" "$!" > "$IMGPID"
     elif exists viu; then
         viu -t "$3" &
-        printf "%s" "$!" > "$IMGPID"
     else
-        fifo_pager print_bin_info "$3"
+        fifo_pager print_bin_info "$3" && return
     fi
-}
+    printf "%s" "$!" > "$IMGPID"
+} 2>/dev/null
 
 ueberzug_layer() {
-    printf '{"action": "add", "identifier": "nnn_ueberzug", "x": 0, "y": 0, "width": "%s", "height": "%s", "scaler": "fit_contain", "path": "%s"}\n' "$1" "$2" "$3" > "$FIFO_UEBERZUG"
+    printf '{"action": "add", "identifier": "nnn_ueberzug", "x": 0, "y": 0, "width": "%d", "height": "%d", "scaler": "fit_contain", "path": "%s"}\n' "$1" "$2" "$3" > "$FIFO_UEBERZUG"
 }
 
 ueberzug_remove() {
@@ -380,46 +372,40 @@ ueberzug_remove() {
 
 ueberzug_refresh() {
     clear
-    kill "$(cat "$IMGPID" 2>/dev/null)" >/dev/null 2>&1
-    pkill -P "$$" >/dev/null 2>&1
-    pkill -f -n preview-tui-ext >/dev/null 2>&1
+    kill "$(cat "$IMGPID")"
+    kill "$(cat "$PAGERPID")"
+    pkill -P "$$"
     tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
-    printf "\n" > "$NNN_FIFO"
-    preview_fifo 2>/dev/null &
+    cat "$CURSEL" > "$NNN_FIFO"
+    preview_fifo &
     preview_file "$(cat "$CURSEL")"
-    wait
-}
+    wait "$!"
+} 2>/dev/null
 
 preview_fifo() {
-    # use cat instead of 'exec <' to avoid issues with dash shell
-    # shellcheck disable=SC2002
-    cat "$NNN_FIFO" |\
+    printf "%s" "$$" > "$FIFOPID"
     while read -r selection; do
-        kill "$(cat "$IMGPID" 2>/dev/null)" >/dev/null 2>&1
-        kill "$(cat "$PAGERPID" 2>/dev/null)" >/dev/null 2>&1
+        kill "$(cat "$IMGPID")"
+        kill "$(cat "$PAGERPID")"
         [ "$TERMINAL" != "kitty" ] && exists ueberzug && ueberzug_remove
         preview_file "$selection"
         printf "%s" "$selection" > "$CURSEL"
-    done
-    kill "$(cat "$IMGPID" 2>/dev/null)" >/dev/null 2>&1
-    kill "$(cat "$PAGERPID" 2>/dev/null)" >/dev/null 2>&1
-    [ "$TERMINAL" != "kitty" ] && exists ueberzug && ueberzug_remove
-    rm "$PAGERPID" "$IMGPID" "$CURSEL" "$FIFO_UEBERZUG" >/dev/null 2>&1
-    pkill -P "$$" >/dev/null 2>&1
-}
+    done < "$NNN_FIFO"
+} 2>/dev/null
 
 if [ "$PREVIEW_MODE" ]; then
     if [ "$TERMINAL" != "kitty" ] && exists ueberzug; then
         mkfifo "$FIFO_UEBERZUG"
-        trap 'ueberzug_refresh; rm "$FIFO_UEBERZUG"' WINCH
+        trap 'ueberzug_refresh' WINCH
         tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
     fi
-    trap 'rm "$PAGERPID" "$IMGPID" "$CURSEL" "$FIFO_UEBERZUG" 2>/dev/null' INT HUP EXIT
 
+    printf "%s" "$PWD/$1" > "$CURSEL"
     preview_file "$PWD/$1"
-    printf "%s" "$PWD/$1" > "$CURSEL" &
-    preview_fifo 2>/dev/null &
-    wait
+    preview_fifo &
+    wait "$!"
+    rm "$PAGERPID" "$IMGPID" "$CURSEL" "$FIFO_UEBERZUG" "$FIFOPID" 2>/dev/null
+    pkill -P "$$"
 else
     if [ ! -r "$NNN_FIFO" ]; then
         clear
@@ -430,6 +416,6 @@ else
         printf "\$KITTY_LISTEN_ON not set!\nPlease read Usage in preview-tui-ext."
         cfg=$(stty -g); stty raw -echo; head -c 1; stty "$cfg"
     else
-        togglepreview "$1" &
+        toggle_preview "$1" &
     fi
 fi


### PR DESCRIPTION
Further cleanup of `preview-tui*`
- `start_preview()` `if/else` to `case`
- per-function redirection instead of per-command
- remove some code duplication in `preview_image()`
- `< "$NNN_FIFO"` instead of `cat` in `preview_fifo()` works fine in `dash` for me
- job control through `FIFOPID` tmpfile

Let me know if you want me to do a more detailed self review but If you're fine with merging for wider testing I wont bother.