### PR TITLE
Preview-tui fix gif whitespace name

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -339,13 +339,14 @@ generate_preview() {
             epub) gnome-epub-thumbnailer "$3" "$NNN_PREVIEWDIR/$3.jpg" ;;
             font) fontpreview -i "$3" -o "$NNN_PREVIEWDIR/$3.jpg" ;;
             gif) if [ -p "$FIFO_UEBERZUG" ] && exists convert; then
+                frameprefix="$NNN_PREVIEWDIR/$3/${3##*/}"
                     if [ ! -d "$NNN_PREVIEWDIR/$3" ]; then
                         mkdir -p "$NNN_PREVIEWDIR/$3"
-                        convert -coalesce -resize "$NNN_PREVIEWWIDTH"x"$NNN_PREVIEWHEIGHT"\> "$3" "$NNN_PREVIEWDIR/$3/${3##*/}.jpg"
+                        convert -coalesce -resize "$NNN_PREVIEWWIDTH"x"$NNN_PREVIEWHEIGHT"\> "$3" "$frameprefix.jpg"
                     fi
                         while true; do
-                            for frame in $(find "$NNN_PREVIEWDIR/$3"/*.jpg | sort -V); do
-                                image_preview "$1" "$2" "$frame"
+                            for i in $(seq 0 "$(($(find "$NNN_PREVIEWDIR/$3" | wc -l) - 2))"); do
+                                image_preview "$1" "$2" "$frameprefix-$i.jpg"
                                 sleep 0.1
                             done
                         done &


### PR DESCRIPTION
Fix #1260. A bit ugly but couldn't find another POSIX compliant way to loop over files in numerical order while respecting whitespace.