### PR TITLE
Add patch conflict instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,28 +312,28 @@ clean:
 
 prepatch:
 ifeq ($(strip $(O_NAMEFIRST)),1)
-	patch --forward --strip=1 --input=$(NAMEFIRST)/mainline.diff
+	patch --forward --merge --strip=1 --input=$(NAMEFIRST)/mainline.diff
 ifeq ($(strip $(O_GITSTATUS)),1)
-	patch --forward --strip=1 --input=$(GITSTATUS)/namefirst.diff
+	patch --forward --merge --strip=1 --input=$(GITSTATUS)/namefirst.diff
 endif
 else ifeq ($(strip $(O_GITSTATUS)),1)
-	patch --forward --strip=1 --input=$(GITSTATUS)/mainline.diff
+	patch --forward --merge --strip=1 --input=$(GITSTATUS)/mainline.diff
 endif
 ifeq ($(strip $(O_RESTOREPREVIEW)),1)
-	patch --forward --strip=1 --input=$(RESTOREPREVIEW)/mainline.diff
+	patch --forward --merge --strip=1 --input=$(RESTOREPREVIEW)/mainline.diff
 endif
 
 postpatch:
 ifeq ($(strip $(O_NAMEFIRST)),1)
 ifeq ($(strip $(O_GITSTATUS)),1)
-	patch --reverse --strip=1 --input=$(GITSTATUS)/namefirst.diff
+	patch --merge --reverse --strip=1 --input=$(GITSTATUS)/namefirst.diff
 endif
-	patch --reverse --strip=1 --input=$(NAMEFIRST)/mainline.diff
+	patch --merge --reverse --strip=1 --input=$(NAMEFIRST)/mainline.diff
 else ifeq ($(strip $(O_GITSTATUS)),1)
-	patch --reverse --strip=1 --input=$(GITSTATUS)/mainline.diff
+	patch --merge --reverse --strip=1 --input=$(GITSTATUS)/mainline.diff
 endif
 ifeq ($(strip $(O_RESTOREPREVIEW)),1)
-	patch --reverse --strip=1 --input=$(RESTOREPREVIEW)/mainline.diff
+	patch --merge --reverse --strip=1 --input=$(RESTOREPREVIEW)/mainline.diff
 endif
 
 skip: ;

--- a/patches/README.md
+++ b/patches/README.md
@@ -14,3 +14,9 @@ The patches will be adapted on each release when necessary (v4.1 onwards). Each 
 To apply a patch, use the corresponding make variable, e.g.:
 
     make O_NAMEFIRST=1
+
+Whenever patch conflicts occur on the latest master, pull requests resolving them are welcome. Let's say a conflict occurs in the `restorepreview` patch. The best way to resolve this conflict would be something along the lines of:
+
+- Ensure you're on latest master and run `cp src/nnn.c src/nnn.c.orig && make O_RESTOREPREVIEW=1`. This will save a copy of the source from master in `src/nnn.c.orig` and generate conflict markers in `src/nnn.c`.
+- Next edit `src.nnn`, resolve all the conflicts around the conflict markers(`<<<<<<<`), and save.
+- Then run `diff -u src/nnn.c.orig src/nnn.c > patch.diff` to generate the new patch file and copy the contents to `patches/restorepreview/mainline.diff` (keeping the description comment at the start of the file).


### PR DESCRIPTION
Add instructions and `--merge` flag in `Makefile` to make the steps required somewhat simpler.