### PR TITLE
Change POSIX shell quitcd wrapper function name to `nnn`.

### DIFF
--- a/misc/quitcd/quitcd.bash_zsh
+++ b/misc/quitcd/quitcd.bash_zsh
@@ -1,4 +1,4 @@
-n ()
+nnn_ ()
 {
     # Block nesting of nnn in subshells
     if [ -n $NNNLVL ] && [ "${NNNLVL:-0}" -ge 1 ]; then
@@ -19,10 +19,11 @@ n ()
     # stty lwrap undef
     # stty lnext undef
 
-    nnn "$@"
+    \nnn "$@"
 
     if [ -f "$NNN_TMPFILE" ]; then
             . "$NNN_TMPFILE"
             rm -f "$NNN_TMPFILE" > /dev/null
     fi
 }
+alias nnn='nnn_'


### PR DESCRIPTION
The recommended name of `n` is kinda bad as it conflicts with https://www.npmjs.com/package/n. This change allows the wrapper function to be named the same as the usual `nnn` command, without crashing shell as with the naive solution of just renaming the function to `nnn`.