### PR TITLE
fix fzhist plugin - get fish_history from the right place

### DIFF
--- a/plugins/fzhist
+++ b/plugins/fzhist
@@ -20,7 +20,7 @@ if [ "$shellname" = "bash" ]; then
     hist_file="$HOME/.bash_history"
     entry="$("$fuzzy" < "$hist_file")"
 elif [ "$shellname" = "fish" ]; then
-    hist_file="$HOME/.config/fish/fish_history"
+    hist_file="$HOME/.local/share/fish/fish_history"
     entry="$(grep "\- cmd: " "$hist_file" | cut -c 8- | "$fuzzy")"
 fi
 


### PR DESCRIPTION
The history file is at this location (`~/.local/share/fish/fish_history`) since fish 2.3.0. [ref](https://github.com/fish-shell/fish-shell/issues/862#issuecomment-19138822)