### PR TITLE
Save session after browse()

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -7734,11 +7734,6 @@ nochange:
 					break; // fallthrough
 			}
 
-#ifndef NOSSN
-			if (session && g_state.prstssn)
-				save_session(session, NULL);
-#endif
-
 			/* CD on Quit */
 			tmp = getenv("NNN_TMPFILE");
 			if ((sel == SEL_QUITCD) || tmp) {
@@ -8636,6 +8631,11 @@ int main(int argc, char *argv[])
 		set_sort_flags(sort);
 
 	opt = browse(initpath, session, pkey);
+
+#ifndef NOSSN
+	if (session && g_state.prstssn)
+		save_session(session, NULL);
+#endif
 
 #ifndef NOMOUSE
 	mousemask(mask, NULL);


### PR DESCRIPTION
`save_session()` after returning from `browse()` since this was skipped by the picker mode `SEL_OPEN` control flow: https://github.com/jarun/nnn/blob/2435263052661afbfd433ffc20b0519affc23866/src/nnn.c#L6827 

I think this fixes https://github.com/mcchrish/nnn.vim/issues/109 without any side-effects.
