### PR TITLE
add nsxiv support to nuke, preview-tabbed and imgview

### DIFF
--- a/plugins/imgview
+++ b/plugins/imgview
@@ -6,6 +6,7 @@
 # Dependencies:
 #   - imv (https://github.com/eXeC64/imv) or,
 #   - sxiv (https://github.com/muennich/sxiv) or,
+#   - nsxiv (https://github.com/nsxiv/nsxiv) or,
 #   - ucollage (https://github.com/ckardaris/ucollage) or,
 #   - lsix (https://github.com/hackerb9/lsix), or
 #   - viu (https://github.com/atanunq/viu), or
@@ -62,6 +63,7 @@ listimages() {
 view_files() {
     [ -f "$target" ] && count="-n $(listimages | grep -a -m 1 -ZznF "$target" | cut -d: -f1)"
     case "$1" in
+        nsxiv) listimages | xargs -0 nsxiv -a "${count:--t}" -- ;;
         sxiv) listimages | xargs -0 sxiv -a "${count:--t}" -- ;;
         imv*) listimages | xargs -0 "$1" "${count:-}" -- ;;
     esac
@@ -86,6 +88,9 @@ elif type ucollage >/dev/null 2>&1; then
 elif type sxiv >/dev/null 2>&1; then
     type ffmpegthumbnailer >/dev/null 2>&1 && make_thumbs 0
     view_files sxiv >/dev/null 2>&1 &
+elif type nsxiv >/dev/null 2>&1; then
+    type ffmpegthumbnailer >/dev/null 2>&1 && make_thumbs 0
+    view_files nsxiv >/dev/null 2>&1 &
 elif type imv >/dev/null 2>&1; then
     make_thumbs ""
     view_files imv >/dev/null 2>&1 &
@@ -102,5 +107,5 @@ elif type catimg >/dev/null 2>&1; then
     catimg "$ret"
     exit_prompt
 else
-    exit_prompt "Please install sxiv/imv/viu/catimg/lsix."
+    exit_prompt "Please install sxiv/nsxiv/imv/viu/catimg/lsix."
 fi

--- a/plugins/nuke
+++ b/plugins/nuke
@@ -51,7 +51,7 @@
 #      htm|html|xhtml: w3m, lynx, elinks
 #      json: jq, python (json.tool module)
 #   Multimedia by mime:
-#      image/*: imv/sxiv (GUI), viu (https://github.com/atanunq/viu), img2txt, exiftool
+#      image/*: imv/sxiv/nsxiv (GUI), viu (https://github.com/atanunq/viu), img2txt, exiftool
 #      video/*: smplayer, mpv (GUI), ffmpegthumbnailer, mediainfo, exiftool
 #      audio/*: mocq (nnn plugin using MOC), mpv, media_client (Haiku), mediainfo, exiftool
 #      application/pdf: zathura (GUI), pdftotext, mutool, exiftool
@@ -323,6 +323,9 @@ handle_multimedia() {
                     exit 0
                 elif type sxiv >/dev/null 2>&1; then
                     load_dir sxiv "${FPATH}" >/dev/null 2>&1 &
+                    exit 0
+                elif type nsxiv >/dev/null 2>&1; then
+                    load_dir nsxiv "${FPATH}" >/dev/null 2>&1 &
                     exit 0
                 fi
             elif type viu >/dev/null 2>&1; then

--- a/plugins/preview-tabbed
+++ b/plugins/preview-tabbed
@@ -6,10 +6,11 @@
 #   - tabbed (https://tools.suckless.org/tabbed): xembed host
 #   - xterm (or urxvt or st) : xembed client for text-based preview
 #   - mpv (https://mpv.io): xembed client for video/audio
-#   - sxiv (https://github.com/muennich/sxiv): xembed client for images
+#   - sxiv (https://github.com/muennich/sxiv) or,
+#   - nsxiv (https://github.com/nsxiv/nsxiv) : xembed client for images
 #   - zathura (https://pwmt.org/projects/zathura): xembed client for PDF
 #   - nnn's nuke plugin for text preview and fallback
-#     nuke is a fallback for 'mpv', 'sxiv', and 'zathura', but has its
+#     nuke is a fallback for 'mpv', 'sxiv'/'nsxiv', and 'zathura', but has its
 #     own dependencies, see the script for more information
 #   - vim (or any editor/pager really)
 #   - file
@@ -35,7 +36,7 @@
 #   provided for `urxvt` and `st`). For graphic preview this can be trickier,
 #   but a few popular viewers are xembed-able, we use:
 #     - `mpv`: multimedia player, for video/audio preview
-#     - `sxiv`: image viewer
+#     - `sxiv`/`nsxiv`: image viewer
 #     - `zathura`: PDF viewer
 #     - but we always fallback to `nuke` plugin
 #
@@ -155,6 +156,8 @@ previewer_loop () {
             image/*)
                 if type sxiv >/dev/null 2>&1 ; then
                     sxiv -e "$XID" "$FILE" &
+                elif type nsxiv >/dev/null 2>&1 ; then
+                    nsxiv -e "$XID" "$FILE" &
                 else
                     term_nuke "$XID" "$FILE"
                 fi


### PR DESCRIPTION
`nuke` and `preview-tabbed` works as expected. I would assume `imgview`
should work as expected as well since `nsxiv` (at the moment at least)
is a drop-in replacement for sxiv, but I haven't tested it.

Closes: https://github.com/jarun/nnn/issues/1229