### PR TITLE
don't leak inotify_fd to plugins

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -8632,7 +8632,7 @@ int main(int argc, char *argv[])
 
 #ifdef LINUX_INOTIFY
 	/* Initialize inotify */
-	inotify_fd = inotify_init1(IN_NONBLOCK);
+	inotify_fd = inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
 	if (inotify_fd < 0) {
 		xerror();
 		return EXIT_FAILURE;


### PR DESCRIPTION
Note: there still might be fds leaking away since I only *skimmed* through the open() calls, didn't inspect them thoroughly (there also might be functions other than `open` which are opening fds). But this seems to be sufficient to solve the issue with `tree`.