### PR TITLE
Proper fix for preview-tui zombie-pane

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -401,13 +401,6 @@ ueberzug_remove() {
 }
 
 winch_handler() {
-    # workaround for preview-tui tmux child causing zombie pane
-    if [ "$NNN_PARENT" -eq "$NNN_PARENT" ] 2>/dev/null; then
-        kill -0 "$NNN_PARENT" || return
-    else
-        pidof nnn || return
-    fi
-
     clear
     kill "$(cat "$PREVIEWPID")"
     if [ -p "$FIFO_UEBERZUG" ]; then
@@ -427,6 +420,7 @@ preview_fifo() {
             printf "%s" "$selection" > "$CURSEL"
         fi
     done < "$NNN_FIFO"
+    sleep 0.1 # make sure potential preview by winch_handler is killed
     pkill -P "$$"
 } 2>/dev/null
 


### PR DESCRIPTION
Think I finally found a proper fix for the zombie-pane issue described in https://github.com/jarun/nnn/pull/1189#issuecomment-933029985.

By sleeping for a short time we can make sure the sub-shell spawned by `SIGWINCH` is killed when exiting the preview loop.