### PR TITLE
FreeBSD: use gsed instead of sed

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -202,7 +202,8 @@
 #define CTX_MAX 8
 #endif
 
-#ifdef __APPLE__
+/* BSDs or Solaris or SunOS */
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__APPLE__) || defined(sun) || defined(__sun)
 #define SED "gsed"
 #else
 #define SED "sed"


### PR DESCRIPTION
I have the same issue as #728 on FreeBSD 13.0. Using GNU sed fixes the issue.