### PR TITLE
Preview-tui fix gif conversion

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -339,19 +339,22 @@ generate_preview() {
             epub) gnome-epub-thumbnailer "$3" "$NNN_PREVIEWDIR/$3.jpg" ;;
             font) fontpreview -i "$3" -o "$NNN_PREVIEWDIR/$3.jpg" ;;
             gif) if [ -p "$FIFO_UEBERZUG" ] && exists convert; then
-                frameprefix="$NNN_PREVIEWDIR/$3/${3##*/}"
+                    frameprefix="$NNN_PREVIEWDIR/$3/${3##*/}"
                     if [ ! -d "$NNN_PREVIEWDIR/$3" ]; then
                         mkdir -p "$NNN_PREVIEWDIR/$3"
-                        convert -coalesce -resize "$NNN_PREVIEWWIDTH"x"$NNN_PREVIEWHEIGHT"\> "$3" "$frameprefix.jpg"
+                        convert -coalesce -resize "$NNN_PREVIEWWIDTH"x"$NNN_PREVIEWHEIGHT"\> "$3" "$frameprefix.jpg" ||
+                        MAGICK_TMPDIR="/tmp" convert -coalesce -resize "$NNN_PREVIEWWIDTH"x"$NNN_PREVIEWHEIGHT"\> "$3" "$frameprefix.jpg"
                     fi
-                        while true; do
-                            for i in $(seq 0 "$(($(find "$NNN_PREVIEWDIR/$3" | wc -l) - 2))"); do
-                                image_preview "$1" "$2" "$frameprefix-$i.jpg"
-                                sleep 0.1
-                            done
-                        done &
-                        printf "%s" "$!" > "$PREVIEWPID"
-                        return
+                    frames=$(($(find "$NNN_PREVIEWDIR/$3" | wc -l) - 2))
+                    [ $frames -lt 0 ] && return
+                    while true; do
+                        for i in $(seq 0 $frames); do
+                            image_preview "$1" "$2" "$frameprefix-$i.jpg"
+                            sleep 0.1
+                        done
+                    done &
+                    printf "%s" "$!" > "$PREVIEWPID"
+                    return
                  else
                     exec >/dev/tty
                     image_preview "$1" "$2" "$3"


### PR DESCRIPTION
Fix #1264:
* Fall back to converting on disk by setting `MAGICK_TMPDIR` to `/tmp`
* Avoid endless loop when conversion has failed anyhow and we try to loop over empty target folder
* (Fix indenting)