### PR TITLE
Add support for more archive formats by using bsdtar by default.

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -781,7 +781,7 @@ static const char * const patterns[] = {
 	// https://github.com/libarchive/libarchive/blob/master/tar/creation_set.c#L69
 	// https://github.com/libarchive/libarchive/blob/master/tar/creation_set.c#L90
 	// https://github.com/libarchive/libarchive/blob/master/tar/creation_set.c#L111
-	"\\.(tar|zip|jar|rar|lha|7z|alz|ace|a|ar|arj|arc|rpm|deb|cab|cpio|iso|mtree|xar|warc|t?(gz|grz|bz|bz2|Z|lzma|lzo|lz|lz4|lrz|xz|rz|uu|zst))",
+	"\\.(tar|zip|jar|rar|lha|7z|alz|ace|a|ar|arj|arc|rpm|deb|cab|cpio|iso|mtree|xar|warc|(t|ta)?(gz|grz|bz|bz2|z|Z|lzma|lzo|lz|lz4|lrz|xz|rz|uu|zst))",
 	SED" -i 's|^%s\\(.*\\)$|%s\\1|' %s",
 	SED" -ze 's|^%s/||' '%s' | xargs -0 %s %s",
 };


### PR DESCRIPTION
### why

I created this PR because I couldn't extract a `.tar.zst` file with nnn. `bsdtar` supports many more formats than `atool`, the current default.

### issues

We let the command error out for unsupported formats. I think this is fine as long as we show the error to the user.
