### PR TITLE
pseudo-ability to run binary files for nuke

### DIFF
--- a/plugins/nuke
+++ b/plugins/nuke
@@ -63,8 +63,9 @@
 #   1. Adapt, test and enable all mimes
 #   2. Clean-up the unnecessary exit codes
 
-# set to 1 to enable GUI apps
+# set to 1 to enable GUI apps and/or BIN execution
 GUI="${GUI:-0}"
+BIN="${BIN:-0}"
 
 set -euf -o noclobber -o noglob -o nounset
 IFS="$(printf '%b_' '\n')"; IFS="${IFS%_}" # protect trailing \n
@@ -513,10 +514,25 @@ handle_blocked() {
     esac
 }
 
+handle_bin() {
+    case "${MIMETYPE}" in
+        application/x-executable|application/x-shellscript)
+        clear
+        echo '-------- Executable File --------' && file --dereference --brief -- "${FPATH}"
+        read -pn 1 "Run executable? (Y/N): " answer
+        case "$answer" in
+            [Yy]* ) exec "${FPATH}";;
+            [Nn]* ) exit;;
+            * ) echo "Please answer Y or N.";;
+        esac
+    esac
+}
+
 MIMETYPE="$( file -bL --mime-type -- "${FPATH}" )"
 handle_extension
 handle_multimedia "${MIMETYPE}"
 handle_mime "${MIMETYPE}"
+[ "$BIN" -ne 0 ] && handle_bin
 handle_blocked "${MIMETYPE}"
 handle_fallback
 

--- a/plugins/nuke
+++ b/plugins/nuke
@@ -519,11 +519,10 @@ handle_bin() {
         application/x-executable|application/x-shellscript)
         clear
         echo '-------- Executable File --------' && file --dereference --brief -- "${FPATH}"
-        read -pn 1 "Run executable? (Y/N): " answer
+        read -n 1 -p "Run executable? (Y/N): " answer
         case "$answer" in
             [Yy]* ) exec "${FPATH}";;
             [Nn]* ) exit;;
-            * ) echo "Please answer Y or N.";;
         esac
     esac
 }

--- a/plugins/nuke
+++ b/plugins/nuke
@@ -519,7 +519,8 @@ handle_bin() {
         application/x-executable|application/x-shellscript)
         clear
         echo '-------- Executable File --------' && file --dereference --brief -- "${FPATH}"
-        read -n 1 -p "Run executable? (Y/N): " answer
+        printf "Run executable (y/N)? "
+        read -r answer
         case "$answer" in
             [Yy]* ) exec "${FPATH}";;
             [Nn]* ) exit;;

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -8016,6 +8016,7 @@ static void cleanup(void)
 	free(ihashbmp);
 	free(bookmark);
 	free(plug);
+	free(lastcmd);
 #ifndef NOFIFO
 	if (g_state.autofifo)
 		unlink(fifopath);


### PR DESCRIPTION
It was becoming quite annoying to have to open the shell each time I wanted to execute a file, so I did this. This can be made to also run shell scripts and the sort (application/x-shellscript is different from text/x-shellscript), but i'm still not sure about it.  

A more elegant way of doing this would be to just create a separate plugin which would handle running things from within nnn, and then binding that to a key (like how e is bound to open in editor) or possibly have nuke use it as an opener like it does mocq.