### PR TITLE
Selections in current context color

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -4190,7 +4190,7 @@ static void printent(const struct entry *ent, uint_t namecols, bool sel)
 
 	uchar_t color_pair = get_color_pair_name_ind(ent, &ind, &attrs);
 
-	addch((ent->flags & FILE_SELECTED) ? '+' | A_REVERSE | A_BOLD : ' ');
+	addch((ent->flags & FILE_SELECTED) ? '+' | A_REVERSE | A_BOLD | COLOR_PAIR(cfg.curctx + 1) : ' ');
 
 	if (g_state.oldcolor)
 		resetdircolor(ent->flags);


### PR DESCRIPTION
Hello,

This patch makes selections use the current context color.

<img width="682" alt="Screenshot 2022-06-05 at 20 56 34" src="https://user-images.githubusercontent.com/595501/172069254-ab7993bf-2a2d-46a5-bbed-81a64619ecdb.png">

Best regards,
Göran Gustafsson
