### PR TITLE
native prompt: clear selection on successful operation

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -5373,7 +5373,7 @@ static bool prompt_run(void)
 {
 	bool ret = FALSE;
 	char *cmdline, *next;
-	int cnt_j, cnt_J;
+	int cnt_j, cnt_J, cmd_ret;
 	size_t len;
 
 	const char *xargs_j = "xargs -0 -I{} %s < %s";
@@ -5433,7 +5433,9 @@ static bool prompt_run(void)
 		else if (cnt_J)
 			snprintf(cmd, CMD_LEN_MAX + 32, xargs_J, cmdline, selpath);
 
-		spawn(shell, "-c", (cnt_j || cnt_J) ? cmd : cmdline, NULL, F_CLI | F_CONFIRM);
+		cmd_ret = spawn(shell, "-c", (cnt_j || cnt_J) ? cmd : cmdline, NULL, F_CLI | F_CONFIRM);
+		if ((cnt_j || cnt_J) && cmd_ret == 0)
+			clearselection();
 	}
 
 	return ret;


### PR DESCRIPTION
have been using the %j substitution for a bit now, it's quite nice :)
but it's also quite annoying when doing something like

	mv "%j" ./

in this case, the files have been moved but the selection is incorrectly
points to them.

when there's a successful operation made on the selection via the native
prompt, it makes sense to clear the selection.