### PR TITLE
Preview-tui ensure pts device for tput in subshell

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -91,12 +91,11 @@ FIFOPID="$TMPDIR/nnn-preview-tui-fifopid.$NNN_PARENT"
 PREVIEWPID="$TMPDIR/nnn-preview-tui-pagerpid.$NNN_PARENT"
 CURSEL="$TMPDIR/nnn-preview-tui-selection.$NNN_PARENT"
 FIFO_UEBERZUG="$TMPDIR/nnn-preview-tui-ueberzug-fifo.$NNN_PARENT"
-PREVIEWSIZE="$TMPDIR/nnn-preview-tui-size.$NNN_PARENT"
 
 start_preview() {
     [ "$PAGER" = "most" ] && PAGER="less -R"
 
-    if [ -e "${TMUX%%,*}" ] && tmux -V | grep -q '[ -][3456789]\.'; then
+    if [ -e "${TMUX%%,*}" ] && tmux -V 2>/dev/null | grep -q '[ -][3456789]\.'; then
         TERMINAL=tmux
     elif [ -n "$KITTY_LISTEN_ON" ]; then
         TERMINAL=kitty
@@ -115,7 +114,7 @@ start_preview() {
     case "$TERMINAL" in
         tmux) # tmux splits are inverted
             if [ "$SPLIT" = "v" ]; then DSPLIT="h"; else DSPLIT="v"; fi
-            tmux split-window -e "NNN_FIFO=$NNN_FIFO" -e "PREVIEWSIZE=$PREVIEWSIZE" -e "PREVIEW_MODE=1"  \
+            tmux split-window -e "NNN_FIFO=$NNN_FIFO" -e "PREVIEW_MODE=1"  \
                 -e "CURSEL=$CURSEL" -e "TMPDIR=$TMPDIR" -e "FIFOPID=$FIFOPID" \
                 -e "BAT_STYLE=$BAT_STYLE" -e "BAT_THEME=$BAT_THEME" -e "PREVIEWPID=$PREVIEWPID" \
                 -e "PAGER=$PAGER" -e "ICONLOOKUP=$ICONLOOKUP" -e "NNN_PREVIEWWIDTH=$NNN_PREVIEWWIDTH" \
@@ -134,7 +133,7 @@ start_preview() {
                 --env "ICONLOOKUP=$ICONLOOKUP" --env "NNN_PREVIEWHEIGHT=$NNN_PREVIEWHEIGHT" \
                 --env "NNN_PREVIEWWIDTH=$NNN_PREVIEWWIDTH" --env "NNN_PREVIEWDIR=$NNN_PREVIEWDIR" \
                 --env "USE_PISTOL=$USE_PISTOL" --env "BAT_STYLE=$BAT_STYLE" \
-                --env "BAT_THEME=$BAT_THEME" --env "FIFOPID=$FIFOPID" --env "PREVIEWSIZE=$PREVIEWSIZE" \
+                --env "BAT_THEME=$BAT_THEME" --env "FIFOPID=$FIFOPID" \
                 --env "CURSEL=$CURSEL" --location "${SPLIT}split" "$0" "$1" ;;
         iterm)
             command="$SHELL -c 'cd $PWD; \
@@ -143,7 +142,7 @@ start_preview() {
                 PREVIEWPID=\\\"$PREVIEWPID\\\" CURSEL=\\\"$CURSEL\\\" TMPDIR=\\\"$TMPDIR\\\" \
                 ICONLOOKUP=\\\"$ICONLOOKUP\\\" NNN_PREVIEWHEIGHT=\\\"$NNN_PREVIEWHEIGHT\\\" \
                 NNN_PREVIEWWIDTH=\\\"$NNN_PREVIEWWIDTH\\\" NNN_PREVIEWDIR=\\\"$NNN_PREVIEWDIR\\\" \
-                USE_PISTOL=\\\"$USE_PISTOL\\\" BAT_STYLE=\\\"$BAT_STYLE\\\" PREVIEWSIZE=\\\"$PREVIEWSIZE\\\" \
+                USE_PISTOL=\\\"$USE_PISTOL\\\" BAT_STYLE=\\\"$BAT_STYLE\\\" \
                 BAT_THEME=\\\"$BAT_THEME\\\" FIFOPID=\\\"$FIFOPID\\\" \\\"$0\\\" \\\"$1\\\"'"
             if [ "$SPLIT" = "h" ]; then split="horizontally"; else split="vertically"; fi
             osascript <<-EOF
@@ -161,7 +160,7 @@ EOF
                      FIFOPID="$FIFOPID" FIFO_UEBERZUG="$FIFO_UEBERZUG" $TERMINAL -e "$0" "$1" &
             fi ;;
     esac
-} >/dev/null 2>&1
+}
 
 toggle_preview() {
     if exists QuickLook.exe; then
@@ -171,7 +170,7 @@ toggle_preview() {
     fi
     if kill "$(cat "$FIFOPID")"; then
         [ -p "$NNN_PPIPE" ] && printf "0" > "$NNN_PPIPE"
-        kill "$(cat "$PREVIEWPID")"
+        kill "$(cat "$PREVIEWPID" 2>/dev/null)" 2>/dev/null
         pkill -f "tail --follow $FIFO_UEBERZUG"
         if [ -n "$QLPATH" ] && stat "$1"; then
             f="$(wslpath -w "$1")" && "$QLPATH" "$f" &
@@ -180,7 +179,7 @@ toggle_preview() {
         [ -p "$NNN_PPIPE" ] && printf "1" > "$NNN_PPIPE"
         start_preview "$1" "$QLPATH"
     fi
-} >/dev/null 2>&1
+}
 
 exists() {
     type "$1" >/dev/null
@@ -306,9 +305,8 @@ preview_file() {
     mimetype="$(file -bL --mime-type -- "$1")"
     ext="${1##*.}"
     [ -n "$ext" ] && ext="$(printf "%s" "${ext}" | tr '[:upper:]' '[:lower:]')"
-    size="$(cat "$PREVIEWSIZE")"
-    lines=${size% *}
-    cols=${size#* }
+    lines=$(tput lines)
+    cols=$(tput cols)
 
     # Otherwise, falling back to the defaults.
     if [ -d "$1" ]; then
@@ -409,7 +407,6 @@ winch_handler() {
         pkill -f "tail --follow $FIFO_UEBERZUG"
         tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
     fi
-    stty size > "$PREVIEWSIZE"
     preview_file "$(cat "$CURSEL")"
 } 2>/dev/null
 
@@ -418,7 +415,7 @@ preview_fifo() {
         if [ -n "$selection" ]; then
             kill "$(cat "$PREVIEWPID")"
             [ -p "$FIFO_UEBERZUG" ] && ueberzug_remove
-            [ "$selection" = "close" ] && sleep 0.15 && pkill -P "$$" && exit
+            [ "$selection" = "close" ] && sleep 0.15 && break
             preview_file "$selection"
             printf "%s" "$selection" > "$CURSEL"
         fi
@@ -433,13 +430,12 @@ if [ "$PREVIEW_MODE" ]; then
         tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
     fi
 
-    stty size > "$PREVIEWSIZE"
     preview_file "$PWD/$1"
     preview_fifo &
     printf "%s" "$!" > "$FIFOPID"
     printf "%s" "$PWD/$1" > "$CURSEL"
     trap 'winch_handler; wait' WINCH
-    trap 'rm "$PREVIEWPID" "$CURSEL" "$FIFO_UEBERZUG" "$FIFOPID $PREVIEWSIZE" 2>/dev/null' INT HUP EXIT
+    trap 'rm "$PREVIEWPID" "$CURSEL" "$FIFO_UEBERZUG" "$FIFOPID" 2>/dev/null' INT HUP EXIT
     wait "$!" 2>/dev/null
 else
     if [ ! -r "$NNN_FIFO" ]; then


### PR DESCRIPTION
~~We can pass the tty device of the main shell in an env variable rather than writing to a tmpfile.~~

Removing redirection of sub-shells restores `tput` behavior without other workarounds for `ncurses-6.3`.