### PR TITLE
change and add some icons-nerdfont

### DIFF
--- a/src/icons-nerdfont.h
+++ b/src/icons-nerdfont.h
@@ -28,17 +28,17 @@
 #define ICON_PUBLIC        "\ue5ff"
 #define ICON_TEMPLATES     "\ufac6"
 #define ICON_VIDEOS        "\uf72f"
-#define ICON_VIDEOFILE     "\ufcdc"
+#define ICON_VIDEOFILE     "\uf72a"
 #define ICON_CHANGELOG     "\uf7d9"
 #define ICON_CONFIGURE     "\uf423"
 #define ICON_LICENSE       "\uf718"
 #define ICON_MAKEFILE      "\uf68c"
-#define ICON_ARCHIVE       "\uf53b"
+#define ICON_ARCHIVE       "\ufac3"
 #define ICON_SCRIPT        "\ue795"
 #define ICON_CPLUSPLUS     "\ue61d"
 #define ICON_JAVA          "\ue738"
 #define ICON_CLOJURE       "\ue76a"
-#define ICON_JAVASCRIPT    "\ue74e"
+#define ICON_JAVASCRIPT    "\uf81d"
 #define ICON_LINUX         "\uf83c"
 #define ICON_FSHARP        "\ue7a7"
 #define ICON_RUBY          "\ue23e"
@@ -87,7 +87,7 @@
 #define ICON_EXT_CONF      ICON_CONFIGURE
 #define ICON_EXT_CPIO      ICON_ARCHIVE
 #define ICON_EXT_CPP       ICON_CPLUSPLUS
-#define ICON_EXT_CSS       "\ue614"
+#define ICON_EXT_CSS       "\ue749"
 #define ICON_EXT_CUE       ICON_PLAYLIST
 #define ICON_EXT_CVS       ICON_CONFIGURE
 #define ICON_EXT_CXX       ICON_CPLUSPLUS
@@ -261,5 +261,6 @@
 /* Z */
 #define ICON_EXT_ZIP       ICON_ARCHIVE
 #define ICON_EXT_ZSH       ICON_SCRIPT
+#define ICON_EXT_ZST       ICON_ARCHIVE
 
 #endif // ICONS_NERDFONT

--- a/src/icons.h
+++ b/src/icons.h
@@ -323,6 +323,7 @@ static const struct icon_pair icons_ext[] = {
 	 /* C */
 	{"c",          ICON_EXT_C,         COLOR_C},
 	{"c++",        ICON_EXT_CPLUSPLUS, COLOR_C},
+	{"cabal",      ICON_EXT_HS,        COLOR_VIDEO},
 	{"cab",        ICON_EXT_CAB,       COLOR_ARCHIVE},
 	{"cbr",        ICON_EXT_CBR,       COLOR_ARCHIVE},
 	{"cbz",        ICON_EXT_CBZ,       COLOR_ARCHIVE},
@@ -335,7 +336,7 @@ static const struct icon_pair icons_ext[] = {
 	{"coffee",     ICON_EXT_COFFEE,    0},
 	{"conf",       ICON_EXT_CONF,      0},
 	{"cpio",       ICON_EXT_CPIO,      COLOR_ARCHIVE},
-	{"cpp",        ICON_EXT_CPP,       0},
+	{"cpp",        ICON_EXT_CPP,       COLOR_C},
 	{"css",        ICON_EXT_CSS,       COLOR_CSS},
 	{"cue",        ICON_EXT_CUE,       COLOR_AUDIO},
 	{"cvs",        ICON_EXT_CVS,       0},
@@ -512,6 +513,7 @@ static const struct icon_pair icons_ext[] = {
 	/* Z */
 	{"zip",        ICON_EXT_ZIP,       COLOR_ARCHIVE},
 	{"zsh",        ICON_EXT_ZSH,       COLOR_SHELL},
+	{"zst",        ICON_EXT_ZST,       COLOR_ARCHIVE},
 
 	/* Other */
 #endif


### PR DESCRIPTION
# More Icons

1. These icons are more pleasant in my opinion

| Name            | Old        | New        |
| :-------------- | :--------: | :--------: |
| ICON_VIDEOFILE  | ﳜ "\ufcdc" |  "\uf72a" |
| ICON_ARCHIVE    |  "\uf53b" | 遲"\ufac3" |
| ICON_JAVASCRIPT |  "\ue74e" |  "\uf81d" |
| ICON_EXT_CSS    |  "\ue614" |  "\ue749" |

2. These instead are some additions and a "fix".<br>
  Added icon for zst archives and cabal files, added COLOR_C to cpp icon
