### PR TITLE
Fix preview-tui jpeg mime

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -197,7 +197,7 @@ print_bin_info() {
 
 handle_mime() {
     case "$2" in
-        image/jpg) image_preview "$cols" "$lines" "$1" ;;
+        image/jpeg) image_preview "$cols" "$lines" "$1" ;;
         image/gif) generate_preview "$cols" "$lines" "$1" "gif" ;;
         image/*) generate_preview "$cols" "$lines" "$1" "image" ;;
         video/*) generate_preview "$cols" "$lines" "$1" "video" ;;


### PR DESCRIPTION
Fix regression introduced in https://github.com/jarun/nnn/commit/bb37c9dd46216b261db6816b9159d82ba19d3002; don't generate previews for `jpeg` files as intended. You might want to clear out your `NNN_PREVIEWDIR` of `jpg` previews if it is not in `TMPDIR`. 

Should also prevent the recursive preview generation mentioned in https://github.com/jarun/nnn/issues/1022#issuecomment-851066265.