### PR TITLE
Close previewer when opening file

### DIFF
--- a/plugins/preview-tabbed
+++ b/plugins/preview-tabbed
@@ -133,6 +133,10 @@ previewer_loop () {
             continue
         fi
 
+        if [ "$FILE" = "close" ] ; then
+            break
+        fi
+
         kill_viewer
 
         MIME="$(file -bL --mime-type "$FILE")"

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -389,6 +389,7 @@ preview_fifo() {
         if [ -n "$selection" ]; then
             kill "$(cat "$PREVIEWPID")"
             [ -p "$FIFO_UEBERZUG" ] && ueberzug_remove
+            [ "$selection" = "close" ] && break
             preview_file "$selection"
             printf "%s" "$selection" > "$CURSEL"
         fi

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -846,7 +846,7 @@ static char *load_input(int fd, const char *path);
 static int set_sort_flags(int r);
 static void statusbar(char *path);
 #ifndef NOFIFO
-static void notify_fifo(bool force);
+static void notify_fifo(bool force, bool closepreview);
 #endif
 
 /* Functions */
@@ -3045,7 +3045,7 @@ try_quit:
 			} else {
 #ifndef NOFIFO
 				if (!g_state.fifomode)
-					notify_fifo(TRUE); /* Send hovered path to NNN_FIFO */
+					notify_fifo(TRUE, FALSE); /* Send hovered path to NNN_FIFO */
 #endif
 				escaped = TRUE;
 				settimeout();
@@ -5787,7 +5787,7 @@ static void populate(char *path, char *lastname)
 }
 
 #ifndef NOFIFO
-static void notify_fifo(bool force)
+static void notify_fifo(bool force, bool closepreview)
 {
 	if (!fifopath)
 		return;
@@ -5801,6 +5801,11 @@ static void notify_fifo(bool force)
 				fifopath = NULL;
 			return;
 		}
+	}
+
+	if (closepreview) {
+		write(fifofd, "close\n", 6);
+		return;
 	}
 
 	static struct entry lastentry;
@@ -5852,7 +5857,7 @@ static void move_cursor(int target, int ignore_scrolloff)
 
 #ifndef NOFIFO
 	if (!g_state.fifomode)
-		notify_fifo(FALSE); /* Send hovered path to NNN_FIFO */
+		notify_fifo(FALSE, FALSE); /* Send hovered path to NNN_FIFO */
 #endif
 }
 
@@ -6735,7 +6740,7 @@ nochange:
 					move_cursor(r, 1);
 #ifndef NOFIFO
 				else if ((event.bstate == BUTTON1_PRESSED) && !g_state.fifomode)
-					notify_fifo(TRUE); /* Send clicked path to NNN_FIFO */
+					notify_fifo(TRUE, FALSE); /* Send clicked path to NNN_FIFO */
 #endif
 				/* Handle right click selection */
 				if (event.bstate == BUTTON3_PRESSED) {
@@ -6808,7 +6813,7 @@ nochange:
                         }
 #ifndef NOFIFO
 			if (g_state.fifomode && (sel == SEL_OPEN)) {
-				notify_fifo(TRUE); /* Send opened path to NNN_FIFO */
+				notify_fifo(TRUE, FALSE); /* Send opened path to NNN_FIFO */
 				goto nochange;
 			}
 #endif
@@ -6890,6 +6895,9 @@ nochange:
 			    && strstr(g_buf, "text")
 #endif
 			) {
+#ifndef NOFIFO
+				notify_fifo(FALSE, TRUE);
+#endif
 				spawn(editor, newpath, NULL, NULL, F_CLI);
 				if (cfg.filtermode) {
 					presel = FILTER;
@@ -6942,6 +6950,9 @@ nochange:
 			}
 
 			/* Invoke desktop opener as last resort */
+#ifndef NOFIFO
+			notify_fifo(FALSE, TRUE);
+#endif
 			spawn(opener, newpath, NULL, NULL, opener_flags);
 
 			/* Move cursor to the next entry if not the last entry */
@@ -7198,6 +7209,9 @@ nochange:
 				copycurname();
 				goto nochange;
 			case SEL_EDIT:
+#ifndef NOFIFO
+				notify_fifo(FALSE, TRUE);
+#endif
 				spawn(editor, newpath, NULL, NULL, F_CLI);
 				continue;
 			default: /* SEL_LOCK */
@@ -8681,7 +8695,7 @@ int main(int argc, char *argv[])
 
 #ifndef NOFIFO
 	if (!g_state.fifomode)
-		notify_fifo(FALSE);
+		notify_fifo(FALSE, FALSE);
 	if (fifofd != -1)
 		close(fifofd);
 #endif


### PR DESCRIPTION
Write opcode to FIFO when opening/editing files to let previewers know that a file has been opened.
Makes the assumption that the previewer is no longer necessary which I think is fair. One can always reopen the previewer when returning to `nnn`.