### PR TITLE
autojump plugin: Support jethrokuan/z (port of z for fish)

### DIFF
--- a/plugins/autojump
+++ b/plugins/autojump
@@ -7,6 +7,7 @@
 #   - OR autojump - https://github.com/wting/autojump
 #   - OR zoxide - https://github.com/ajeetdsouza/zoxide
 #   - OR z - https://github.com/rupa/z (z requires fzf)
+#   - OR z (fish) - https://github.com/jethrokuan/z (z requires fzf)
 #
 # Note: The dependencies STORE NAVIGATION PATTERNS
 #
@@ -41,7 +42,9 @@ elif type zoxide >/dev/null 2>&1; then
     	printf "%s" "0c$odir" > "$NNN_PIPE"
     fi
 else
-    datafile="${_Z_DATA:-$HOME/.z}"
+    # rupa/z uses $_Z_DATA, jethrokuan/z (=port of z for fish) uses $Z_DATA
+    datafile="${_Z_DATA:-$Z_DATA}"
+    datafile="${datafile:-$HOME/.z}"
     if type fzf >/dev/null 2>&1 && [ -f "$datafile" ]; then
         # Read the data from z's file instead of calling
         # z so the data doesn't need to be processed twice

--- a/plugins/autojump
+++ b/plugins/autojump
@@ -43,8 +43,7 @@ elif type zoxide >/dev/null 2>&1; then
     fi
 else
     # rupa/z uses $_Z_DATA, jethrokuan/z (=port of z for fish) uses $Z_DATA
-    datafile="${_Z_DATA:-$Z_DATA}"
-    datafile="${datafile:-$HOME/.z}"
+    datafile="${_Z_DATA:-${Z_DATA:-$HOME/.z}}"
     if type fzf >/dev/null 2>&1 && [ -f "$datafile" ]; then
         # Read the data from z's file instead of calling
         # z so the data doesn't need to be processed twice


### PR DESCRIPTION
The port of z for the fish shell ([jethrokuan/z](https://github.com/jethrokuan/z)) uses `$Z_DATA` for the location of the data file while the original [rupa/z](https://github.com/rupa/z) for bash uses `$_Z_DATA`.

This pull request adds support for jethrokuan/z by checking `$Z_DATA`, too.