### PR TITLE
Fix preview-tui zombie pager

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -307,8 +307,8 @@ if [ "$PREVIEW_MODE" ]; then
     preview_file "$PWD/$1"
     preview_fifo &
     wait "$!"
-    rm "$PAGERPID" "$IMGPID" "$CURSEL" "$FIFO_UEBERZUG" "$FIFOPID" 2>/dev/null
     pkill -P "$$"
+    rm "$PAGERPID" "$IMGPID" "$CURSEL" "$FIFO_UEBERZUG" "$FIFOPID" 2>/dev/null
 else
     if [ ! -r "$NNN_FIFO" ]; then
         clear

--- a/plugins/preview-tui-ext
+++ b/plugins/preview-tui-ext
@@ -404,8 +404,8 @@ if [ "$PREVIEW_MODE" ]; then
     preview_file "$PWD/$1"
     preview_fifo &
     wait "$!"
-    rm "$PAGERPID" "$IMGPID" "$CURSEL" "$FIFO_UEBERZUG" "$FIFOPID" 2>/dev/null
     pkill -P "$$"
+    rm "$PAGERPID" "$IMGPID" "$CURSEL" "$FIFO_UEBERZUG" "$FIFOPID" 2>/dev/null
 else
     if [ ! -r "$NNN_FIFO" ]; then
         clear


### PR DESCRIPTION
I can't explain the behavior I was seeing but ONLY when starting `nnn` with a command such as `st -c file tmux new-session -A -s nnn nnn -Pp` would result in a zombie `tmux` pane with an empty pager when closing `nnn` (Introduced by #1013).

Didn't happen when just manually starting `nnn` and toggling `preview-tui*` or even when starting with `preview-tui*` open with `nnn -Pp` in an existing `tmux` session. 

Even when the pager wasn't used for the previewed entry at all(e.g. `ICONLOOKUP` dir entry), it would open after exiting `nnn` and leave an empty `tmux` pane.

Anyhow swapping around the tmpfiles `rm` and `pkill` seems to fix it although I can't really explain why.