### PR TITLE
Pedantic cleanups

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -1322,7 +1322,7 @@ static void msg(const char *message)
 }
 
 #ifdef KEY_RESIZE
-static void handle_key_resize()
+static void handle_key_resize(void)
 {
 	endwin();
 	refresh();

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3803,7 +3803,7 @@ static char *get_kv_val(kv *kvarr, char *buf, int key, uchar_t max, uchar_t id)
 	if (!kvarr)
 		return NULL;
 
-	for (int r = 0; kvarr[r].key && r < max; ++r) {
+	for (int r = 0; r < max && kvarr[r].key; ++r) {
 		if (kvarr[r].key == key) {
 			/* Do not allocate new memory for plugin */
 			if (id == NNN_PLUG)
@@ -3827,7 +3827,7 @@ static int get_kv_key(kv *kvarr, char *val, uchar_t max, uchar_t id)
 	if (id != NNN_ORDER) /* For now this function supports only order string */
 		return -1;
 
-	for (int r = 0; kvarr[r].key && r < max; ++r) {
+	for (int r = 0; r < max && kvarr[r].key; ++r) {
 		if (xstrcmp((orderstr + kvarr[r].off), val) == 0)
 			return kvarr[r].key;
 	}

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -7971,9 +7971,9 @@ static char *load_input(int fd, const char *path)
 		++chunk_count;
 
 		while (off < total_read) {
-			next = memchr(input + off, '\0', total_read - off) + 1;
-			if (next == (void *)1)
+			if ((next = memchr(input + off, '\0', total_read - off)) == NULL)
 				break;
+			++next;
 
 			if (next - input == off + 1) {
 				off = next - input;


### PR DESCRIPTION
Fixes a couple small warnings when compiled with additional warning flags (`-Wpointer-arith`, `-Wstrict-prototypes`).
