### PR TITLE
fix incorrect usage of sizeof

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -2542,7 +2542,7 @@ static bool cpmv_rename(int choice, const char *path)
 	uint_t count = 0, lines = 0;
 	bool ret = FALSE;
 	char *cmd = (choice == 'c' ? cp : mv);
-	char buf[sizeof(patterns[P_CPMVRNM]) + sizeof(cmd) + (PATH_MAX << 1)];
+	char buf[sizeof(patterns[P_CPMVRNM]) + (MAX(sizeof(cp), sizeof(mv))) + (PATH_MAX << 1)];
 
 	fd = create_tmp_file();
 	if (fd == -1)


### PR DESCRIPTION
`sizeof(cmd)` here would give the sizeof a char pointer, not the sizeof
the cp/mv array.