### PR TITLE
Fix invisible description

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -187,7 +187,7 @@ Notes:
 
 | Key:Command | Description |
 |---|---|
-| `c:!convert $nnn png:- | xclip -sel clipboard -t image/png*` | Copy image to clipboard |
+| `c:!convert $nnn png:- \| xclip -sel clipboard -t image/png*` | Copy image to clipboard |
 | `e:-!sudo -E vim $nnn*` | Edit file as root in vim |
 | `g:-!git diff` | Show git diff |
 | `h:-!hx $nnn*` | Open hovered file in [hx](https://github.com/krpors/hx) hex editor |


### PR DESCRIPTION
### Summary 

One of the inline command descriptions is invisible due to unscape pipe character in code block.

### Screenshots

#### Before
![select-1636264300](https://user-images.githubusercontent.com/33394747/140638953-0c07221b-9d5a-4422-b91e-a7a3f9264bfc.png)

### After
![select-1636275865](https://user-images.githubusercontent.com/33394747/140638955-fbbf1847-d68c-4737-8fc5-fae436b24533.png)