### PR TITLE
Improve restorepreview race conditions

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -146,15 +146,15 @@ toggle_preview() {
         QLPATH="Bridge.exe"
     fi
     if kill "$(cat "$FIFOPID")"; then
+        printf "0" > "$NNN_PPIPE"
         kill "$(cat "$PREVIEWPID")"
         pkill -f "tail --follow $FIFO_UEBERZUG"
         if [ -n "$QLPATH" ] && stat "$1"; then
             f="$(wslpath -w "$1")" && "$QLPATH" "$f" &
         fi
-        printf "0" > "$NNN_PPIPE"
     else
-        start_preview "$1" "$QLPATH"
         printf "1" > "$NNN_PPIPE"
+        start_preview "$1" "$QLPATH"
     fi
 } >/dev/null 2>&1
 
@@ -391,7 +391,7 @@ preview_fifo() {
         if [ -n "$selection" ]; then
             kill "$(cat "$PREVIEWPID")"
             [ -p "$FIFO_UEBERZUG" ] && ueberzug_remove
-            [ "$selection" = "close" ] && sleep 0.1 && break
+            [ "$selection" = "close" ] && sleep 0.15 && break
             preview_file "$selection"
             printf "%s" "$selection" > "$CURSEL"
         fi


### PR DESCRIPTION
* Send runstate as soon as possible (updating g_state.previewer earlier avoiding some cases where the previewer is left open).
* Sleep longer before breaking from the preview loop such that editor has had longer to start up and will receive `SIGWINCH`.

My editor (neovim) only uses half the screen when the preview pane is closed while it is starting up, prolonging the sleep fixes it:
![out](https://user-images.githubusercontent.com/31730729/134369947-bc098f00-eb8b-478a-9083-249e41c1bd14.gif)
Slower machines might need a longer sleep and faster machines could do with shorter probably. On my machine `0.05` seems to work for most files but some larger files require `0.15`.

