### PR TITLE
icon for zsh, nix, and matlab files(nerdfonts), lua color to lua file

### DIFF
--- a/plugins/.iconlookup
+++ b/plugins/.iconlookup
@@ -39,6 +39,7 @@ awk 'BEGIN {
     color_fsharp=31   #color_fsharp=179    #color_fsharp="180;142;173"
     color_ruby=160    #color_ruby=150      #color_ruby="163;190;140"
     color_scala=196   #color_scala=139     #color_scala="143;188;187"
+    color_shell=47    #color_shell=109     #color_shell="143;188;187"
     color_vim=28      #color_vim=109       #color_vim="143;188;187"
 
 # icons[][1] contains icon and icons[][2] contains color
@@ -69,7 +70,7 @@ awk 'BEGIN {
     icons["license"][1] = ""; icons["license"][2] = color_docs
     icons["makefile"][1] = ""; icons["makefile"][2] = color_default
     icons["archive"][1] = ""; icons["archive"][2] = color_archive
-    icons["script"][1] = ""; icons["script"][2] = color_default
+    icons["script"][1] = ""; icons["script"][2] = color_shell
     icons["cplusplus"][1] = ""; icons["cplusplus"][2] = color_c
     icons["java"][1] = ""; icons["java"][2] = color_java
     icons["clojure"][1] = ""; icons["clojure"][2] = color_default
@@ -187,13 +188,15 @@ awk 'BEGIN {
     icons["lha"][1] = icons["archive"][1]; icons["lha"][2] = icons["archive"][2]
     icons["lhs"][1] = icons["haskell"][1]; icons["lhs"][2] = icons["haskell"][2]
     icons["ilog"][1] = icons["document"][1]; icons["ilog"][2] = icons["document"][2]
-    icons["lua"][1] = ""; icons["lua"][2] = color_default
+    icons["lua"][1] = ""; icons["lua"][2] = color_lua
     icons["lzh"][1] = icons["archive"][1]; icons["lzh"][2] = icons["archive"][2]
     icons["lzma"][1] = icons["archive"][1]; icons["lzma"][2] = icons["archive"][2]
 
 # m
+    icons["m"][1] = "ﴜ"; icons["mat"][2] = color_c
     icons["m4a"][1] = icons["musicfile"][1]; icons["m4a"][2] = icons["musicfile"][2]
     icons["m4v"][1] = icons["videofile"][1]; icons["m4v"][2] = icons["videofile"][2]
+    icons["mat"][1] = ""; icons["mat"][2] = color_c
     icons["markdown"][1] = ""; icons["markdown"][2] = color_docs
     icons["md"][1] = ""; icons["md"][2] = color_docs
     icons["mk"][1] = icons["makefile"][1]; icons["mk"][2] = icons["makefile"][2]
@@ -206,6 +209,7 @@ awk 'BEGIN {
     icons["msi"][1] = ""; icons["msi"][2] = color_default
 
 # n
+    icons["nix"][1] = ""; icons["nix"][2] = color_fsharp
 
 # o
     icons["o"][1] = icons["manual"][1]; icons["o"][2] = icons["manual"][2]
@@ -288,6 +292,7 @@ awk 'BEGIN {
     icons["yml"][1] = icons["configure"][1]; icons["yml"][2] = icons["configure"][2]
 # z
     icons["zip"][1] = icons["archive"][1]; icons["zip"][2] = icons["archive"][2]
+    icons["zsh"][1] = icons["script"][1]; icons["zsh"][2] = icons["script"][2]
 
     FS = "."
     limit = ENVIRON["limit"]

--- a/src/icons-nerdfont.h
+++ b/src/icons-nerdfont.h
@@ -163,6 +163,7 @@
 /* M */
 #define ICON_EXT_M4A       ICON_MUSICFILE
 #define ICON_EXT_M4V       ICON_VIDEOFILE
+#define ICON_EXT_M         "\ufd1c"
 #define ICON_EXT_MAT       "\uf0ce"
 #define ICON_EXT_MD        "\ue609"
 #define ICON_EXT_MK        ICON_MAKEFILE
@@ -259,5 +260,6 @@
 
 /* Z */
 #define ICON_EXT_ZIP       ICON_ARCHIVE
+#define ICON_EXT_ZSH       ICON_SCRIPT
 
 #endif // ICONS_NERDFONT

--- a/src/icons-nerdfont.h
+++ b/src/icons-nerdfont.h
@@ -163,6 +163,7 @@
 /* M */
 #define ICON_EXT_M4A       ICON_MUSICFILE
 #define ICON_EXT_M4V       ICON_VIDEOFILE
+#define ICON_EXT_MAT       "\uf0ce"
 #define ICON_EXT_MD        "\ue609"
 #define ICON_EXT_MK        ICON_MAKEFILE
 #define ICON_EXT_MKV       ICON_VIDEOFILE
@@ -174,6 +175,7 @@
 #define ICON_EXT_MSI       "\uf871"
 
 /* N */
+#define ICON_EXT_NIX       "\uf313"
 
 /* O */
 #define ICON_EXT_O         ICON_MANUAL

--- a/src/icons.h
+++ b/src/icons.h
@@ -199,7 +199,7 @@ static const struct icon_pair icons_ext[] = {
 	/* L */
 	{"lha",      FA_FILE_ARCHIVE_O,    COLOR_ARCHIVE},
 	{"log",      FA_FILE_TEXT_O,       0},
-	{"lua",      FILE_LUA,             0},
+	{"lua",      FILE_LUA,             COLOR_LUA},
 	{"lzh",      FA_FILE_ARCHIVE_O,    COLOR_ARCHIVE},
 	{"lzma",     FA_FILE_ARCHIVE_O,    COLOR_ARCHIVE},
 
@@ -404,14 +404,16 @@ static const struct icon_pair icons_ext[] = {
 	{"lha",        ICON_EXT_LHA,       COLOR_ARCHIVE},
 	{"lhs",        ICON_EXT_LHS,       COLOR_VIM},
 	{"log",        ICON_EXT_LOG,       0},
-	{"lua",        ICON_EXT_LUA,       0},
+	{"lua",        ICON_EXT_LUA,       COLOR_LUA},
 	{"lzh",        ICON_EXT_LZH,       COLOR_ARCHIVE},
 	{"lzma",       ICON_EXT_LZMA,      COLOR_ARCHIVE},
 
 	/* M */
+	{"m",          ICON_EXT_C,         COLOR_C},
 	{"m4a",        ICON_EXT_M4A,       COLOR_AUDIO},
 	{"m4v",        ICON_EXT_M4V,       COLOR_VIDEO},
 	{"markdown",   ICON_EXT_MD,        COLOR_DOCS},
+	{"mat",        ICON_EXT_MAT,       COLOR_C},
 	{"md",         ICON_EXT_MD,        COLOR_DOCS},
 	{"mk",         ICON_EXT_MK,        0},
 	{"mkv",        ICON_EXT_MKV,       COLOR_VIDEO},
@@ -423,6 +425,7 @@ static const struct icon_pair icons_ext[] = {
 	{"msi",        ICON_EXT_MSI,       0},
 
 	/* N */
+	{"nix",        ICON_EXT_NIX,       COLOR_FSHARP},
 
 	/* O */
 	{"o",          ICON_EXT_O,         0},
@@ -507,6 +510,7 @@ static const struct icon_pair icons_ext[] = {
 
 	/* Z */
 	{"zip",        ICON_EXT_ZIP,       COLOR_ARCHIVE},
+	{"zsh",        ICON_EXT_ZSH,       0},
 
 	/* Other */
 #endif

--- a/src/icons.h
+++ b/src/icons.h
@@ -41,6 +41,7 @@ struct icon_pair {
 #define COLOR_FSHARP       31  /* DeepSkyBlue3 */
 #define COLOR_RUBY         160 /* Red3 */
 #define COLOR_SCALA        196 /* Red1 */
+#define COLOR_SHELL        47  /* SpringGreen2 */
 #define COLOR_VIM          28  /* Green4 */
 
 /*
@@ -253,7 +254,7 @@ static const struct icon_pair icons_ext[] = {
 	/* S */
 	{"so",       FILE_MANPAGE,         0},
 	{"scala",    MFIZZ_SCALA,          0},
-	{"sh",       MFIZZ_SCRIPT,         0},
+	{"sh",       MFIZZ_SCRIPT,         COLOR_SHELL},
 	{"slim",     FA_FILE_CODE_O,       0},
 	{"sln",      DEV_VISUALSTUDIO,     0},
 	{"sql",      MFIZZ_MYSQL,          0},
@@ -409,7 +410,7 @@ static const struct icon_pair icons_ext[] = {
 	{"lzma",       ICON_EXT_LZMA,      COLOR_ARCHIVE},
 
 	/* M */
-	{"m",          ICON_EXT_C,         COLOR_C},
+	{"m",          ICON_EXT_M,         COLOR_C},
 	{"m4a",        ICON_EXT_M4A,       COLOR_AUDIO},
 	{"m4v",        ICON_EXT_M4V,       COLOR_VIDEO},
 	{"markdown",   ICON_EXT_MD,        COLOR_DOCS},
@@ -464,7 +465,7 @@ static const struct icon_pair icons_ext[] = {
 	{"scss",       ICON_EXT_SCSS,      COLOR_CSS},
 	{"so",         ICON_EXT_SO,        0},
 	{"scala",      ICON_EXT_SCALA,     COLOR_SCALA},
-	{"sh",         ICON_EXT_SH,        0},
+	{"sh",         ICON_EXT_SH,        COLOR_SHELL},
 	{"slim",       ICON_EXT_SLIM,      COLOR_DOCUMENT},
 	{"sln",        ICON_EXT_SLN,       0},
 	{"sql",        ICON_EXT_SQL,       0},
@@ -510,7 +511,7 @@ static const struct icon_pair icons_ext[] = {
 
 	/* Z */
 	{"zip",        ICON_EXT_ZIP,       COLOR_ARCHIVE},
-	{"zsh",        ICON_EXT_ZSH,       0},
+	{"zsh",        ICON_EXT_ZSH,       COLOR_SHELL},
 
 	/* Other */
 #endif


### PR DESCRIPTION
I added some icons mainly for nerdfonts, they should probably extended for icons-in-terminal and .iconlookup plugin.
I would also like to suggest to add color to *.*sh icon (COLOR_JAVASCRIPT seems suitable).