### PR TITLE
Add 'font' mime-type registry check for preview-tui plugin

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -229,7 +229,7 @@ handle_mime() {
         image/*) generate_preview "$cols" "$lines" "$1" "image" ;;
         video/*) generate_preview "$cols" "$lines" "$1" "video" ;;
         audio/*) generate_preview "$cols" "$lines" "$1" "audio" ;;
-        application/font*|application/*opentype) generate_preview "$cols" "$lines" "$1" "font" ;;
+        application/font*|application/*opentype|font/*) generate_preview "$cols" "$lines" "$1" "font" ;;
         */*office*|*/*document*) generate_preview "$cols" "$lines" "$1" "office" ;;
         application/zip) fifo_pager unzip -l "$1" ;;
         text/troff)


### PR DESCRIPTION
The `preview-tui` plugin does not show a preview for TTF fonts that have a mime-type such as `font/<sub-type>`. For example when querying the mime-type for the OpenSans TTF font on my system, the mime-type returned is: `font/sfnt`

``` shell
file -bL --mime-type OpenSans-Regular.ttf
> 'font/sfnt'
```
It seems that now the `font` registry is the official one. This Pull Request adds a check for fonts in this registry. I left the other checks as is, as likely some systems may still return these values.

Sources:
- https://www.iana.org/assignments/media-types/media-types.xhtml#font
- https://stackoverflow.com/a/2907377

Signed-off-by: Sacha Telgenhof <me@sachatelgenhof.com>