### PR TITLE
Guard open_with getreadline for picker

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -7519,10 +7519,13 @@ nochange:
 				tmp = xreadline(tmp, messages[MSG_ARCHIVE_NAME]);
 				break;
 			case SEL_OPENWITH:
-#ifdef NORL
-				tmp = xreadline(NULL, messages[MSG_OPEN_WITH]);
-#else
-				tmp = getreadline(messages[MSG_OPEN_WITH]);
+#ifndef NORL
+				if (g_state.picker) {
+#endif
+					tmp = xreadline(NULL, messages[MSG_OPEN_WITH]);
+#ifndef NORL
+				} else
+					tmp = getreadline(messages[MSG_OPEN_WITH]);
 #endif
 				break;
 			case SEL_NEW:


### PR DESCRIPTION
Copied the [guard](https://github.com/jarun/nnn/blob/256f0d008fe9d28699aebb0155ab31664c06d683/src/nnn.c#L5386) already present in [`prompt_run()`](https://github.com/jarun/nnn/blob/256f0d008fe9d28699aebb0155ab31664c06d683/src/nnn.c#L5374) which I assume is there for the same reason.

fix luukvbaal/nnn.nvim#25

Edit: Yeah looked through git blame to find the original relevant issue: https://github.com/mcchrish/nnn.vim/issues/39.