### PR TITLE
misc sed tweaks

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -2729,12 +2729,7 @@ static void archive_selection(const char *cmd, const char *archive, const char *
 	}
 
 	snprintf(buf, CMD_LEN_MAX,
-#ifdef __linux__
 		SED" -ze 's|^%s/||' '%s' | xargs -0 %s %s", curpath, selpath, cmd, archive
-#else
-		"tr '\\0' '\n' < '%s' | "SED" -e 's|^%s/||' | tr '\n' '\\0' | xargs -0 %s %s",
-		selpath, curpath, cmd, archive
-#endif
 		);
 	spawn(utils[UTIL_SH_EXEC], buf, NULL, NULL, F_CLI | F_CONFIRM);
 	free(buf);

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -202,11 +202,13 @@
 #define CTX_MAX 8
 #endif
 
+#ifndef SED
 /* BSDs or Solaris or SunOS */
 #if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__APPLE__) || defined(sun) || defined(__sun)
 #define SED "gsed"
 #else
 #define SED "sed"
+#endif
 #endif
 
 /* Large selection threshold */


### PR DESCRIPTION
Hello,

re-reading #1210 I noticed that @0xACE highlighted a chunk of code in `archive_selection` that is no more necessary.  If I've understood the discussion correctly, `gsed` is now mandatory, so why don't use it?  It makes archive_selection slightly more robust on every platform.  Tested on OpenBSD and the `z` key seems to be working fine.

While there I've also wrapped the ifdef block that defines SED in another ifndef, this way porters can override the `SED` constant without patching.