### PR TITLE
Preview-tui fix winch_handler

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -274,8 +274,10 @@ ueberzug_remove() {
 winch_handler() {
     clear
     kill "$(cat "$IMGPID")" "$(cat "$PAGERPID")"
-    pkill -P "$$"
-    if [ -p "$FIFO_UEBERZUG" ]; then tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json & fi
+    if [ -p "$FIFO_UEBERZUG" ];
+        pkill -P "$$"
+        then tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
+    fi
     cat "$CURSEL" > "$NNN_FIFO"
     preview_file "$(cat "$CURSEL")"
     preview_fifo &

--- a/plugins/preview-tui-ext
+++ b/plugins/preview-tui-ext
@@ -373,8 +373,10 @@ ueberzug_remove() {
 winch_handler() {
     clear
     kill "$(cat "$IMGPID")" "$(cat "$PAGERPID")"
-    pkill -P "$$"
-    if [ -p "$FIFO_UEBERZUG" ]; then tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json & fi
+    if [ -p "$FIFO_UEBERZUG" ];
+        pkill -P "$$"
+        then tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
+    fi
     cat "$CURSEL" > "$NNN_FIFO"
     preview_file "$(cat "$CURSEL")"
     preview_fifo &


### PR DESCRIPTION
`pkill` in `winch_handler()` should be exclusive to `ueberzug` case. Resizing for the non-`ueberzug` case was broken, this fixes that. Hard to test all these cases 😅