### PR TITLE
Use -x flag with BSD stat

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -4526,7 +4526,11 @@ static bool show_stats(char *fpath)
 		("file " FILE_MIME_OPTS),
 #endif
 		"file -b",
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__APPLE__)
+		"stat -x",
+#else
 		"stat",
+#endif
 	};
 
 	size_t r = ELEMENTS(cmds);


### PR DESCRIPTION
Hello,

This patch makes `stat` start with flag `-x` on FreeBSD, NetBSD, OpenBSD and macOS.

```-x      Display information in a more verbose way as known from some Linux distributions.```

<img width="752" alt="Screenshot 2022-06-05 at 22 24 49" src="https://user-images.githubusercontent.com/595501/172069389-b2c4849c-2a9e-4c44-8582-d4c23194fd33.png">

`stat` above and `stat -x` below.

Best regards,
Göran Gustafsson

