### PR TITLE
Disable e on picker mode

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -7206,7 +7206,8 @@ nochange:
 				copycurname();
 				goto nochange;
 			case SEL_EDIT:
-				spawn(editor, newpath, NULL, NULL, F_CLI);
+				if (!g_state.picker)
+					spawn(editor, newpath, NULL, NULL, F_CLI);
 				continue;
 			default: /* SEL_LOCK */
 				lock_terminal();


### PR DESCRIPTION
Mainly so that pressing 'e' due to muscle memory on nnn.vim doesn't nest
a new editor instance inside the embedded vim terminal.

However invoking nnn with picker mode implies that the intention is to
pick file(s), there shouldn't be any business trying to edit things on
the fly. And if editing a file while in picker mode is desirable, then
'l' can be used for that instead.