### PR TITLE
xdgdefault: make dmenu case-insensitive, fix style

### DIFF
--- a/plugins/xdgdefault
+++ b/plugins/xdgdefault
@@ -13,10 +13,10 @@
 # set to 1 to enable GUI apps
 GUI="${GUI:-0}"
 
-if [ "$GUI" -ne 0 ] && command -v dmenu >/dev/null 2>& 1; then
-  menu="dmenu -l 7"
+if [ "$GUI" -ne 0 ] && command -v dmenu > /dev/null 2>& 1; then
+    menu="dmenu -i -l 7"
 elif command -v fzf > /dev/null 2>& 1; then
-  menu="fzf -e --tiebreak=begin"
+    menu="fzf -e --tiebreak=begin"
 fi
 
 if [ -z "$1" ] || [ -z "$menu" ] > /dev/null 2>& 1; then


### PR DESCRIPTION
Most *.desktop entries have same name as their application name so this
is not an issue most of the time. However in the case of Neovim, the
application name is "Neovim" while the desktop entry is "nvim.desktop"

Since dmenu is case sensitive by default this means that searching
"neovim" will not show any results since the N is not capitalized and
the desktop entry name is "nvim"

fzf doesn't have this issue since its case-insensitive/fuzzy by
default. Making dmenu case-insensitive solves this.

Also fix the indentation to be consistent with the rest of the script.