### PR TITLE
Preview-tui fixes

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -249,7 +249,7 @@ image_preview() {
     if [ "$TERMINAL" = "kitty" ]; then
         # Kitty terminal users can use the native image preview method
         kitty +kitten icat --silent --place "$1"x"$2"@0x0 --transfer-mode=stream --stdin=no "$3" &
-    elif [ -n "$QLPATH" ] && stat "$3" >/dev/null 2>&1; then
+    elif [ -n "$QLPATH" ] && stat "$3"; then
         f="$(wslpath -w "$3")" && "$QLPATH" "$f" && return
     elif exists ueberzug; then
         ueberzug_layer "$1" "$2" "$3" && return
@@ -271,24 +271,22 @@ ueberzug_remove() {
     printf '{"action": "remove", "identifier": "nnn_ueberzug"}\n' > "$FIFO_UEBERZUG"
 }
 
-ueberzug_refresh() {
+winch_handler() {
     clear
-    kill "$(cat "$IMGPID")"
-    kill "$(cat "$PAGERPID")"
+    kill "$(cat "$IMGPID")" "$(cat "$PAGERPID")"
     pkill -P "$$"
-    tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
+    if [ -p "$FIFO_UEBERZUG" ]; then tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json & fi
     cat "$CURSEL" > "$NNN_FIFO"
-    preview_fifo &
     preview_file "$(cat "$CURSEL")"
+    preview_fifo &
     wait "$!"
 } 2>/dev/null
 
 preview_fifo() {
     printf "%s" "$$" > "$FIFOPID"
     while read -r selection; do
-        kill "$(cat "$IMGPID")"
-        kill "$(cat "$PAGERPID")"
-        [ "$TERMINAL" != "kitty" ] && exists ueberzug && ueberzug_remove
+        kill "$(cat "$IMGPID")" "$(cat "$PAGERPID")"
+        [ -p "$FIFO_UEBERZUG" ] && ueberzug_remove
         preview_file "$selection"
         printf "%s" "$selection" > "$CURSEL"
     done < "$NNN_FIFO"
@@ -297,16 +295,15 @@ preview_fifo() {
 if [ "$PREVIEW_MODE" ]; then
     if [ "$TERMINAL" != "kitty" ] && exists ueberzug; then
         mkfifo "$FIFO_UEBERZUG"
-        trap 'ueberzug_refresh' WINCH
         tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
     fi
 
     printf "%s" "$PWD/$1" > "$CURSEL"
     preview_file "$PWD/$1"
     preview_fifo &
+    trap 'winch_handler' WINCH
+    trap 'rm "$PAGERPID" "$IMGPID" "$CURSEL" "$FIFO_UEBERZUG" "$FIFOPID" 2>/dev/null' INT HUP EXIT
     wait "$!" 2>/dev/null
-    pkill -P "$$"
-    rm "$PAGERPID" "$IMGPID" "$CURSEL" "$FIFO_UEBERZUG" "$FIFOPID" 2>/dev/null
 else
     if [ ! -r "$NNN_FIFO" ]; then
         clear

--- a/plugins/preview-tui-ext
+++ b/plugins/preview-tui-ext
@@ -313,7 +313,7 @@ generate_preview() {
             audio) ffmpeg -i "$3" -filter_complex "scale=iw*min(1\,min($NNN_PREVIEWWIDTH/iw\,ih)):-1" "$NNN_PREVIEWDIR/$3.jpg" -y ;;
             epub) gnome-epub-thumbnailer "$3" "$NNN_PREVIEWDIR/$3.jpg" ;;
             font) fontpreview -i "$3" -o "$NNN_PREVIEWDIR/$3.jpg" ;;
-            gif) if exists ueberzug && exists convert && [ "$TERMINAL" != "kitty" ]; then
+            gif) if [ -p "$FIFO_UEBERZUG" ] && exists convert; then
                     if [ ! -d "$NNN_PREVIEWDIR/$3" ]; then
                         mkdir -p "$NNN_PREVIEWDIR/$3"
                         convert -coalesce -resize "$NNN_PREVIEWWIDTH"x"$NNN_PREVIEWHEIGHT"\> "$3" "$NNN_PREVIEWDIR/$3/${3##*/}.jpg"
@@ -337,13 +337,13 @@ generate_preview() {
             pdf) pdftoppm -jpeg -f 1 -singlefile "$3" "$NNN_PREVIEWDIR/$3" ;;
             video) ffmpegthumbnailer -s0 -i "$3" -o "$NNN_PREVIEWDIR/$3.jpg" || rm "$NNN_PREVIEWDIR/$3.jpg" ;;
         esac
-    fi
+    fi >/dev/null
     if [ -f "$NNN_PREVIEWDIR/$3.jpg" ]; then
         image_preview "$1" "$2" "$NNN_PREVIEWDIR/$3.jpg"
     else
         fifo_pager print_bin_info "$3"
     fi
-} >/dev/null 2>&1
+} 2>/dev/null
 
 image_preview() {
     clear
@@ -370,24 +370,22 @@ ueberzug_remove() {
     printf '{"action": "remove", "identifier": "nnn_ueberzug"}\n' > "$FIFO_UEBERZUG"
 }
 
-ueberzug_refresh() {
+winch_handler() {
     clear
-    kill "$(cat "$IMGPID")"
-    kill "$(cat "$PAGERPID")"
+    kill "$(cat "$IMGPID")" "$(cat "$PAGERPID")"
     pkill -P "$$"
-    tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
+    if [ -p "$FIFO_UEBERZUG" ]; then tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json & fi
     cat "$CURSEL" > "$NNN_FIFO"
-    preview_fifo &
     preview_file "$(cat "$CURSEL")"
+    preview_fifo &
     wait "$!"
 } 2>/dev/null
 
 preview_fifo() {
     printf "%s" "$$" > "$FIFOPID"
     while read -r selection; do
-        kill "$(cat "$IMGPID")"
-        kill "$(cat "$PAGERPID")"
-        [ "$TERMINAL" != "kitty" ] && exists ueberzug && ueberzug_remove
+        kill "$(cat "$IMGPID")" "$(cat "$PAGERPID")"
+        [ -p "$FIFO_UEBERZUG" ] && ueberzug_remove
         preview_file "$selection"
         printf "%s" "$selection" > "$CURSEL"
     done < "$NNN_FIFO"
@@ -396,16 +394,15 @@ preview_fifo() {
 if [ "$PREVIEW_MODE" ]; then
     if [ "$TERMINAL" != "kitty" ] && exists ueberzug; then
         mkfifo "$FIFO_UEBERZUG"
-        trap 'ueberzug_refresh' WINCH
         tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
     fi
 
     printf "%s" "$PWD/$1" > "$CURSEL"
     preview_file "$PWD/$1"
     preview_fifo &
+    trap 'winch_handler' WINCH
+    trap 'rm "$PAGERPID" "$IMGPID" "$CURSEL" "$FIFO_UEBERZUG" "$FIFOPID" 2>/dev/null' INT HUP EXIT
     wait "$!" 2>/dev/null
-    pkill -P "$$"
-    rm "$PAGERPID" "$IMGPID" "$CURSEL" "$FIFO_UEBERZUG" "$FIFOPID" 2>/dev/null
 else
     if [ ! -r "$NNN_FIFO" ]; then
         clear


### PR DESCRIPTION
- Restore `viu/catimg` previews after regression in #1013 (was redirected to `/dev/null`)
- Handle `WINCH` for all image previewers, not just `ueberzug` 
- Reduce tests for `ueberzug` case by testing if named pipe `FIFO_UEBERZUG` exists
- Restore cleanup trap to remove tmpfiles when exiting `nnn` with <kbd>q</kbd>
