### PR TITLE
Unicode arrow indicators for O_ICONS/NERD

### DIFF
--- a/src/icons-nerdfont.h
+++ b/src/icons-nerdfont.h
@@ -4,6 +4,11 @@
 // You can find hex codes for nerd fonts here
 // https://www.nerdfonts.com/cheat-sheet
 
+// Arrows
+#define MD_ARROW_UPWARD    "\uf55c"
+#define MD_ARROW_FORWARD   "\uf553"
+#define MD_ARROW_DOWNWARD  "\uf544"
+
 // Generics
 #define ICON_DIRECTORY     "\ue5ff"
 #define ICON_FILE          "\uf713"

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -5781,7 +5781,11 @@ static void statusbar(char *path)
 
 			if (i > 1) { /* Show symlink target */
 				g_buf[i] = '\0';
+#ifdef ICONS_ENABLED
+				addstr(" "MD_ARROW_FORWARD);
+#else
 				addstr(" ->");
+#endif
 				addstr(g_buf);
 			}
 		} else {
@@ -5814,7 +5818,11 @@ static inline void markhovered(void)
 {
 	if (cfg.showdetail && ndents) { /* Reversed block for hovered entry */
 		tocursor();
+#ifdef ICONS_ENABLED
+		addstr(MD_ARROW_FORWARD);
+#else
 		addch(' ' | A_REVERSE);
+#endif
 	}
 }
 
@@ -5967,7 +5975,11 @@ static void redraw(char *path)
 	/* Go to first entry */
 	if (curscroll > 0) {
 		move(1, 0);
+#ifdef ICONS_ENABLED
+		addstr(MD_ARROW_UPWARD);
+#else
 		addch('^');
+#endif
 	}
 
 	if (g_state.oldcolor) {
@@ -5992,7 +6004,11 @@ static void redraw(char *path)
 	/* Go to last entry */
 	if (onscreen < ndents) {
 		move(xlines - 2, 0);
+#ifdef ICONS_ENABLED
+		addstr(MD_ARROW_DOWNWARD);
+#else
 		addch('v');
+#endif
 	}
 
 	markhovered();


### PR DESCRIPTION
Replace arrow indicators with unicode versions supplied by icons-in-terminal or nerd-font when compiled with `O_ICONS/NERD`.