### PR TITLE
plugin autojump: on jump - read entire line

### DIFF
--- a/plugins/autojump
+++ b/plugins/autojump
@@ -21,8 +21,8 @@ fi
 
 if type jump >/dev/null 2>&1; then
     printf "jump to : "
-    read -r dir
-    odir="$(jump cd "$dir")"
+    IFS= read -r line
+    odir="$(jump cd "${line}")"
     printf "%s" "0c$odir" > "$NNN_PIPE"
 elif type autojump >/dev/null 2>&1; then
     printf "jump to : "


### PR DESCRIPTION
jump allows the user to provide several parameters - and does "recursive" fuzzy search on them.
this fix makes sure the entire line (provided by the user) is used when running jump