### PR TITLE
export NNN_INCLUDE_HIDDEN to plugins

### DIFF
--- a/plugins/.nmv
+++ b/plugins/.nmv
@@ -19,7 +19,7 @@
 
 EDITOR="${EDITOR:-vi}"
 TMPDIR="${TMPDIR:-/tmp}"
-INCLUDE_HIDDEN="${INCLUDE_HIDDEN:-0}"
+NNN_INCLUDE_HIDDEN="${NNN_INCLUDE_HIDDEN:-0}"
 VERBOSE="${VERBOSE:-0}"
 RECURSIVE="${RECURSIVE:-0}"
 
@@ -55,7 +55,7 @@ else
 		findcmd="$findcmd -prune"
 	fi
 
-	if [ "$INCLUDE_HIDDEN" -eq 0 ]; then
+	if [ "$NNN_INCLUDE_HIDDEN" -eq 0 ]; then
 		findcmd="$findcmd ! -name \".*\""
 	fi
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -209,6 +209,7 @@ When `nnn` executes a plugin, it does the following:
     2. `$2`: The working directory (might differ from `$PWD` in case of symlinked paths; non-canonical).
     3. `$3`: The picker mode output file (`-` for stdout) if `nnn` is executed as a file picker.
 - Sets the environment variable `NNN_PIPE` used to control `nnn` active directory.
+- Sets the environment variable `NNN_INCLUDE_HIDDEN` to `1` if hidden files are active, `0` otherwise.
 - Exports the [special variables](https://github.com/jarun/nnn/wiki/Concepts#special-variables).
 
 Plugins can also read the `.selection` file in the config directory.

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -5130,6 +5130,7 @@ static void setexports(void)
 			}
 		}
 	}
+	setenv("NNN_INCLUDE_HIDDEN", xitoa(cfg.showhidden), 1);
 }
 
 static bool run_cmd_as_plugin(const char *file, char *runfile, uchar_t flags)
@@ -7269,7 +7270,7 @@ nochange:
 				break;
 			case SEL_RENAMEMUL:
 				endselection(TRUE);
-				setenv("INCLUDE_HIDDEN", xitoa(cfg.showhidden), 1);
+				setenv("NNN_INCLUDE_HIDDEN", xitoa(cfg.showhidden), 1);
 				setenv("NNN_LIST", listpath ? listroot : "", 1);
 
 				if (!(getutil(utils[UTIL_BASH])


### PR DESCRIPTION
Closes: https://github.com/jarun/nnn/issues/1308

---

Think this should do the trick. Plugins can check if hidden files is active or not via `[ "$NNN_INCLUDE_HIDDEN" -eq 1 ]`. 