### PR TITLE
Remove opinionated options

### DIFF
--- a/plugins/fzopen
+++ b/plugins/fzopen
@@ -26,7 +26,7 @@ if type fzf >/dev/null 2>&1; then
     else
         [ -z "$cmd" ] && cmd="find . -type f 2>/dev/null"
     fi
-    entry="$(eval "$cmd" | fzf -m --delimiter / --nth=-1 --tiebreak=begin --info=hidden)"
+    entry="$(eval "$cmd" | fzf -m)"
     # To show only the file name
     # entry=$(find . -type f 2>/dev/null | fzf --delimiter / --with-nth=-1 --tiebreak=begin --info=hidden)
 elif type sk >/dev/null 2>&1; then


### PR DESCRIPTION
The file picker becomes close to useless for me when used in a large enough project since I can only match against the file name, not the entire path. I think we can assume the majority of people wants multi selection, so this is set by default.

If one is interested in using other options, they can set `$FZF_DEFAULT_OPTS` accordingly.