### PR TITLE
Fix preview-tui zombie

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -380,6 +380,9 @@ winch_handler() {
         tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
     fi
     preview_file "$(cat "$CURSEL")"
+    if ! kill -0 "$NNN_PARENT" || ! pgrep nnn; then
+        pkill -P "$$"
+    fi
 } 2>/dev/null
 
 preview_fifo() {


### PR DESCRIPTION
Again found a case that was not covered by the new job control in #1051🤦🏻‍♂️ 
When starting `nnn` in an existing `tmux` session, the process tree looks like
```
├─tmux: server─┬─nnn
│              ├─sh─┬─sh
│              │    ├─tail
│              │    └─ueberzug───2*[{ueberzug}]
```
By contrast starting `nnn` with a command such as `st tmux new-session nnn -Pp` it looks like
```
├─tmux: server─┬─sh─┬─sh
│              │    ├─tail
│              │    └─ueberzug───2*[{ueberzug}]
│              └─zsh───nnn
```
This left the preview fifo running when exiting `nnn`.

This PR fixes it but only when using `nnn -a`, `NNN_FIFO=/tmp/nnn.fifo nnn` is not covered by this fix. Couldn't think of anything else though.