### PR TITLE
nuke: port sxiv-rifle performance improvement over

### DIFF
--- a/plugins/nuke
+++ b/plugins/nuke
@@ -259,27 +259,32 @@ handle_extension() {
     esac
 }
 
+# sets the variable abs_target, this should be faster than calling printf
 abspath() {
     case "$1" in
-        /*) printf "%s\n" "$1";;
-        *)  printf "%s\n" "$PWD/$1";;
+        /*) abs_target="$1";;
+        *)  abs_target="$PWD/$1";;
     esac
 }
 
+# storing the result to a tmp file is faster than calling listimages twice
 listimages() {
-    find -L "$(dirname "$target")" -maxdepth 1 -type f -iregex \
-      '.*\(jpe?g\|bmp\|webp\|ico\|svg\|png\|gif\)$' -print0 | sort -z
+    find -L "///${1%/*}" -maxdepth 1 -type f -print0 |
+        grep -izZE '\.(jpe?g|png|gif|webp|tiff|bmp|ico|svg)$' |
+        sort -z | tee "$tmp"
 }
 
 load_dir() {
-    target="$(abspath "$2")"
-    count="$(listimages | grep -a -m 1 -ZznF "$target" | cut -d: -f1)"
+    abspath "$2"
+    tmp="${TMPDIR:-/tmp}/nuke_$$"
+    trap 'rm -f $tmp' EXIT
+    count="$(listimages "$abs_target" | grep -a -m 1 -ZznF "$abs_target" | cut -d: -f1)"
 
     if [ -n "$count" ]; then
         if [ "$GUI" -ne 0 ]; then
-            listimages | xargs -0 nohup "$1" -n "$count" --
+            xargs -0 nohup "$1" -n "$count" -- < "$tmp"
         else
-            listimages | xargs -0 "$1" -n "$count" --
+            xargs -0 "$1" -n "$count" -- < "$tmp"
         fi
     else
         shift


### PR DESCRIPTION
this commit is mostly porting over some recent performance improvements
from `sxiv-rifle`: https://github.com/ranger/ranger/pull/2411

there's one "bug-fix" in this commit. currently a file named "afilejpeg"
would be matched due to the `-iregex` in listimages. this commit changes
that so only extensions would match, so for example "afile.jpeg" would
match but not "afilejpeg".

As for performance, there's a couple things this commit does:

* store the result of listimages into a tmp file instead of calling that
  function twice, this is probably the biggest performance improvement.
  especially when loading large directories.

* abspath now sets the var abs_target instead of calling printf. since
  abspath is only called from load_dir, we can go one step further and
  inline it. but i haven't done that since the function might be useful
  later on.

* avoid call to dirname and use parameter subsitution instead inside
  `listimages`

* use grep instead of `-iregex`, it's POSIX compliant and can be faster.

i've tested this out with sxiv and everything seems to be working as
expected.