### PR TITLE
Added %j and %J for using selection in shell

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -5391,12 +5391,12 @@ static bool prompt_run(void)
 
 		cnt_J = 0;
 		next = cmdline;
-		while (!cnt_j && (next = strstr(next, "%J"))) {
+		while ((next = strstr(next, "%J"))) {
 			++cnt_J;
 
 			tmplen = xstrsncpy(tmpcmd, cmdline, next - cmdline + 1) - 1;
-			tmplen += xstrsncpy(tmpcmd + tmplen, "${0} ${@}", sizeof("${0} ${@}"));
-			xstrsncpy(tmpcmd + tmplen, next + 2, len - (next - cmdline + 2));
+			tmplen += xstrsncpy(tmpcmd + tmplen, "${0} ${@}", sizeof("${0} ${@}")) - 1;
+			xstrsncpy(tmpcmd + tmplen, next + 2, len - (next - cmdline + 2) + 1);
 
 			++next;
 		}


### PR DESCRIPTION
Example usage:
`echo %s` - list every file in selection, one per line
`echo %S` - list every file in selection, all at once.

%s and %S cannot be combined inside a single command.
Multiple %s can be used in a single command.
We should probably print a warning instead of silently ignoring a command, but I didn't know exactly where that would go so I left it out.

Perhaps we should implement some sort of escape. Currently you aren't able to run something like `printf "%s" "some string"` as the `%s` would be replaced.