### PR TITLE
plugin(dragdrop): unquote $all to prevent possible empty argument

### DIFF
--- a/plugins/dragdrop
+++ b/plugins/dragdrop
@@ -54,10 +54,10 @@ fi
 
 if [ "$resp" = "s" ]; then
     use_all
-    sed -z 's|'"$PWD/"'||g' < "$selection" | xargs -0 "$dnd" "$all" &
+    sed -z 's|'"$PWD/"'||g' < "$selection" | xargs -0 "$dnd" $all &
 elif [ "$resp" = "d" ]; then
     use_all
-    "$dnd" "$all" "$PWD/"* &
+    "$dnd" $all "$PWD/"* &
 elif [ "$resp" = "r" ]; then
     true > "$selection"
     "$dnd" --print-path --target | while read -r f


### PR DESCRIPTION
When using the `dragdrop` plugin to select multiple files (via selection / current directory), it's possible to specify an optional argument to drag all files at once, or separately. If we leave this option empty, the line that calls `$dnd` passes an empty argument (`"$all"`), which results in an error as displayed here:

![image](https://user-images.githubusercontent.com/24478021/162963695-4f3a7681-b30c-409b-8e68-21531b48ee3b.png)

This PR just unquotes that `$all` so the shell ignores it if we leave it empty.