### PR TITLE
Print usage info to stdout instead of stderr

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -8145,7 +8145,7 @@ static void check_key_collision(void)
 
 static void usage(void)
 {
-	dprintf(STDERR_FILENO,
+	dprintf(STDOUT_FILENO,
 		"%s: nnn [OPTIONS] [PATH]\n\n"
 		"The unorthodox terminal file manager.\n\n"
 		"positional args:\n"


### PR DESCRIPTION
Hello,

This patch makes nnn print usage info to stdout instead of stderr.

After:
```
$ nnn -h | grep show
 -H      show hidden files
 -i      show current file info
 -U      show user and group
 -V      show version
 -h      show help
```

Before:
```
/opt/homebrew/bin/nnn -h | grep show
usage: nnn [OPTIONS] [PATH]

The unorthodox terminal file manager.

positional args:
  PATH   start dir/file [default: .]

optional args:
 -a      auto NNN_FIFO
 -A      no dir auto-enter in type-to-nav
 -b key  open bookmark key (trumps -s/S)
 -c      cli-only NNN_OPENER (trumps -e)
 -C      8-color scheme
 -d      detail mode
 -D      dirs in context color
 -e      text in $VISUAL/$EDITOR/vi
 -E      internal edits in EDITOR
 -f      use readline history file
 -F val  fifo mode [0:preview 1:explore]
 -g      regex filters
 -H      show hidden files
 -i      show current file info
 -J      no auto-jump on selection
 -K      detect key collision
 -l val  set scroll lines
 -n      type-to-nav mode
 -o      open files only on Enter
 -p file selection file [-:stdout]
 -P key  run plugin key
 -Q      no quit confirmation
 -r      use advcpmv patched cp, mv
 -R      no rollover at edges
 -s name load session by name
 -S      persistent session
 -t secs timeout to lock
 -T key  sort order [a/d/e/r/s/t/v]
 -u      use selection (no prompt)
 -U      show user and group
 -V      show version
 -x      notis, selection sync, xterm title
 -h      show help

v4.5
BSD 2-Clause
https://github.com/jarun/nnn
```
\+ my confused face: :raised_eyebrow:

Best regards,
Göran Gustafsson
