### PR TITLE
Go to last dir on bookmark key repeat

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -7138,8 +7138,10 @@ nochange:
 					goto nochange;
 				}
 
-				if (strcmp(path, newpath) == 0)
-					break;
+				if (strcmp(path, newpath) == 0) {
+					dir = lastdir; /* Go to last dir on bookmark key repeat */
+					xstrsncpy(newpath, dir, PATH_MAX);
+				}
 			}
 
 			/* In list mode, retain the last file name to highlight it, if possible */


### PR DESCRIPTION
Hello,

This patch makes `SEL_BMOPEN` toggle between bookmarks directory and last directory, just like `SEL_CDHOME` and  `SEL_CDROOT`. 

Disclaimer: I don't know what the hell I am doing. I have not played around with C for more than 7 years.... BUT it doesn't segmentation fault on me (anymore) and it works 😃 

Best regards,
Göran Gustafsson
