### PR TITLE
Fix false positive selbm

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -7119,6 +7119,7 @@ nochange:
 				goto nochange;
 			}
 
+			g_state.selbm = 0;
 			if (strcmp(path, dir) == 0) {
 				if (dir == ipath) {
 					if (cfg.filtermode)


### PR DESCRIPTION
Avoid unintentionally entering symlink target when leaving bookmark dir through `CDHOME/CDBEGIN/CDLAST/CDROOT`.

For example pressing <kbd>b\`</kbd> -> `/bin` enters `/usr/bin` instead of `/bin`.