### PR TITLE
patch/docs: correct the git status build flag, Fix #1211

### DIFF
--- a/patches/README.md
+++ b/patches/README.md
@@ -7,7 +7,7 @@ The patches will be adapted on each release when necessary (v4.1 onwards). Each 
 ## List of patches
 | Patch (a-z) | Description | Make var |
 | --- | --- | --- |
-| gitstatus | Add git status column to the detail view. Provides command line flag `-G` to show column in normal mode. | `O_GISTATUS` |
+| gitstatus | Add git status column to the detail view. Provides command line flag `-G` to show column in normal mode. | `O_GITSTATUS` |
 | namefirst | Print filenames first in the detail view. Print user/group columns when a directory contains different users/groups. | `O_NAMEFIRST` |
 | restorepreview | Add pipe to close and restore [`preview-tui`](https://github.com/jarun/nnn/blob/master/plugins/preview-tui) for internal undetached edits (<kbd>e</kbd> key)| `O_RESTOREPREVIEW` |
 


### PR DESCRIPTION
The git status build flag is missing the letter 'T'.