### PR TITLE
Decide string length at compile time

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -7972,12 +7972,12 @@ static bool setup_config(void)
 			return FALSE;
 		}
 
-		len = xstrlen(xdgcfg) + 1 + 14; /* add length of "/nnn/bookmarks" */
+		len = xstrlen(xdgcfg) + strlen("/nnn/bookmarks") + 1;
 		xdg = TRUE;
 	}
 
 	if (!xdg)
-		len = xstrlen(home) + 1 + 22; /* add length of "/.config/nnn/bookmarks" */
+		len = xstrlen(home) + strlen("/.config/nnn/bookmarks") + 1;
 
 	cfgpath = (char *)malloc(len);
 	plgpath = (char *)malloc(len);
@@ -7988,7 +7988,7 @@ static bool setup_config(void)
 
 	if (xdg) {
 		xstrsncpy(cfgpath, xdgcfg, len);
-		r = len - 13; /* subtract length of "/nnn/sessions" */
+		r = len - strlen("/nnn/sessions");
 	} else {
 		r = xstrsncpy(cfgpath, home, len);
 


### PR DESCRIPTION
I run into many premature optimizations in our codebase which are
unnecessary.

In this particular case `strlen()` is optimized at compile time even at
`-O0` with `gcc`.

I would value higher code quality than dealing with these things in our
future endeavours. If this is accepted I may supply some more
readability patches.