### PR TITLE
File-explorer functionality

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -6428,7 +6428,7 @@ nochange:
 			if (g_state.picker && sel == SEL_OPEN) {
 				appendfpath(newpath, mkpath(path, pent->name, newpath));
 				// do not exit if in explorer mode
-				if (explorer) {
+				if (g_state.explorer) {
 					// add a newline to the file to make it easier to parse `tail -F`
 					strcat(pselbuf, "\n");
 					appendsel(pselbuf, selbufpos);
@@ -7817,7 +7817,7 @@ int main(int argc, char *argv[])
 
 	while ((opt = (env_opts_id > 0
 		       ? env_opts[--env_opts_id]
-		       : getopt(argc, argv, "aAb:cCdDeEfgHJKl:nop:P:QrRs:St:T:uUVwxh"))) != -1) {
+		       : getopt(argc, argv, "aAb:cCdDeEfFgHJKl:nop:P:QrRs:St:T:uUVwxh"))) != -1) {
 		switch (opt) {
 #ifndef NOFIFO
 		case 'a':
@@ -7853,6 +7853,9 @@ int main(int argc, char *argv[])
 #ifndef NORL
 			rlhist = TRUE;
 #endif
+			break;
+		case 'F':
+		  	g_state.explorer = 1;
 			break;
 		case 'g':
 			cfg.regex = 1;
@@ -8221,7 +8224,7 @@ int main(int argc, char *argv[])
 		if (selbufpos) {
 			fd = selpath ? open(selpath, O_WRONLY | O_CREAT, 0600) : STDOUT_FILENO;
 			// HACK: don't send seltofile if in explorer mode
-			if (!explorer && ((fd == -1) || (seltofile(fd, NULL) != (size_t)(selbufpos))))
+			if (!g_state.explorer && ((fd == -1) || (seltofile(fd, NULL) != (size_t)(selbufpos))))
 				xerror();
 
 			if (fd > 1)

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -339,6 +339,7 @@ typedef struct {
 	uint_t dirctx     : 1;  /* Show dirs in context color */
 	uint_t uidgid     : 1;  /* Show owner and group info */
 	uint_t prstssn    : 1;  /* Persistent session */
+	uint_t explorer   : 1;  /* Explorer mode: don't exit after selection is opened */
 	uint_t duinit     : 1;  /* Initialize disk usage */
 	uint_t reserved   : 8;  /* Adjust when adding/removing a field */
 } runstate;

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -6430,16 +6430,16 @@ nochange:
 				// do not exit if in explorer mode
 				if (g_state.explorer) {
 					// add a newline to the file to make it easier to parse `tail -F`
-					strcat(pselbuf, "\n");
+					strlcat(pselbuf, "\n", selbufpos + 2);
 					appendsel(pselbuf, selbufpos);
 					selbufpos = 0;
 					// is this necessary?
 					/* pselbuf[0] = '\0'; */
 					break;
-				} else {
-					writesel(pselbuf, selbufpos - 1);
-					return EXIT_SUCCESS;
 				}
+
+				writesel(pselbuf, selbufpos - 1);
+				return EXIT_SUCCESS;
 			}
 
 			if (sel == SEL_NAV_IN) {

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -1393,6 +1393,21 @@ static void writesel(const char *buf, const size_t buflen)
 		printwarn(NULL);
 }
 
+static void appendsel(const char *buf, const size_t buflen)
+{
+	if (!selpath)
+		return;
+
+	FILE *fp = fopen(selpath, "a");
+
+	if (fp) {
+		if (fwrite(buf, 1, buflen, fp) != buflen)
+			printwarn(NULL);
+		fclose(fp);
+	} else
+		printwarn(NULL);
+}
+
 static void appendfpath(const char *path, const size_t len)
 {
 	if ((selbufpos >= selbuflen) || ((len + 3) > (selbuflen - selbufpos))) {

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -6433,8 +6433,8 @@ nochange:
 					strcat(pselbuf, "\n");
 					appendsel(pselbuf, selbufpos);
 					selbufpos = 0;
-				        // is this necessary?
-				        /* pselbuf[0] = '\0'; */
+					// is this necessary?
+					/* pselbuf[0] = '\0'; */
 					break;
 				} else {
 					writesel(pselbuf, selbufpos - 1);

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -6429,7 +6429,10 @@ nochange:
 				appendfpath(newpath, mkpath(path, pent->name, newpath));
 				// add a newline to the file to make it easier to parse `tail -F`
 				strcat(pselbuf, "\n");
-				writesel(pselbuf, selbufpos);
+				appendsel(pselbuf, selbufpos);
+				selbufpos = 0;
+				// is this necessary?
+				/* pselbuf[0] = '\0'; */
 				break;
 			}
 

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -8195,8 +8195,9 @@ int main(int argc, char *argv[])
 	if (g_state.picker) {
 		if (selbufpos) {
 			fd = selpath ? open(selpath, O_WRONLY | O_CREAT, 0600) : STDOUT_FILENO;
-			if ((fd == -1) || (seltofile(fd, NULL) != (size_t)(selbufpos)))
-				xerror();
+			// HACK: don't send seltofile
+			// if ((fd == -1) || (seltofile(fd, NULL) != (size_t)(selbufpos)))
+			// 	xerror();
 
 			if (fd > 1)
 				close(fd);

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -6430,7 +6430,7 @@ nochange:
 				// do not exit if in explorer mode
 				if (g_state.explorer) {
 					// add a newline to the file to make it easier to parse `tail -F`
-					strlcat(pselbuf, "\n", selbufpos + 2);
+					appendfpath("\n", 2);
 					appendsel(pselbuf, selbufpos);
 					selbufpos = 0;
 					// is this necessary?

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -6411,8 +6411,10 @@ nochange:
 			/* If opened as vim plugin and Enter/^M pressed, pick */
 			if (g_state.picker && sel == SEL_OPEN) {
 				appendfpath(newpath, mkpath(path, pent->name, newpath));
-				writesel(pselbuf, selbufpos - 1);
-				return EXIT_SUCCESS;
+				// add a newline to the file to make it easier to parse `tail -F`
+				strcat(pselbuf, "\n");
+				writesel(pselbuf, selbufpos);
+				break;
 			}
 
 			if (sel == SEL_NAV_IN) {

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -6427,13 +6427,19 @@ nochange:
 			/* If opened as vim plugin and Enter/^M pressed, pick */
 			if (g_state.picker && sel == SEL_OPEN) {
 				appendfpath(newpath, mkpath(path, pent->name, newpath));
-				// add a newline to the file to make it easier to parse `tail -F`
-				strcat(pselbuf, "\n");
-				appendsel(pselbuf, selbufpos);
-				selbufpos = 0;
-				// is this necessary?
-				/* pselbuf[0] = '\0'; */
-				break;
+				// do not exit if in explorer mode
+				if (explorer) {
+					// add a newline to the file to make it easier to parse `tail -F`
+					strcat(pselbuf, "\n");
+					appendsel(pselbuf, selbufpos);
+					selbufpos = 0;
+				        // is this necessary?
+				        /* pselbuf[0] = '\0'; */
+					break;
+				} else {
+					writesel(pselbuf, selbufpos - 1);
+					return EXIT_SUCCESS;
+				}
 			}
 
 			if (sel == SEL_NAV_IN) {

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -8214,9 +8214,9 @@ int main(int argc, char *argv[])
 	if (g_state.picker) {
 		if (selbufpos) {
 			fd = selpath ? open(selpath, O_WRONLY | O_CREAT, 0600) : STDOUT_FILENO;
-			// HACK: don't send seltofile
-			// if ((fd == -1) || (seltofile(fd, NULL) != (size_t)(selbufpos)))
-			// 	xerror();
+			// HACK: don't send seltofile if in explorer mode
+			if (!explorer && ((fd == -1) || (seltofile(fd, NULL) != (size_t)(selbufpos))))
+				xerror();
 
 			if (fd > 1)
 				close(fd);


### PR DESCRIPTION
Adds flag `-F` that prevents nnn from exiting on selection. This uses the path given to `-p` and will append to the output on each selection.

I'm not exactly aware of what `seltofile` does but it was getting in the way so I commented it out. I am not that great at C so please point out if I'm doing anything incorrectly here.