### PR TITLE
Resolve symlinks one level for .nmv when in list mode

### DIFF
--- a/plugins/.nmv
+++ b/plugins/.nmv
@@ -64,7 +64,7 @@ printf "%s" "$arr" | awk '{printf("%'"${width}"'d %s\n", NR, $0)}' > "$dst_file"
 items=("~")
 while IFS='' read -r line; do
 	if [ "$NNN_LIST" -eq 1 ]; then
-		line=$(readlink "$line" || printf "$line")
+		line=$(readlink "$line" || printf "%s" "$line")
 	fi
 
 	items+=("$line");

--- a/plugins/.nmv
+++ b/plugins/.nmv
@@ -5,6 +5,7 @@
 # Note: nnn auto-detects and invokes this plugin if available
 #       Whitespace is used as delimiter for read.
 #       The plugin doesn't support filenames with leading or trailing whitespace
+#       To use NNN_LIST your shell must support readlink(1)
 #
 # Capabilities:
 #    1. Basic file rename
@@ -21,6 +22,7 @@ TMPDIR="${TMPDIR:-/tmp}"
 INCLUDE_HIDDEN="${INCLUDE_HIDDEN:-0}"
 VERBOSE="${VERBOSE:-0}"
 RECURSIVE="${RECURSIVE:-0}"
+NNN_LIST="${NNN_LIST:-0}"
 
 selection=${NNN_SEL:-${XDG_CONFIG_HOME:-$HOME/.config}/nnn/.selection}
 exit_status=0
@@ -61,6 +63,10 @@ printf "%s" "$arr" | awk '{printf("%'"${width}"'d %s\n", NR, $0)}' > "$dst_file"
 
 items=("~")
 while IFS='' read -r line; do
+	if [ "$NNN_LIST" -eq 1 ]; then
+		line=$(readlink "$line" || printf "$line")
+	fi
+
 	items+=("$line");
 done < <(printf "%s\n" "$arr")
 

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -7269,8 +7269,9 @@ nochange:
 			case SEL_RENAMEMUL:
 				endselection(TRUE);
 				setenv("INCLUDE_HIDDEN", xitoa(cfg.showhidden), 1);
-				if (listpath && is_prefix(path, listpath, xstrlen(listpath)))
-					setenv("NNN_LIST", "1", 1);
+				if (listpath)
+					setenv("NNN_LIST",
+						xitoa(is_prefix(path, listpath, xstrlen(listpath))), 1);
 
 				if (!(getutil(utils[UTIL_BASH])
 				      && plugscript(utils[UTIL_NMV], F_CLI))

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -7269,6 +7269,8 @@ nochange:
 			case SEL_RENAMEMUL:
 				endselection(TRUE);
 				setenv("INCLUDE_HIDDEN", xitoa(cfg.showhidden), 1);
+				if (listpath && is_prefix(path, listpath, xstrlen(listpath)))
+					setenv("NNN_LIST", "1", 1);
 
 				if (!(getutil(utils[UTIL_BASH])
 				      && plugscript(utils[UTIL_NMV], F_CLI))


### PR DESCRIPTION
`NNN_LIST` is set automatically if we are in list mode and we are in the tmp directory.

Resolving is done using `readlink(1)`. This utility reads out what the symlink points to (the thing `ls -l` would display). We always use absolute paths so that's fine. The resolving is done while reading in the input, this way most of the script can stay untouched.