### PR TITLE
Preview-tui pass pts device in env variable

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -95,7 +95,7 @@ FIFO_UEBERZUG="$TMPDIR/nnn-preview-tui-ueberzug-fifo.$NNN_PARENT"
 start_preview() {
     [ "$PAGER" = "most" ] && PAGER="less -R"
 
-    if [ -e "${TMUX%%,*}" ] && tmux -V 2>/dev/null | grep -q '[ -][3456789]\.'; then
+    if [ -e "${TMUX%%,*}" ] && tmux -V | grep -q '[ -][3456789]\.'; then
         TERMINAL=tmux
     elif [ -n "$KITTY_LISTEN_ON" ]; then
         TERMINAL=kitty
@@ -105,7 +105,7 @@ start_preview() {
         TERMINAL="${TERMINAL:-xterm}"
     fi
 
-    if [ -z "$SPLIT" ] && [ $(($(tput lines) * 2)) -gt "$(tput cols)" ]; then
+    if [ -z "$SPLIT" ] && [ $(($(tput lines <"$TTY") * 2)) -gt "$(tput cols <"$TTY")" ]; then
         SPLIT='h'
     elif [ "$SPLIT" != 'h' ]; then
         SPLIT='v'
@@ -114,7 +114,7 @@ start_preview() {
     case "$TERMINAL" in
         tmux) # tmux splits are inverted
             if [ "$SPLIT" = "v" ]; then DSPLIT="h"; else DSPLIT="v"; fi
-            tmux split-window -e "NNN_FIFO=$NNN_FIFO" -e "PREVIEW_MODE=1"  \
+            tmux split-window -e "NNN_FIFO=$NNN_FIFO" -e "PREVIEW_MODE=1" -e TTY="$TTY" \
                 -e "CURSEL=$CURSEL" -e "TMPDIR=$TMPDIR" -e "FIFOPID=$FIFOPID" \
                 -e "BAT_STYLE=$BAT_STYLE" -e "BAT_THEME=$BAT_THEME" -e "PREVIEWPID=$PREVIEWPID" \
                 -e "PAGER=$PAGER" -e "ICONLOOKUP=$ICONLOOKUP" -e "NNN_PREVIEWWIDTH=$NNN_PREVIEWWIDTH" \
@@ -133,7 +133,7 @@ start_preview() {
                 --env "ICONLOOKUP=$ICONLOOKUP" --env "NNN_PREVIEWHEIGHT=$NNN_PREVIEWHEIGHT" \
                 --env "NNN_PREVIEWWIDTH=$NNN_PREVIEWWIDTH" --env "NNN_PREVIEWDIR=$NNN_PREVIEWDIR" \
                 --env "USE_PISTOL=$USE_PISTOL" --env "BAT_STYLE=$BAT_STYLE" \
-                --env "BAT_THEME=$BAT_THEME" --env "FIFOPID=$FIFOPID" \
+                --env "BAT_THEME=$BAT_THEME" --env "FIFOPID=$FIFOPID" --env TTY="$TTY" \
                 --env "CURSEL=$CURSEL" --location "${SPLIT}split" "$0" "$1" ;;
         iterm)
             command="$SHELL -c 'cd $PWD; \
@@ -142,7 +142,7 @@ start_preview() {
                 PREVIEWPID=\\\"$PREVIEWPID\\\" CURSEL=\\\"$CURSEL\\\" TMPDIR=\\\"$TMPDIR\\\" \
                 ICONLOOKUP=\\\"$ICONLOOKUP\\\" NNN_PREVIEWHEIGHT=\\\"$NNN_PREVIEWHEIGHT\\\" \
                 NNN_PREVIEWWIDTH=\\\"$NNN_PREVIEWWIDTH\\\" NNN_PREVIEWDIR=\\\"$NNN_PREVIEWDIR\\\" \
-                USE_PISTOL=\\\"$USE_PISTOL\\\" BAT_STYLE=\\\"$BAT_STYLE\\\" \
+                USE_PISTOL=\\\"$USE_PISTOL\\\" BAT_STYLE=\\\"$BAT_STYLE\\\" TTY=\\\"$TTY\\\" \
                 BAT_THEME=\\\"$BAT_THEME\\\" FIFOPID=\\\"$FIFOPID\\\" \\\"$0\\\" \\\"$1\\\"'"
             if [ "$SPLIT" = "h" ]; then split="horizontally"; else split="vertically"; fi
             osascript <<-EOF
@@ -156,11 +156,11 @@ EOF
         *)  if [ -n "$2" ]; then
                 QUICKLOOK=1 QLPATH="$2" PREVIEW_MODE=1 "$0" "$1" &
             else
-                PREVIEWPID="$PREVIEWPID" CURSEL="$CURSEL" PREVIEW_MODE=1 \
+                PREVIEWPID="$PREVIEWPID" CURSEL="$CURSEL" PREVIEW_MODE=1 TTY="$TTY" \
                      FIFOPID="$FIFOPID" FIFO_UEBERZUG="$FIFO_UEBERZUG" $TERMINAL -e "$0" "$1" &
             fi ;;
     esac
-}
+} >/dev/null 2>&1
 
 toggle_preview() {
     if exists QuickLook.exe; then
@@ -170,7 +170,7 @@ toggle_preview() {
     fi
     if kill "$(cat "$FIFOPID")"; then
         [ -p "$NNN_PPIPE" ] && printf "0" > "$NNN_PPIPE"
-        kill "$(cat "$PREVIEWPID" 2>/dev/null)" 2>/dev/null
+        kill "$(cat "$PREVIEWPID")"
         pkill -f "tail --follow $FIFO_UEBERZUG"
         if [ -n "$QLPATH" ] && stat "$1"; then
             f="$(wslpath -w "$1")" && "$QLPATH" "$f" &
@@ -179,7 +179,7 @@ toggle_preview() {
         [ -p "$NNN_PPIPE" ] && printf "1" > "$NNN_PPIPE"
         start_preview "$1" "$QLPATH"
     fi
-}
+} >/dev/null 2>&1
 
 exists() {
     type "$1" >/dev/null
@@ -200,7 +200,7 @@ fifo_pager() {
         exec > "$tmpfifopath"
         if [ "$cmd" = "pager" ]; then
             if exists bat; then
-                bat --terminal-width="$(tput cols)" --decorations=always --color=always \
+                bat --terminal-width="$(tput cols <"$TTY")" --decorations=always --color=always \
                     --paging=never --style="$BAT_STYLE" --theme="$BAT_THEME" "$@" &
             else
                 $PAGER "$@" &
@@ -305,8 +305,8 @@ preview_file() {
     mimetype="$(file -bL --mime-type -- "$1")"
     ext="${1##*.}"
     [ -n "$ext" ] && ext="$(printf "%s" "${ext}" | tr '[:upper:]' '[:lower:]')"
-    lines=$(tput lines)
-    cols=$(tput cols)
+    lines=$(tput lines <"$TTY")
+    cols=$(tput cols <"$TTY")
 
     # Otherwise, falling back to the defaults.
     if [ -d "$1" ]; then
@@ -415,7 +415,7 @@ preview_fifo() {
         if [ -n "$selection" ]; then
             kill "$(cat "$PREVIEWPID")"
             [ -p "$FIFO_UEBERZUG" ] && ueberzug_remove
-            [ "$selection" = "close" ] && sleep 0.15 && break
+            [ "$selection" = "close" ] && sleep 0.15 && pkill -P "$$" && exit
             preview_file "$selection"
             printf "%s" "$selection" > "$CURSEL"
         fi
@@ -447,6 +447,7 @@ else
         printf "\$KITTY_LISTEN_ON not set!\nPlease read Usage in preview-tui."
         cfg=$(stty -g); stty raw -echo; head -c 1; stty "$cfg"
     else
-        toggle_preview "$1" &
+        TTY="$(tty)"
+        TTY="$TTY" toggle_preview "$1" &
     fi
 fi


### PR DESCRIPTION
Seems I was too quick in my testing of #1234... That commit makes `tput` return other than default dimensions, but NOT the correct dimensions. This actually fixes the issue.
