### PR TITLE
Remove trailing blanks to assure .desktop suffix for xdg-mime.

### DIFF
--- a/plugins/xdgdefault
+++ b/plugins/xdgdefault
@@ -49,5 +49,5 @@ app=$(find "$@" -iname '*.desktop' -exec grep '^Name=' {} + \
     | cut -f 2)
 
 if [ -n "$app" ]; then
-    xdg-mime default "$app" "$ftype"
+    xdg-mime default "${app%%[[:blank:]]*}" "$ftype"
 fi


### PR DESCRIPTION
I remember this plugin worked without any problems when I last used it, but now trailing blanks in the name of the .desktop file seem to cause xdg-mime to give "Malformed argument" error.