### PR TITLE
Update gitstatus patch

### DIFF
--- a/patches/gitstatus/mainline.diff
+++ b/patches/gitstatus/mainline.diff
@@ -8,7 +8,7 @@
 # Authors: @crides, Luuk van Baal
 
 diff --git a/src/nnn.c b/src/nnn.c
-index 402d905..e10035b 100644
+index 67523fe6..c965bd1c 100644
 --- a/src/nnn.c
 +++ b/src/nnn.c
 @@ -105,6 +105,7 @@
@@ -19,33 +19,15 @@ index 402d905..e10035b 100644
 
  #if !defined(alloca) && defined(__GNUC__)
  /*
-@@ -244,6 +245,16 @@ typedef unsigned int uint_t;
- typedef unsigned char uchar_t;
- typedef unsigned short ushort_t;
- typedef unsigned long long ulong_t;
-+typedef enum {
-+	GIT_COLUMN_STATUS_UNMOD = 0,
-+	GIT_COLUMN_STATUS_NEW,
-+	GIT_COLUMN_STATUS_MODIFIED,
-+	GIT_COLUMN_STATUS_DELETED,
-+	GIT_COLUMN_STATUS_RENAMED,
-+	GIT_COLUMN_STATUS_TYPE_CHANGE,
-+	GIT_COLUMN_STATUS_IGNORED,
-+	GIT_COLUMN_STATUS_CONFLICTED,
-+} git_column_status_t;
-
- /* STRUCTURES */
-
-@@ -263,6 +274,8 @@ typedef struct entry {
+@@ -265,6 +266,7 @@ typedef struct entry {
  	uid_t uid; /* 4 bytes */
  	gid_t gid; /* 4 bytes */
  #endif
-+	git_column_status_t status_indexed;
-+	git_column_status_t status_staged;
++	git_status_t git_status;
  } *pEntry;
 
  /* Key-value pairs from env */
-@@ -313,6 +326,7 @@ typedef struct {
+@@ -315,6 +317,7 @@ typedef struct {
  	uint_t cliopener  : 1;  /* All-CLI app opener */
  	uint_t waitedit   : 1;  /* For ops that can't be detached, used EDITOR */
  	uint_t rollover   : 1;  /* Roll over at edges */
@@ -53,7 +35,7 @@ index 402d905..e10035b 100644
  } settings;
 
  /* Non-persistent program-internal states */
-@@ -362,7 +376,18 @@ typedef struct {
+@@ -363,7 +366,19 @@ typedef struct {
  } session_header_t;
  #endif
 
@@ -65,6 +47,7 @@ index 402d905..e10035b 100644
 +typedef struct {
 +	simple_git_status_t *statuses;
 +	size_t len;
++	bool show;
 +} simple_git_statuses_t;
 +
  /* GLOBALS */
@@ -72,7 +55,7 @@ index 402d905..e10035b 100644
 
  /* Configuration, contexts */
  static settings cfg = {
-@@ -393,6 +418,7 @@ static settings cfg = {
+@@ -394,6 +409,7 @@ static settings cfg = {
  	0, /* cliopener */
  	0, /* waitedit */
  	1, /* rollover */
@@ -80,41 +63,26 @@ index 402d905..e10035b 100644
  };
 
  static context g_ctx[CTX_MAX] __attribute__ ((aligned));
-@@ -3464,6 +3490,80 @@ static char *get_kv_val(kv *kvarr, char *buf, int key, uchar_t max, uchar_t id)
+@@ -3498,6 +3514,66 @@ static char *get_kv_val(kv *kvarr, char *buf, int key, uchar_t max, uchar_t id)
  	return NULL;
  }
 
-+static git_column_status_t git_get_indexed_status(const uint32_t status) {
-+	if (status & GIT_STATUS_INDEX_NEW)         return GIT_COLUMN_STATUS_NEW;
-+	if (status & GIT_STATUS_INDEX_MODIFIED)    return GIT_COLUMN_STATUS_MODIFIED;
-+	if (status & GIT_STATUS_INDEX_DELETED)     return GIT_COLUMN_STATUS_DELETED;
-+	if (status & GIT_STATUS_INDEX_RENAMED)     return GIT_COLUMN_STATUS_RENAMED;
-+	if (status & GIT_STATUS_INDEX_TYPECHANGE)  return GIT_COLUMN_STATUS_TYPE_CHANGE;
-+	return GIT_COLUMN_STATUS_UNMOD;
-+}
++static void print_gitstatus(git_status_t status) {
++	if (status & GIT_STATUS_INDEX_NEW)             addch('N' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(C_EXE)));
++	else if (status & GIT_STATUS_INDEX_MODIFIED)   addch('M' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(4)));
++	else if (status & GIT_STATUS_INDEX_DELETED)    addch('D' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(C_UND)));
++	else if (status & GIT_STATUS_INDEX_RENAMED)    addch('R' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(C_CHR)));
++	else if (status & GIT_STATUS_INDEX_TYPECHANGE) addch('T' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(C_HRD)));
++	else                                           addch('-' | 0);
 +
-+static git_column_status_t git_get_staged_status(const uint32_t status) {
-+	if (status & GIT_STATUS_WT_NEW)         return GIT_COLUMN_STATUS_NEW;
-+	if (status & GIT_STATUS_WT_MODIFIED)    return GIT_COLUMN_STATUS_MODIFIED;
-+	if (status & GIT_STATUS_WT_DELETED)     return GIT_COLUMN_STATUS_DELETED;
-+	if (status & GIT_STATUS_WT_RENAMED)     return GIT_COLUMN_STATUS_RENAMED;
-+	if (status & GIT_STATUS_WT_TYPECHANGE)  return GIT_COLUMN_STATUS_TYPE_CHANGE;
-+	if (status & GIT_STATUS_IGNORED)        return GIT_COLUMN_STATUS_IGNORED;
-+	if (status & GIT_STATUS_CONFLICTED)     return GIT_COLUMN_STATUS_CONFLICTED;
-+	return GIT_COLUMN_STATUS_UNMOD;
-+}
-+
-+static void print_gitstatus(git_column_status_t status) {
-+	switch (status) {
-+		case GIT_COLUMN_STATUS_UNMOD:        addch('-' | 0); break;
-+		case GIT_COLUMN_STATUS_NEW:          addch('N' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(C_EXE))); break;
-+		case GIT_COLUMN_STATUS_MODIFIED:     addch('M' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(4))); break;
-+		case GIT_COLUMN_STATUS_DELETED:      addch('D' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(C_UND))); break;
-+		case GIT_COLUMN_STATUS_RENAMED:      addch('R' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(C_CHR))); break;
-+		case GIT_COLUMN_STATUS_TYPE_CHANGE:  addch('T' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(C_HRD))); break;
-+		case GIT_COLUMN_STATUS_IGNORED:      addch('I' | 0); break;
-+		case GIT_COLUMN_STATUS_CONFLICTED:   addch('U' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(C_UND))); break;
-+	}
++	if (status & GIT_STATUS_WT_NEW)             addch('N' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(C_EXE)));
++	else if (status & GIT_STATUS_WT_MODIFIED)   addch('M' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(4)));
++	else if (status & GIT_STATUS_WT_DELETED)    addch('D' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(C_UND)));
++	else if (status & GIT_STATUS_WT_RENAMED)    addch('R' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(C_CHR)));
++	else if (status & GIT_STATUS_WT_TYPECHANGE) addch('T' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(C_HRD)));
++	else if (status & GIT_STATUS_IGNORED)       addch('I' | 0);
++	else if (status & GIT_STATUS_CONFLICTED)    addch('U' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(C_UND)));
++	else                                        addch('-' | 0);
 +}
 +
 +static simple_git_statuses_t statuses_from_path(const char *path) {
@@ -156,26 +124,26 @@ index 402d905..e10035b 100644
 +
 +	free(git_statuses.statuses);
 +	git_statuses.len = 0;
++	git_statuses.show = FALSE;
 +}
 +
  static void resetdircolor(int flags)
  {
  	/* Directories are always shown on top, clear the color when moving to first file */
-@@ -3800,6 +3900,13 @@ static void printent(const struct entry *ent, uint_t namecols, bool sel)
+@@ -3835,6 +3911,12 @@ static void printent(const struct entry *ent, uint_t namecols, bool sel)
 
  	uchar_t color_pair = get_color_pair_name_ind(ent, &ind, &attrs);
 
-+	if (git_statuses.len && (cfg.showdetail || cfg.normalgit)) {
++	if (git_statuses.show && (cfg.showdetail || cfg.normalgit)) {
 +		if (cfg.normalgit && !cfg.showdetail)
 +			addch(' ');
-+		print_gitstatus(ent->status_indexed);
-+		print_gitstatus(ent->status_staged);
++		print_gitstatus(ent->git_status);
 +	}
 +
  	addch((ent->flags & FILE_SELECTED) ? '+' | A_REVERSE | A_BOLD : ' ');
 
  	if (g_state.oldcolor)
-@@ -5119,6 +5226,10 @@ static int dentfill(char *path, struct entry **ppdents)
+@@ -5160,6 +5242,10 @@ static int dentfill(char *path, struct entry **ppdents)
  		attron(COLOR_PAIR(cfg.curctx + 1));
  	}
 
@@ -186,30 +154,31 @@ index 402d905..e10035b 100644
  #if _POSIX_C_SOURCE >= 200112L
  	posix_fadvise(fd, 0, 0, POSIX_FADV_SEQUENTIAL);
  #endif
-@@ -5316,6 +5427,22 @@ static int dentfill(char *path, struct entry **ppdents)
+@@ -5357,6 +5443,23 @@ static int dentfill(char *path, struct entry **ppdents)
  #endif
  		}
 
 +		if (git_statuses.len) {
 +			char *dentpath = abspath(dentp->name, path);
 +			namebuflen = xstrlen(dentpath);
-+			uint merged_status = 0;
++			dentp->git_status = GIT_STATUS_CURRENT;
 +
 +			for (size_t i = 0; i < git_statuses.len; ++i)
-+				if (!(dentp->flags & DIR_OR_LINK_TO_DIR) ? !xstrcmp(git_statuses.statuses[i].path, dentpath) :
-+						(is_prefix(git_statuses.statuses[i].path, dentpath, namebuflen) &&
-+						(namebuflen <= xstrlen(git_statuses.statuses[i].path))))
-+					merged_status |= git_statuses.statuses[i].status;
++				if (git_statuses.statuses[i].status)
++					if ((dentp->flags & DIR_OR_LINK_TO_DIR) ? (is_prefix(git_statuses.statuses[i].path, dentpath, namebuflen) &&
++							namebuflen <= xstrlen(git_statuses.statuses[i].path)) : !xstrcmp(git_statuses.statuses[i].path, dentpath)) {
++						if (git_statuses.statuses[i].status != GIT_STATUS_IGNORED)
++							git_statuses.show = TRUE;
++						dentp->git_status |= git_statuses.statuses[i].status;
++					}
 +
-+			dentp->status_indexed = git_get_indexed_status(merged_status);
-+			dentp->status_staged = git_get_staged_status(merged_status);
 +			free(dentpath);
 +		}
 +
  		++ndents;
  	} while ((dp = readdir(dirp)));
 
-@@ -5834,16 +5961,16 @@ static int adjust_cols(int n)
+@@ -5873,16 +5976,16 @@ static int adjust_cols(int n)
  #endif
  	if (cfg.showdetail) {
  		/* Fallback to light mode if less than 35 columns */
@@ -219,25 +188,25 @@ index 402d905..e10035b 100644
  		else {
  			/* 2 more accounted for below */
 -			n -= 32;
-+			n -= 34;
++			n -= (git_statuses.show ? 34 : 32);
  		}
  	}
 
  	/* 2 columns for preceding space and indicator */
 -	return (n - 2);
-+	return (n - ((cfg.normalgit && !cfg.showdetail) ? 5 : 2));
++	return (n - ((git_statuses.show && (cfg.normalgit && !cfg.showdetail)) ? 5 : 2));
  }
 
  static void draw_line(char *path, int ncols)
-@@ -7574,6 +7701,7 @@ static void usage(void)
+@@ -7608,6 +7711,7 @@ static void usage(void)
+ 		" -f      use readline history file\n"
  #endif
- 		" -F      show fortune\n"
  		" -g      regex filters\n"
 +		" -G      always show git status\n"
  		" -H      show hidden files\n"
  		" -J      no auto-proceed on select\n"
  		" -K      detect key collision\n"
-@@ -7712,6 +7840,8 @@ static void cleanup(void)
+@@ -7746,6 +7850,8 @@ static void cleanup(void)
  		fflush(stdout);
  	}
  #endif
@@ -246,16 +215,16 @@ index 402d905..e10035b 100644
  	free(selpath);
  	free(plgpath);
  	free(cfgpath);
-@@ -7756,7 +7886,7 @@ int main(int argc, char *argv[])
+@@ -7790,7 +7896,7 @@ int main(int argc, char *argv[])
 
  	while ((opt = (env_opts_id > 0
  		       ? env_opts[--env_opts_id]
--		       : getopt(argc, argv, "aAb:cCdDeEfgHJKl:nop:P:QrRs:St:T:uUVwxh"))) != -1) {
-+		       : getopt(argc, argv, "aAb:cCdDeEfgGHJKl:nop:P:QrRs:St:T:uUVwxh"))) != -1) {
+-		       : getopt(argc, argv, "aAb:cCdDeEfgHJKl:nop:P:QrRs:St:T:uUVwxX:h"))) != -1) {
++		       : getopt(argc, argv, "aAb:cCdDeEfgGHJKl:nop:P:QrRs:St:T:uUVwxX:h"))) != -1) {
  		switch (opt) {
  #ifndef NOFIFO
  		case 'a':
-@@ -7800,6 +7930,9 @@ int main(int argc, char *argv[])
+@@ -7831,6 +7937,9 @@ int main(int argc, char *argv[])
  			cfg.regex = 1;
  			filterfn = &visible_re;
  			break;
@@ -265,7 +234,7 @@ index 402d905..e10035b 100644
  		case 'H':
  			cfg.showhidden = 1;
  			break;
-@@ -7907,6 +8040,7 @@ int main(int argc, char *argv[])
+@@ -7938,6 +8047,7 @@ int main(int argc, char *argv[])
  		return EXIT_FAILURE;
 
  	atexit(cleanup);

--- a/patches/gitstatus/namefirst.diff
+++ b/patches/gitstatus/namefirst.diff
@@ -10,7 +10,7 @@
 # Authors: @crides, Luuk van Baal
 
 diff --git a/src/nnn.c b/src/nnn.c
-index 9141d78..de4d9f0 100644
+index b8b222d4..80ef884f 100644
 --- a/src/nnn.c
 +++ b/src/nnn.c
 @@ -105,6 +105,7 @@
@@ -21,33 +21,15 @@ index 9141d78..de4d9f0 100644
 
  #if !defined(alloca) && defined(__GNUC__)
  /*
-@@ -244,6 +245,16 @@ typedef unsigned int uint_t;
- typedef unsigned char uchar_t;
- typedef unsigned short ushort_t;
- typedef unsigned long long ulong_t;
-+typedef enum {
-+	GIT_COLUMN_STATUS_UNMOD = 0,
-+	GIT_COLUMN_STATUS_NEW,
-+	GIT_COLUMN_STATUS_MODIFIED,
-+	GIT_COLUMN_STATUS_DELETED,
-+	GIT_COLUMN_STATUS_RENAMED,
-+	GIT_COLUMN_STATUS_TYPE_CHANGE,
-+	GIT_COLUMN_STATUS_IGNORED,
-+	GIT_COLUMN_STATUS_CONFLICTED,
-+} git_column_status_t;
-
- /* STRUCTURES */
-
-@@ -262,6 +273,8 @@ typedef struct entry {
- #ifndef NOUG
+@@ -265,6 +266,7 @@ typedef struct entry {
  	uid_t uid; /* 4 bytes */
  	gid_t gid; /* 4 bytes */
-+	git_column_status_t status_indexed;
-+	git_column_status_t status_staged;
  #endif
++	git_status_t git_status;
  } *pEntry;
 
-@@ -313,6 +326,7 @@ typedef struct {
+ /* Key-value pairs from env */
+@@ -315,6 +317,7 @@ typedef struct {
  	uint_t cliopener  : 1;  /* All-CLI app opener */
  	uint_t waitedit   : 1;  /* For ops that can't be detached, used EDITOR */
  	uint_t rollover   : 1;  /* Roll over at edges */
@@ -55,7 +37,7 @@ index 9141d78..de4d9f0 100644
  } settings;
 
  /* Non-persistent program-internal states */
-@@ -366,7 +380,18 @@ static struct {
+@@ -367,7 +370,19 @@ static struct {
  	ushort_t maxnameln, maxsizeln, maxuidln, maxgidln, maxentln, uidln, gidln, printguid;
  } dtls;
 
@@ -67,6 +49,7 @@ index 9141d78..de4d9f0 100644
 +typedef struct {
 +	simple_git_status_t *statuses;
 +	size_t len;
++	bool show;
 +} simple_git_statuses_t;
 +
  /* GLOBALS */
@@ -74,7 +57,7 @@ index 9141d78..de4d9f0 100644
 
  /* Configuration, contexts */
  static settings cfg = {
-@@ -397,6 +422,7 @@ static settings cfg = {
+@@ -398,6 +413,7 @@ static settings cfg = {
  	0, /* cliopener */
  	0, /* waitedit */
  	1, /* rollover */
@@ -82,41 +65,26 @@ index 9141d78..de4d9f0 100644
  };
 
  static context g_ctx[CTX_MAX] __attribute__ ((aligned));
-@@ -3472,6 +3498,79 @@ static char *get_kv_val(kv *kvarr, char *buf, int key, uchar_t max, uchar_t id)
+@@ -3506,6 +3522,66 @@ static char *get_kv_val(kv *kvarr, char *buf, int key, uchar_t max, uchar_t id)
  	return NULL;
  }
 
-+static git_column_status_t git_get_indexed_status(const uint32_t status) {
-+	if (status & GIT_STATUS_INDEX_NEW)         return GIT_COLUMN_STATUS_NEW;
-+	if (status & GIT_STATUS_INDEX_MODIFIED)    return GIT_COLUMN_STATUS_MODIFIED;
-+	if (status & GIT_STATUS_INDEX_DELETED)     return GIT_COLUMN_STATUS_DELETED;
-+	if (status & GIT_STATUS_INDEX_RENAMED)     return GIT_COLUMN_STATUS_RENAMED;
-+	if (status & GIT_STATUS_INDEX_TYPECHANGE)  return GIT_COLUMN_STATUS_TYPE_CHANGE;
-+	return GIT_COLUMN_STATUS_UNMOD;
-+}
++static void print_gitstatus(git_status_t status) {
++	if (status & GIT_STATUS_INDEX_NEW)             addch('N' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(C_EXE)));
++	else if (status & GIT_STATUS_INDEX_MODIFIED)   addch('M' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(4)));
++	else if (status & GIT_STATUS_INDEX_DELETED)    addch('D' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(C_UND)));
++	else if (status & GIT_STATUS_INDEX_RENAMED)    addch('R' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(C_CHR)));
++	else if (status & GIT_STATUS_INDEX_TYPECHANGE) addch('T' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(C_HRD)));
++	else                                           addch('-' | 0);
 +
-+static git_column_status_t git_get_staged_status(const uint32_t status) {
-+	if (status & GIT_STATUS_WT_NEW)         return GIT_COLUMN_STATUS_NEW;
-+	if (status & GIT_STATUS_WT_MODIFIED)    return GIT_COLUMN_STATUS_MODIFIED;
-+	if (status & GIT_STATUS_WT_DELETED)     return GIT_COLUMN_STATUS_DELETED;
-+	if (status & GIT_STATUS_WT_RENAMED)     return GIT_COLUMN_STATUS_RENAMED;
-+	if (status & GIT_STATUS_WT_TYPECHANGE)  return GIT_COLUMN_STATUS_TYPE_CHANGE;
-+	if (status & GIT_STATUS_IGNORED)        return GIT_COLUMN_STATUS_IGNORED;
-+	if (status & GIT_STATUS_CONFLICTED)     return GIT_COLUMN_STATUS_CONFLICTED;
-+	return GIT_COLUMN_STATUS_UNMOD;
-+}
-+
-+static void print_gitstatus(git_column_status_t status) {
-+	switch (status) {
-+		case GIT_COLUMN_STATUS_UNMOD:        addch('-' | 0); break;
-+		case GIT_COLUMN_STATUS_NEW:          addch('N' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(C_EXE))); break;
-+		case GIT_COLUMN_STATUS_MODIFIED:     addch('M' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(4))); break;
-+		case GIT_COLUMN_STATUS_DELETED:      addch('D' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(C_UND))); break;
-+		case GIT_COLUMN_STATUS_RENAMED:      addch('R' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(C_CHR))); break;
-+		case GIT_COLUMN_STATUS_TYPE_CHANGE:  addch('T' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(C_HRD))); break;
-+		case GIT_COLUMN_STATUS_IGNORED:      addch('I' | 0); break;
-+		case GIT_COLUMN_STATUS_CONFLICTED:   addch('U' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(C_UND))); break;
-+	}
++	if (status & GIT_STATUS_WT_NEW)             addch('N' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(C_EXE)));
++	else if (status & GIT_STATUS_WT_MODIFIED)   addch('M' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(4)));
++	else if (status & GIT_STATUS_WT_DELETED)    addch('D' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(C_UND)));
++	else if (status & GIT_STATUS_WT_RENAMED)    addch('R' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(C_CHR)));
++	else if (status & GIT_STATUS_WT_TYPECHANGE) addch('T' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(C_HRD)));
++	else if (status & GIT_STATUS_IGNORED)       addch('I' | 0);
++	else if (status & GIT_STATUS_CONFLICTED)    addch('U' | (g_state.oldcolor ? COLOR_PAIR(1) : COLOR_PAIR(C_UND)));
++	else                                        addch('-' | 0);
 +}
 +
 +static simple_git_statuses_t statuses_from_path(const char *path) {
@@ -157,25 +125,26 @@ index 9141d78..de4d9f0 100644
 +		free(git_statuses.statuses[i].path);
 +
 +	free(git_statuses.statuses);
++	git_statuses.len = 0;
++	git_statuses.show = FALSE;
 +}
 +
  static void resetdircolor(int flags)
  {
  	/* Directories are always shown on top, clear the color when moving to first file */
-@@ -3781,6 +3880,12 @@ static void printent(const struct entry *ent, uint_t namecols, bool sel)
+@@ -3816,6 +3892,11 @@ static void printent(const struct entry *ent, uint_t namecols, bool sel)
  	int attrs = 0, namelen;
  	uchar_t color_pair = get_color_pair_name_ind(ent, &ind, &attrs);
 
-+	if (git_statuses.len && (cfg.showdetail || cfg.normalgit)) {
++	if (git_statuses.show && (cfg.showdetail || cfg.normalgit)) {
 +		addch(' ');
-+		print_gitstatus(ent->status_indexed);
-+		print_gitstatus(ent->status_staged);
++		print_gitstatus(ent->git_status);
 +	}
 +
  	addch((ent->flags & FILE_SELECTED) ? '+' | A_REVERSE | A_BOLD : ' ');
 
  	if (g_state.oldcolor)
-@@ -5125,6 +5230,10 @@ static int dentfill(char *path, struct entry **ppdents)
+@@ -5166,6 +5247,10 @@ static int dentfill(char *path, struct entry **ppdents)
  		attron(COLOR_PAIR(cfg.curctx + 1));
  	}
 
@@ -186,56 +155,57 @@ index 9141d78..de4d9f0 100644
  #if _POSIX_C_SOURCE >= 200112L
  	posix_fadvise(fd, 0, 0, POSIX_FADV_SEQUENTIAL);
  #endif
-@@ -5322,6 +5431,22 @@ static int dentfill(char *path, struct entry **ppdents)
+@@ -5363,6 +5448,23 @@ static int dentfill(char *path, struct entry **ppdents)
  #endif
  		}
 
 +		if (git_statuses.len) {
 +			char *dentpath = abspath(dentp->name, path);
 +			namebuflen = xstrlen(dentpath);
-+			uint merged_status = 0;
++			dentp->git_status = GIT_STATUS_CURRENT;
 +
 +			for (size_t i = 0; i < git_statuses.len; ++i)
-+				if (!(dentp->flags & DIR_OR_LINK_TO_DIR) ? !xstrcmp(git_statuses.statuses[i].path, dentpath) :
-+						(is_prefix(git_statuses.statuses[i].path, dentpath, namebuflen) &&
-+						(namebuflen <= xstrlen(git_statuses.statuses[i].path))))
-+					merged_status |= git_statuses.statuses[i].status;
++				if (git_statuses.statuses[i].status)
++					if ((dentp->flags & DIR_OR_LINK_TO_DIR) ? (is_prefix(git_statuses.statuses[i].path, dentpath, namebuflen) &&
++							namebuflen <= xstrlen(git_statuses.statuses[i].path)) : !xstrcmp(git_statuses.statuses[i].path, dentpath)) {
++						if (git_statuses.statuses[i].status != GIT_STATUS_IGNORED)
++							git_statuses.show = TRUE;
++						dentp->git_status |= git_statuses.statuses[i].status;
++					}
 +
-+			dentp->status_indexed = git_get_indexed_status(merged_status);
-+			dentp->status_staged = git_get_staged_status(merged_status);
 +			free(dentpath);
 +		}
 +
  		++ndents;
  	} while ((dp = readdir(dirp)));
 
-@@ -5834,7 +5959,7 @@ static int adjust_cols(int n)
+@@ -5873,7 +5975,7 @@ static int adjust_cols(int n)
  	}
 
  	/* 2 columns for preceding space and indicator */
 -	return (n - 2);
-+	return (n - ((cfg.normalgit && !cfg.showdetail) ? 5 : 2));
++	return (n - ((git_statuses.show && (cfg.normalgit && !cfg.showdetail)) ? 5 : 2));
  }
 
  static void draw_line(char *path, int ncols)
-@@ -5972,7 +6097,7 @@ static void redraw(char *path)
+@@ -6011,7 +6113,7 @@ static void redraw(char *path)
  #endif
  		}
  	}
 -	dtls.maxentln = dtls.maxnameln + dtls.maxsizeln + (dtls.printguid ? (dtls.maxuidln + dtls.maxgidln) : 0) + (g_state.uidgid ? 26 : 23);
-+	dtls.maxentln = dtls.maxnameln + dtls.maxsizeln + (dtls.printguid ? (dtls.maxuidln + dtls.maxgidln) : 0) + (g_state.uidgid ? 29 : 26);
++	dtls.maxentln = dtls.maxnameln + dtls.maxsizeln + (dtls.printguid ? (dtls.maxuidln + dtls.maxgidln) : 0) + (git_statuses.show ? 3 : 0) + (g_state.uidgid ? 26 : 23);
 
  	ncols = adjust_cols(ncols);
 
-@@ -7576,6 +7701,7 @@ static void usage(void)
+@@ -7610,6 +7712,7 @@ static void usage(void)
+ 		" -f      use readline history file\n"
  #endif
- 		" -F      show fortune\n"
  		" -g      regex filters\n"
 +		" -G      always show git status\n"
  		" -H      show hidden files\n"
  		" -J      no auto-proceed on select\n"
  		" -K      detect key collision\n"
-@@ -7714,6 +7840,8 @@ static void cleanup(void)
+@@ -7748,6 +7851,8 @@ static void cleanup(void)
  		fflush(stdout);
  	}
  #endif
@@ -244,16 +214,16 @@ index 9141d78..de4d9f0 100644
  	free(selpath);
  	free(plgpath);
  	free(cfgpath);
-@@ -7758,7 +7886,7 @@ int main(int argc, char *argv[])
+@@ -7792,7 +7897,7 @@ int main(int argc, char *argv[])
 
  	while ((opt = (env_opts_id > 0
  		       ? env_opts[--env_opts_id]
--		       : getopt(argc, argv, "aAb:cCdDeEfgHJKl:nop:P:QrRs:St:T:uUVwxh"))) != -1) {
-+		       : getopt(argc, argv, "aAb:cCdDeEfgGHJKl:nop:P:QrRs:St:T:uUVwxh"))) != -1) {
+-		       : getopt(argc, argv, "aAb:cCdDeEfgHJKl:nop:P:QrRs:St:T:uUVwxX:h"))) != -1) {
++		       : getopt(argc, argv, "aAb:cCdDeEfgGHJKl:nop:P:QrRs:St:T:uUVwxX:h"))) != -1) {
  		switch (opt) {
  #ifndef NOFIFO
  		case 'a':
-@@ -7802,6 +7930,9 @@ int main(int argc, char *argv[])
+@@ -7833,6 +7938,9 @@ int main(int argc, char *argv[])
  			cfg.regex = 1;
  			filterfn = &visible_re;
  			break;
@@ -263,7 +233,7 @@ index 9141d78..de4d9f0 100644
  		case 'H':
  			cfg.showhidden = 1;
  			break;
-@@ -7909,6 +8040,7 @@ int main(int argc, char *argv[])
+@@ -7940,6 +8048,7 @@ int main(int argc, char *argv[])
  		return EXIT_FAILURE;
 
  	atexit(cleanup);

--- a/patches/namefirst/mainline.diff
+++ b/patches/namefirst/mainline.diff
@@ -4,10 +4,10 @@
 # Author: Luuk van Baal
 
 diff --git a/src/nnn.c b/src/nnn.c
-index d83d7f6..22402fa 100644
+index eabe30f0..d8dc5925 100644
 --- a/src/nnn.c
 +++ b/src/nnn.c
-@@ -362,6 +362,10 @@ typedef struct {
+@@ -363,6 +363,10 @@ typedef struct {
  } session_header_t;
  #endif
 
@@ -18,8 +18,8 @@ index d83d7f6..22402fa 100644
  /* GLOBALS */
 
  /* Configuration, contexts */
-@@ -1038,10 +1042,12 @@ static char *getpwname(uid_t uid)
- 	static char *namecache = NULL;
+@@ -1039,10 +1043,12 @@ static char *getpwname(uid_t uid)
+ 	static char *namecache;
 
  	if (uidcache != uid) {
 +		if (dtls.maxuidln && !dtls.printguid) dtls.printguid = 1;
@@ -31,8 +31,8 @@ index d83d7f6..22402fa 100644
  	}
 
  	return namecache ? namecache : xitoa(uid);
-@@ -1053,10 +1059,12 @@ static char *getgrname(gid_t gid)
- 	static char *grpcache = NULL;
+@@ -1054,10 +1060,12 @@ static char *getgrname(gid_t gid)
+ 	static char *grpcache;
 
  	if (gidcache != gid) {
 +		if (dtls.maxgidln && !dtls.printguid) dtls.printguid = 1;
@@ -44,7 +44,7 @@ index d83d7f6..22402fa 100644
  	}
 
  	return grpcache ? grpcache : xitoa(gid);
-@@ -3479,14 +3487,13 @@ static void resetdircolor(int flags)
+@@ -3509,14 +3517,13 @@ static void resetdircolor(int flags)
   * Max supported str length: NAME_MAX;
   */
  #ifdef NOLC
@@ -62,7 +62,7 @@ index d83d7f6..22402fa 100644
  {
  	wchar_t * const wbuf = (wchar_t *)g_buf;
  	wchar_t *buf = wbuf;
-@@ -3510,7 +3517,7 @@ static wchar_t *unescape(const char *str, uint_t maxcols)
+@@ -3541,7 +3548,7 @@ static wchar_t *unescape(const char *str, uint_t maxcols)
  		++buf;
  	}
 
@@ -71,7 +71,7 @@ index d83d7f6..22402fa 100644
  }
 
  static off_t get_size(off_t size, off_t *pval, uint_t comp)
-@@ -3771,33 +3778,7 @@ static uchar_t get_color_pair_name_ind(const struct entry *ent, char *pind, int
+@@ -3802,33 +3809,7 @@ static uchar_t get_color_pair_name_ind(const struct entry *ent, char *pind, int
  static void printent(const struct entry *ent, uint_t namecols, bool sel)
  {
  	char ind = '\0';
@@ -106,7 +106,7 @@ index d83d7f6..22402fa 100644
  	uchar_t color_pair = get_color_pair_name_ind(ent, &ind, &attrs);
 
  	addch((ent->flags & FILE_SELECTED) ? '+' | A_REVERSE | A_BOLD : ' ');
-@@ -3822,15 +3803,40 @@ static void printent(const struct entry *ent, uint_t namecols, bool sel)
+@@ -3853,15 +3834,40 @@ static void printent(const struct entry *ent, uint_t namecols, bool sel)
  		++namecols;
 
  #ifndef NOLC
@@ -150,7 +150,7 @@ index d83d7f6..22402fa 100644
  }
 
  static void savecurctx(settings *curcfg, char *path, char *curname, int nextctx)
-@@ -5814,18 +5820,6 @@ static void statusbar(char *path)
+@@ -5849,18 +5855,6 @@ static void statusbar(char *path)
  		tocursor();
  }
 
@@ -169,7 +169,7 @@ index d83d7f6..22402fa 100644
  static int adjust_cols(int n)
  {
  	/* Calculate the number of cols available to print entry name */
-@@ -5833,13 +5827,10 @@ static int adjust_cols(int n)
+@@ -5868,13 +5862,10 @@ static int adjust_cols(int n)
  	n -= (g_state.oldcolor ? 0 : 1 + xstrlen(ICON_PADDING_LEFT) + xstrlen(ICON_PADDING_RIGHT));
  #endif
  	if (cfg.showdetail) {
@@ -186,7 +186,7 @@ index d83d7f6..22402fa 100644
  	}
 
  	/* 2 columns for preceding space and indicator */
-@@ -5877,8 +5868,6 @@ static void draw_line(char *path, int ncols)
+@@ -5912,8 +5903,6 @@ static void draw_line(char *path, int ncols)
  	if (dir)
  		attroff(COLOR_PAIR(cfg.curctx + 1) | A_BOLD);
 
@@ -195,7 +195,7 @@ index d83d7f6..22402fa 100644
  	statusbar(path);
  }
 
-@@ -5970,6 +5959,21 @@ static void redraw(char *path)
+@@ -6005,6 +5994,21 @@ static void redraw(char *path)
 
  	attroff(A_UNDERLINE | COLOR_PAIR(cfg.curctx + 1));
 
@@ -217,7 +217,7 @@ index d83d7f6..22402fa 100644
  	ncols = adjust_cols(ncols);
 
  	/* Go to first entry */
-@@ -6011,8 +6015,6 @@ static void redraw(char *path)
+@@ -6046,8 +6050,6 @@ static void redraw(char *path)
  #endif
  	}
 


### PR DESCRIPTION
* Directly use `libgit2` `git_status_t` lookup in `print_gitstatus()`, getting rid of custom `git_column_status_t` `enum` and `git_get_indexed/staged_status()` functions. (Less code and should be more performant as well although I didn't benchmark)
* Don't print git status when folder contains only unchanged or ignored entries: (git status column showing up in my homefolder due to dotfile repository was bothering me:yum:)
![out](https://user-images.githubusercontent.com/31730729/122246677-0b664e80-cec7-11eb-9b53-0754b52dde8a.gif)
Determined in `dentfill()` by setting boolean `git_statuses.show` to `TRUE` according to the described precondition; performance hit should be negligible.
In my opinion this is desired or at least reasonable behavior although if any user of the patch (now or in the future) disagrees we could reconsider.

@crides please review if you want/can and see if you agree with the change(don't know if you have looked at and/or actually ended up using the current patch)
@KlzXS as well if you can since you reviewed the initial patch.

* Also rebase the namefirst patch to master while we're at it.

