### PR TITLE
Fix namefirst patch conflict

### DIFF
--- a/patches/gitstatus/mainline.diff
+++ b/patches/gitstatus/mainline.diff
@@ -6,18 +6,18 @@
 # Authors: Luuk van Baal, @crides
 
 diff --git a/src/nnn.c b/src/nnn.c
-index c4bced5..a4f2a39 100644
+index fe5d650..059c7bf 100644
 --- a/src/nnn.c
 +++ b/src/nnn.c
-@@ -269,6 +269,7 @@ typedef struct entry {
+@@ -277,6 +277,7 @@ typedef struct entry {
  	uid_t uid; /* 4 bytes */
  	gid_t gid; /* 4 bytes */
  #endif
 +	char git_status[2];
  } *pEntry;
 
- /* Key-value pairs from env */
-@@ -319,6 +320,7 @@ typedef struct {
+ /* Selection marker */
+@@ -333,6 +334,7 @@ typedef struct {
  	uint_t cliopener  : 1;  /* All-CLI app opener */
  	uint_t waitedit   : 1;  /* For ops that can't be detached, used EDITOR */
  	uint_t rollover   : 1;  /* Roll over at edges */
@@ -25,7 +25,7 @@ index c4bced5..a4f2a39 100644
  } settings;
 
  /* Non-persistent program-internal states (alphabeical order) */
-@@ -368,7 +370,17 @@ typedef struct {
+@@ -382,7 +384,17 @@ typedef struct {
  } session_header_t;
  #endif
 
@@ -43,7 +43,7 @@ index c4bced5..a4f2a39 100644
 
  /* Configuration, contexts */
  static settings cfg = {
-@@ -399,6 +411,7 @@ static settings cfg = {
+@@ -413,6 +425,7 @@ static settings cfg = {
  	0, /* cliopener */
  	0, /* waitedit */
  	1, /* rollover */
@@ -51,7 +51,7 @@ index c4bced5..a4f2a39 100644
  };
 
  static context g_ctx[CTX_MAX] __attribute__ ((aligned));
-@@ -3506,6 +3519,39 @@ static char *get_kv_val(kv *kvarr, char *buf, int key, uchar_t max, uchar_t id)
+@@ -3781,6 +3794,39 @@ static char *get_kv_val(kv *kvarr, char *buf, int key, uchar_t max, uchar_t id)
  	return NULL;
  }
 
@@ -91,7 +91,7 @@ index c4bced5..a4f2a39 100644
  static void resetdircolor(int flags)
  {
  	/* Directories are always shown on top, clear the color when moving to first file */
-@@ -3843,6 +3889,10 @@ static void printent(const struct entry *ent, uint_t namecols, bool sel)
+@@ -4118,6 +4164,10 @@ static void printent(const struct entry *ent, uint_t namecols, bool sel)
 
  	uchar_t color_pair = get_color_pair_name_ind(ent, &ind, &attrs);
 
@@ -102,7 +102,7 @@ index c4bced5..a4f2a39 100644
  	addch((ent->flags & FILE_SELECTED) ? '+' | A_REVERSE | A_BOLD : ' ');
 
  	if (g_state.oldcolor)
-@@ -5177,6 +5227,10 @@ static int dentfill(char *path, struct entry **ppdents)
+@@ -5451,6 +5501,10 @@ static int dentfill(char *path, struct entry **ppdents)
  		attron(COLOR_PAIR(cfg.curctx + 1));
  	}
 
@@ -113,7 +113,7 @@ index c4bced5..a4f2a39 100644
  #if _POSIX_C_SOURCE >= 200112L
  	posix_fadvise(fd, 0, 0, POSIX_FADV_SEQUENTIAL);
  #endif
-@@ -5375,6 +5429,34 @@ static int dentfill(char *path, struct entry **ppdents)
+@@ -5649,6 +5703,34 @@ static int dentfill(char *path, struct entry **ppdents)
  #endif
  		}
 
@@ -148,7 +148,7 @@ index c4bced5..a4f2a39 100644
  		++ndents;
  	} while ((dp = readdir(dirp)));
 
-@@ -5891,11 +5973,12 @@ static int adjust_cols(int n)
+@@ -6160,11 +6242,12 @@ static int adjust_cols(int n)
  #endif
  	if (cfg.showdetail) {
  		/* Fallback to light mode if less than 35 columns */
@@ -164,7 +164,7 @@ index c4bced5..a4f2a39 100644
 
  	/* 2 columns for preceding space and indicator */
  	return (n - 2);
-@@ -7642,6 +7725,7 @@ static void usage(void)
+@@ -7913,6 +7996,7 @@ static void usage(void)
  		" -F val  fifo mode [0:preview 1:explore]\n"
  #endif
  		" -g      regex filters\n"
@@ -172,7 +172,7 @@ index c4bced5..a4f2a39 100644
  		" -H      show hidden files\n"
  		" -J      no auto-proceed on select\n"
  		" -K      detect key collision\n"
-@@ -7780,6 +7864,7 @@ static void cleanup(void)
+@@ -8051,6 +8135,7 @@ static void cleanup(void)
  		fflush(stdout);
  	}
  #endif
@@ -180,7 +180,7 @@ index c4bced5..a4f2a39 100644
  	free(selpath);
  	free(plgpath);
  	free(cfgpath);
-@@ -7823,7 +7908,7 @@ int main(int argc, char *argv[])
+@@ -8095,7 +8180,7 @@ int main(int argc, char *argv[])
 
  	while ((opt = (env_opts_id > 0
  		       ? env_opts[--env_opts_id]
@@ -189,7 +189,7 @@ index c4bced5..a4f2a39 100644
  		switch (opt) {
  #ifndef NOFIFO
  		case 'a':
-@@ -7874,6 +7959,9 @@ int main(int argc, char *argv[])
+@@ -8146,6 +8231,9 @@ int main(int argc, char *argv[])
  			cfg.regex = 1;
  			filterfn = &visible_re;
  			break;

--- a/patches/gitstatus/namefirst.diff
+++ b/patches/gitstatus/namefirst.diff
@@ -7,18 +7,18 @@
 # Authors: Luuk van Baal, @crides
 
 diff --git a/src/nnn.c b/src/nnn.c
-index f5101b1..4691b43 100644
+index 2d33716..b190177 100644
 --- a/src/nnn.c
 +++ b/src/nnn.c
-@@ -269,6 +269,7 @@ typedef struct entry {
+@@ -277,6 +277,7 @@ typedef struct entry {
  	uid_t uid; /* 4 bytes */
  	gid_t gid; /* 4 bytes */
  #endif
 +	char git_status[2];
  } *pEntry;
 
- /* Key-value pairs from env */
-@@ -319,6 +320,7 @@ typedef struct {
+ /* Selection marker */
+@@ -333,6 +334,7 @@ typedef struct {
  	uint_t cliopener  : 1;  /* All-CLI app opener */
  	uint_t waitedit   : 1;  /* For ops that can't be detached, used EDITOR */
  	uint_t rollover   : 1;  /* Roll over at edges */
@@ -26,7 +26,7 @@ index f5101b1..4691b43 100644
  } settings;
 
  /* Non-persistent program-internal states (alphabeical order) */
-@@ -372,7 +374,17 @@ static struct {
+@@ -386,7 +388,17 @@ static struct {
  	ushort_t maxnameln, maxsizeln, maxuidln, maxgidln, maxentln, uidln, gidln, printguid;
  } dtls;
 
@@ -44,7 +44,7 @@ index f5101b1..4691b43 100644
 
  /* Configuration, contexts */
  static settings cfg = {
-@@ -403,6 +415,7 @@ static settings cfg = {
+@@ -417,6 +429,7 @@ static settings cfg = {
  	0, /* cliopener */
  	0, /* waitedit */
  	1, /* rollover */
@@ -52,7 +52,7 @@ index f5101b1..4691b43 100644
  };
 
  static context g_ctx[CTX_MAX] __attribute__ ((aligned));
-@@ -3514,6 +3527,39 @@ static char *get_kv_val(kv *kvarr, char *buf, int key, uchar_t max, uchar_t id)
+@@ -3789,6 +3802,39 @@ static char *get_kv_val(kv *kvarr, char *buf, int key, uchar_t max, uchar_t id)
  	return NULL;
  }
 
@@ -92,7 +92,7 @@ index f5101b1..4691b43 100644
  static void resetdircolor(int flags)
  {
  	/* Directories are always shown on top, clear the color when moving to first file */
-@@ -3824,6 +3870,9 @@ static void printent(const struct entry *ent, uint_t namecols, bool sel)
+@@ -4099,6 +4145,9 @@ static void printent(const struct entry *ent, uint_t namecols, bool sel)
  	int attrs = 0, namelen;
  	uchar_t color_pair = get_color_pair_name_ind(ent, &ind, &attrs);
 
@@ -102,7 +102,7 @@ index f5101b1..4691b43 100644
  	addch((ent->flags & FILE_SELECTED) ? '+' | A_REVERSE | A_BOLD : ' ');
 
  	if (g_state.oldcolor)
-@@ -5183,6 +5232,10 @@ static int dentfill(char *path, struct entry **ppdents)
+@@ -5457,6 +5506,10 @@ static int dentfill(char *path, struct entry **ppdents)
  		attron(COLOR_PAIR(cfg.curctx + 1));
  	}
 
@@ -113,7 +113,7 @@ index f5101b1..4691b43 100644
  #if _POSIX_C_SOURCE >= 200112L
  	posix_fadvise(fd, 0, 0, POSIX_FADV_SEQUENTIAL);
  #endif
-@@ -5381,6 +5434,34 @@ static int dentfill(char *path, struct entry **ppdents)
+@@ -5655,6 +5708,34 @@ static int dentfill(char *path, struct entry **ppdents)
  #endif
  		}
 
@@ -148,7 +148,7 @@ index f5101b1..4691b43 100644
  		++ndents;
  	} while ((dp = readdir(dirp)));
 
-@@ -5888,7 +5969,8 @@ static int adjust_cols(int n)
+@@ -6157,7 +6238,8 @@ static int adjust_cols(int n)
  			cfg.showdetail ^= 1;
  		else /* 2 more accounted for below */
  			n -= (dtls.maxentln - 2 - dtls.maxnameln);
@@ -158,7 +158,7 @@ index f5101b1..4691b43 100644
 
  	/* 2 columns for preceding space and indicator */
  	return (n - 2);
-@@ -6045,7 +6127,7 @@ static void redraw(char *path)
+@@ -6312,7 +6394,7 @@ static void redraw(char *path)
  			}
  #endif
  		}
@@ -167,7 +167,7 @@ index f5101b1..4691b43 100644
  	}
 
  	ncols = adjust_cols(ncols);
-@@ -7646,6 +7728,7 @@ static void usage(void)
+@@ -7919,6 +8001,7 @@ static void usage(void)
  		" -F val  fifo mode [0:preview 1:explore]\n"
  #endif
  		" -g      regex filters\n"
@@ -175,7 +175,7 @@ index f5101b1..4691b43 100644
  		" -H      show hidden files\n"
  		" -J      no auto-proceed on select\n"
  		" -K      detect key collision\n"
-@@ -7784,6 +7867,7 @@ static void cleanup(void)
+@@ -8057,6 +8140,7 @@ static void cleanup(void)
  		fflush(stdout);
  	}
  #endif
@@ -183,7 +183,7 @@ index f5101b1..4691b43 100644
  	free(selpath);
  	free(plgpath);
  	free(cfgpath);
-@@ -7827,7 +7911,7 @@ int main(int argc, char *argv[])
+@@ -8101,7 +8185,7 @@ int main(int argc, char *argv[])
 
  	while ((opt = (env_opts_id > 0
  		       ? env_opts[--env_opts_id]
@@ -192,7 +192,7 @@ index f5101b1..4691b43 100644
  		switch (opt) {
  #ifndef NOFIFO
  		case 'a':
-@@ -7878,6 +7962,9 @@ int main(int argc, char *argv[])
+@@ -8152,6 +8236,9 @@ int main(int argc, char *argv[])
  			cfg.regex = 1;
  			filterfn = &visible_re;
  			break;

--- a/patches/namefirst/mainline.diff
+++ b/patches/namefirst/mainline.diff
@@ -4,10 +4,10 @@
 # Author: Luuk van Baal
 
 diff --git a/src/nnn.c b/src/nnn.c
-index c4bced5..f5101b1 100644
+index fe5d650..2d33716 100644
 --- a/src/nnn.c
 +++ b/src/nnn.c
-@@ -368,6 +368,10 @@ typedef struct {
+@@ -382,6 +382,10 @@ typedef struct {
  } session_header_t;
  #endif
 
@@ -18,7 +18,7 @@ index c4bced5..f5101b1 100644
  /* GLOBALS */
 
  /* Configuration, contexts */
-@@ -1052,10 +1056,12 @@ static char *getpwname(uid_t uid)
+@@ -1065,10 +1069,12 @@ static char *getpwname(uid_t uid)
  	static char *namecache;
 
  	if (uidcache != uid) {
@@ -31,7 +31,7 @@ index c4bced5..f5101b1 100644
  	}
 
  	return namecache ? namecache : xitoa(uid);
-@@ -1067,10 +1073,12 @@ static char *getgrname(gid_t gid)
+@@ -1080,10 +1086,12 @@ static char *getgrname(gid_t gid)
  	static char *grpcache;
 
  	if (gidcache != gid) {
@@ -44,7 +44,7 @@ index c4bced5..f5101b1 100644
  	}
 
  	return grpcache ? grpcache : xitoa(gid);
-@@ -3521,14 +3529,13 @@ static void resetdircolor(int flags)
+@@ -3796,14 +3804,13 @@ static void resetdircolor(int flags)
   * Max supported str length: NAME_MAX;
   */
  #ifdef NOLC
@@ -62,7 +62,7 @@ index c4bced5..f5101b1 100644
  {
  	wchar_t * const wbuf = (wchar_t *)g_buf;
  	wchar_t *buf = wbuf;
-@@ -3553,7 +3560,7 @@ static wchar_t *unescape(const char *str, uint_t maxcols)
+@@ -3828,7 +3835,7 @@ static wchar_t *unescape(const char *str, uint_t maxcols)
  		++buf;
  	}
 
@@ -71,7 +71,7 @@ index c4bced5..f5101b1 100644
  }
 
  static off_t get_size(off_t size, off_t *pval, int comp)
-@@ -3814,33 +3821,7 @@ static uchar_t get_color_pair_name_ind(const struct entry *ent, char *pind, int
+@@ -4089,33 +4096,7 @@ static uchar_t get_color_pair_name_ind(const struct entry *ent, char *pind, int
  static void printent(const struct entry *ent, uint_t namecols, bool sel)
  {
  	char ind = '\0';
@@ -106,7 +106,7 @@ index c4bced5..f5101b1 100644
  	uchar_t color_pair = get_color_pair_name_ind(ent, &ind, &attrs);
 
  	addch((ent->flags & FILE_SELECTED) ? '+' | A_REVERSE | A_BOLD : ' ');
-@@ -3865,15 +3846,40 @@ static void printent(const struct entry *ent, uint_t namecols, bool sel)
+@@ -4140,15 +4121,40 @@ static void printent(const struct entry *ent, uint_t namecols, bool sel)
  		++namecols;
 
  #ifndef NOLC
@@ -150,7 +150,7 @@ index c4bced5..f5101b1 100644
  }
 
  static void savecurctx(char *path, char *curname, int nextctx)
-@@ -5871,18 +5877,6 @@ static void statusbar(char *path)
+@@ -6140,18 +6146,6 @@ static void statusbar(char *path)
  		tocursor();
  }
 
@@ -169,7 +169,7 @@ index c4bced5..f5101b1 100644
  static int adjust_cols(int n)
  {
  	/* Calculate the number of cols available to print entry name */
-@@ -5890,11 +5884,10 @@ static int adjust_cols(int n)
+@@ -6159,11 +6153,10 @@ static int adjust_cols(int n)
  	n -= (g_state.oldcolor ? 0 : 1 + xstrlen(ICON_PADDING_LEFT) + xstrlen(ICON_PADDING_RIGHT));
  #endif
  	if (cfg.showdetail) {
@@ -183,16 +183,16 @@ index c4bced5..f5101b1 100644
  	}
 
  	/* 2 columns for preceding space and indicator */
-@@ -5932,8 +5925,6 @@ static void draw_line(char *path, int ncols)
+@@ -6200,8 +6193,6 @@ static void draw_line(int ncols)
+ 	/* Must reset e.g. no files in dir */
  	if (dir)
  		attroff(COLOR_PAIR(cfg.curctx + 1) | A_BOLD);
-
--	markhovered();
 -
- 	statusbar(path);
+-	markhovered();
  }
 
-@@ -6042,6 +6033,21 @@ static void redraw(char *path)
+ static void redraw(char *path)
+@@ -6309,6 +6300,21 @@ static void redraw(char *path)
 
  	onscreen = MIN(onscreen + curscroll, ndents);
 
@@ -213,13 +213,13 @@ index c4bced5..f5101b1 100644
 +
  	ncols = adjust_cols(ncols);
 
- 	/* Print listing */
-@@ -6066,8 +6072,6 @@ static void redraw(char *path)
+ 	int len = scanselforpath(path, FALSE);
+@@ -6339,7 +6345,7 @@ static void redraw(char *path)
  #endif
  	}
 
 -	markhovered();
--
- 	statusbar(path);
++	statusbar(path);
  }
 
+ static bool cdprep(char *lastdir, char *lastname, char *path, char *newpath)

--- a/plugins/finder
+++ b/plugins/finder
@@ -64,7 +64,7 @@ clear
 
 mapfile -t fexprs < <(sort "$NNN_FINDHIST" | uniq -c | sort -nr | head -n5 |\
   awk '{for (i=2; i<NF; i++) printf $i " "; print $NF}')
-printf "Most used earch expressions:\n"
+printf "Most used search expressions:\n"
 printexprs 0
 
 mapfile -t -O"$i" fexprs < <(tac "$NNN_FINDHIST" | awk '!a[$0]++' | head -n5)


### PR DESCRIPTION
* Fixes namefirst patch conflict from commit https://github.com/jarun/nnn/commit/bf2b8d8c84f676f43839614ff76fdc641efaaa75.
* Rebase patches while we're at it.
* Fix typo in `finder` plugin.