### PR TITLE
Misc cleanups

### DIFF
--- a/patches/gitstatus/mainline.diff
+++ b/patches/gitstatus/mainline.diff
@@ -6,13 +6,13 @@
 # Authors: Luuk van Baal
 
 diff --git a/src/nnn.c b/src/nnn.c
-index 508ee915..77d56d63 100644
+index f8a2c58..157cea5 100644
 --- a/src/nnn.c
 +++ b/src/nnn.c
 @@ -265,6 +265,25 @@
  #define FREE     0
  #define CAPACITY 1
-
+ 
 +/* Git icons */
 +#ifdef NERD
 +#define GIT_ADD ""
@@ -41,20 +41,20 @@ index 508ee915..77d56d63 100644
  #endif
 +	char git_status[2][5];
  } *pEntry;
-
+ 
  /* Selection marker */
-@@ -345,6 +365,7 @@ typedef struct {
+@@ -344,6 +364,7 @@ typedef struct {
  	uint_t cliopener  : 1;  /* All-CLI app opener */
  	uint_t waitedit   : 1;  /* For ops that can't be detached, used EDITOR */
  	uint_t rollover   : 1;  /* Roll over at edges */
 +	uint_t normalgit  : 1;  /* Show git status in normal mode */
  } settings;
-
+ 
  /* Non-persistent program-internal states (alphabeical order) */
 @@ -394,7 +415,17 @@ typedef struct {
  } session_header_t;
  #endif
-
+ 
 +typedef struct {
 +	char status[2];
 +	char path[PATH_MAX];
@@ -66,21 +66,13 @@ index 508ee915..77d56d63 100644
 +	size_t len;
 +	git_status_t *statuses;
 +} git_statuses;
-
+ 
  /* Configuration, contexts */
  static settings cfg = {
-@@ -425,6 +456,7 @@ static settings cfg = {
- 	0, /* cliopener */
- 	0, /* waitedit */
- 	1, /* rollover */
-+	0, /* normalgit */
- };
-
- static context g_ctx[CTX_MAX] __attribute__ ((aligned));
-@@ -3838,6 +3870,56 @@ static int get_kv_key(kv *kvarr, char *val, uchar_t max, uchar_t id)
+@@ -3819,6 +3850,56 @@ static int get_kv_key(kv *kvarr, char *val, uchar_t max, uchar_t id)
  	return -1;
  }
-
+ 
 +static size_t get_git_statuses(const char *path)
 +{
 +	static char gitrev[] = "git rev-parse --show-toplevel 2>/dev/null";
@@ -134,21 +126,21 @@ index 508ee915..77d56d63 100644
  static void resetdircolor(int flags)
  {
  	/* Directories are always shown on top, clear the color when moving to first file */
-@@ -4182,6 +4264,10 @@ static void printent(const struct entry *ent, uint_t namecols, bool sel)
-
+@@ -4163,6 +4244,10 @@ static void printent(const struct entry *ent, uint_t namecols, bool sel)
+ 
  	uchar_t color_pair = get_color_pair_name_ind(ent, &ind, &attrs);
-
+ 
 +	if (git_statuses.show && (cfg.showdetail || cfg.normalgit))
 +		printw("%*s%s%s", (cfg.normalgit && !cfg.showdetail) ? 1 : 0, "",
 +				ent->git_status[0], ent->git_status[1]);
 +
  	addch((ent->flags & FILE_SELECTED) ? '+' | A_REVERSE | A_BOLD : ' ');
-
+ 
  	if (g_state.oldcolor)
-@@ -5630,6 +5716,11 @@ static int dentfill(char *path, struct entry **ppdents)
+@@ -5629,6 +5714,11 @@ static int dentfill(char *path, struct entry **ppdents)
  		attron(COLOR_PAIR(cfg.curctx + 1));
  	}
-
+ 
 +	char linkpath[PATH_MAX];
 +	if ((git_statuses.len = get_git_statuses(path)))
 +		if (!realpath(path, linkpath))
@@ -157,10 +149,10 @@ index 508ee915..77d56d63 100644
  #if _POSIX_C_SOURCE >= 200112L
  	posix_fadvise(fd, 0, 0, POSIX_FADV_SEQUENTIAL);
  #endif
-@@ -5830,6 +5921,29 @@ static int dentfill(char *path, struct entry **ppdents)
+@@ -5829,6 +5919,29 @@ static int dentfill(char *path, struct entry **ppdents)
  #endif
  		}
-
+ 
 +		if (git_statuses.len) {
 +			char dentpath[PATH_MAX];
 +			size_t pathlen = mkpath(linkpath, dentp->name, dentpath);
@@ -186,8 +178,8 @@ index 508ee915..77d56d63 100644
 +
  		++ndents;
  	} while ((dp = readdir(dirp)));
-
-@@ -6373,11 +6487,12 @@ static int adjust_cols(int n)
+ 
+@@ -6372,11 +6485,12 @@ static int adjust_cols(int n)
  #endif
  	if (cfg.showdetail) {
  		/* Fallback to light mode if less than 35 columns */
@@ -200,10 +192,10 @@ index 508ee915..77d56d63 100644
 +			n -= (git_statuses.show ? 34 : 32);
 +	} else if (cfg.normalgit && git_statuses.show)
 +		n -= 3;
-
+ 
  	/* 2 columns for preceding space and indicator */
  	return (n - 2);
-@@ -8144,6 +8259,7 @@ static void usage(void)
+@@ -8148,6 +8262,7 @@ static void usage(void)
  		" -F val  fifo mode [0:preview 1:explore]\n"
  #endif
  		" -g      regex filters\n"
@@ -211,7 +203,7 @@ index 508ee915..77d56d63 100644
  		" -H      show hidden files\n"
  		" -i      show current file info\n"
  		" -J      no auto-advance on selection\n"
-@@ -8282,6 +8398,7 @@ static void cleanup(void)
+@@ -8286,6 +8401,7 @@ static void cleanup(void)
  		fflush(stdout);
  	}
  #endif
@@ -219,8 +211,8 @@ index 508ee915..77d56d63 100644
  	free(selpath);
  	free(plgpath);
  	free(cfgpath);
-@@ -8326,7 +8443,7 @@ int main(int argc, char *argv[])
-
+@@ -8330,7 +8446,7 @@ int main(int argc, char *argv[])
+ 
  	while ((opt = (env_opts_id > 0
  		       ? env_opts[--env_opts_id]
 -		       : getopt(argc, argv, "aAb:cCdDeEfF:gHiJKl:nop:P:QrRs:St:T:uUVxh"))) != -1) {
@@ -228,7 +220,7 @@ index 508ee915..77d56d63 100644
  		switch (opt) {
  #ifndef NOFIFO
  		case 'a':
-@@ -8377,6 +8494,9 @@ int main(int argc, char *argv[])
+@@ -8381,6 +8497,9 @@ int main(int argc, char *argv[])
  			cfg.regex = 1;
  			filterfn = &visible_re;
  			break;

--- a/patches/gitstatus/namefirst.diff
+++ b/patches/gitstatus/namefirst.diff
@@ -70,14 +70,6 @@ index ee1f5beb..91aab231 100644
 
  /* Configuration, contexts */
  static settings cfg = {
-@@ -429,6 +460,7 @@ static settings cfg = {
- 	0, /* cliopener */
- 	0, /* waitedit */
- 	1, /* rollover */
-+	0, /* normalgit */
- };
-
- static context g_ctx[CTX_MAX] __attribute__ ((aligned));
 @@ -3846,6 +3878,56 @@ static int get_kv_key(kv *kvarr, char *val, uchar_t max, uchar_t id)
  	return -1;
  }

--- a/patches/namefirst/mainline.diff
+++ b/patches/namefirst/mainline.diff
@@ -4,23 +4,23 @@
 # Author: Luuk van Baal
 
 diff --git a/src/nnn.c b/src/nnn.c
-index 508ee915..ee1f5beb 100644
+index f8a2c58..9802a1f 100644
 --- a/src/nnn.c
 +++ b/src/nnn.c
 @@ -394,6 +394,10 @@ typedef struct {
  } session_header_t;
  #endif
-
+ 
 +static struct {
 +	ushort_t maxnameln, maxsizeln, maxuidln, maxgidln, maxentln, uidln, gidln, printguid;
 +} dtls;
 +
  /* GLOBALS */
-
+ 
  /* Configuration, contexts */
-@@ -1091,10 +1095,12 @@ static char *getpwname(uid_t uid)
+@@ -1070,10 +1074,12 @@ static char *getpwname(uid_t uid)
  	static char *namecache;
-
+ 
  	if (uidcache != uid) {
 +		if (dtls.maxuidln && !dtls.printguid) dtls.printguid = 1;
  		struct passwd *pw = getpwuid(uid);
@@ -29,22 +29,22 @@ index 508ee915..ee1f5beb 100644
  		namecache = pw ? pw->pw_name : NULL;
 +		dtls.uidln = xstrlen(namecache ? namecache : xitoa(uid));
  	}
-
+ 
  	return namecache ? namecache : xitoa(uid);
-@@ -1106,10 +1112,12 @@ static char *getgrname(gid_t gid)
+@@ -1085,10 +1091,12 @@ static char *getgrname(gid_t gid)
  	static char *grpcache;
-
+ 
  	if (gidcache != gid) {
 +		if (dtls.maxgidln && !dtls.printguid) dtls.printguid = 1;
  		struct group *gr = getgrgid(gid);
-
+ 
  		gidcache = gid;
  		grpcache = gr ? gr->gr_name : NULL;
 +		dtls.gidln = xstrlen(grpcache ? grpcache : xitoa(gid));
  	}
-
+ 
  	return grpcache ? grpcache : xitoa(gid);
-@@ -3853,14 +3861,13 @@ static void resetdircolor(int flags)
+@@ -3834,14 +3842,13 @@ static void resetdircolor(int flags)
   * Max supported str length: NAME_MAX;
   */
  #ifdef NOLC
@@ -62,16 +62,16 @@ index 508ee915..ee1f5beb 100644
  {
  	wchar_t * const wbuf = (wchar_t *)g_buf;
  	wchar_t *buf = wbuf;
-@@ -3885,7 +3892,7 @@ static wchar_t *unescape(const char *str, uint_t maxcols)
+@@ -3866,7 +3873,7 @@ static wchar_t *unescape(const char *str, uint_t maxcols)
  		++buf;
  	}
-
+ 
 -	return wbuf;
 +	return len;
  }
-
+ 
  static off_t get_size(off_t size, off_t *pval, int comp)
-@@ -4153,33 +4160,7 @@ static uchar_t get_color_pair_name_ind(const struct entry *ent, char *pind, int
+@@ -4134,33 +4141,7 @@ static uchar_t get_color_pair_name_ind(const struct entry *ent, char *pind, int
  static void printent(const struct entry *ent, uint_t namecols, bool sel)
  {
  	char ind = '\0';
@@ -104,11 +104,11 @@ index 508ee915..ee1f5beb 100644
 -
 +	int attrs = 0, namelen;
  	uchar_t color_pair = get_color_pair_name_ind(ent, &ind, &attrs);
-
+ 
  	addch((ent->flags & FILE_SELECTED) ? '+' | A_REVERSE | A_BOLD : ' ');
-@@ -4204,15 +4185,40 @@ static void printent(const struct entry *ent, uint_t namecols, bool sel)
+@@ -4185,15 +4166,40 @@ static void printent(const struct entry *ent, uint_t namecols, bool sel)
  		++namecols;
-
+ 
  #ifndef NOLC
 -	addwstr(unescape(ent->name, namecols));
 +	addwstr((namelen = unescape(ent->name, namecols), (wchar_t *)g_buf));
@@ -116,7 +116,7 @@ index 508ee915..ee1f5beb 100644
 -	addstr(unescape(ent->name, MIN(namecols, ent->nlen) + 1));
 +	addstr((namelen = unescape(ent->name, MIN(namecols, ent->nlen) + 1), (char *)g_buf));
  #endif
-
+ 
 -	if (attrs)
 +	if (!sel && attrs)
  		attroff(attrs);
@@ -148,12 +148,12 @@ index 508ee915..ee1f5beb 100644
 +	if (attrs)
 +		attroff(attrs);
  }
-
+ 
  static void savecurctx(char *path, char *curname, int nextctx)
-@@ -6357,14 +6363,6 @@ static void statusbar(char *path)
+@@ -6356,26 +6362,19 @@ static void statusbar(char *path)
  	tocursor();
  }
-
+ 
 -static inline void markhovered(void)
 -{
 -	if (cfg.showdetail && ndents) { /* Bold forward arrowhead */
@@ -165,11 +165,12 @@ index 508ee915..ee1f5beb 100644
  static int adjust_cols(int n)
  {
  	/* Calculate the number of cols available to print entry name */
-@@ -6372,11 +6370,10 @@ static int adjust_cols(int n)
- 	n -= (g_state.oldcolor ? 0 : 1 + ICON_PADDING_LEFT_LEN + ICON_PADDING_RIGHT_LEN);
+ #ifdef ICONS_ENABLED
+ 	n -= (g_state.oldcolor ? 0 : ICON_SIZE + ICON_PADDING_LEFT_LEN + ICON_PADDING_RIGHT_LEN);
  #endif
++
  	if (cfg.showdetail) {
--		/* Fallback to light mode if less than 35 columns */
+ 		/* Fallback to light mode if less than 35 columns */
 -		if (n < 36)
 +		if (n < (dtls.maxentln + 1 - dtls.maxnameln))
  			cfg.showdetail ^= 1;
@@ -177,21 +178,21 @@ index 508ee915..ee1f5beb 100644
 -			n -= 32;
 +			n -= (dtls.maxentln - 2 - dtls.maxnameln);
  	}
-
+ 
  	/* 2 columns for preceding space and indicator */
-@@ -6413,8 +6410,6 @@ static void draw_line(int ncols)
+@@ -6412,8 +6411,6 @@ static void draw_line(int ncols)
  	/* Must reset e.g. no files in dir */
  	if (dir)
  		attroff(COLOR_PAIR(cfg.curctx + 1) | A_BOLD);
 -
 -	markhovered();
  }
-
+ 
  static void redraw(char *path)
-@@ -6522,6 +6517,21 @@ static void redraw(char *path)
+@@ -6521,6 +6518,21 @@ static void redraw(char *path)
  
  	onscreen = MIN(onscreen + curscroll, ndents);
-
+ 
 +	if (cfg.showdetail) {
 +		ushort_t lenbuf = dtls.maxnameln = dtls.maxsizeln = dtls.maxuidln = dtls.maxgidln = dtls.printguid = 0;
 +		for (i = curscroll; i < onscreen; ++i) {
@@ -208,14 +209,14 @@ index 508ee915..ee1f5beb 100644
 +	}
 +
  	ncols = adjust_cols(ncols);
-
+ 
  	int len = scanselforpath(path, FALSE);
-@@ -6552,7 +6562,7 @@ static void redraw(char *path)
+@@ -6551,7 +6563,7 @@ static void redraw(char *path)
  #endif
  	}
-
+ 
 -	markhovered();
 +	statusbar(path);
  }
-
+ 
  static bool cdprep(char *lastdir, char *lastname, char *path, char *newpath)

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3073,9 +3073,8 @@ try_quit:
 #ifdef LINUX_INOTIFY
 		if (!cfg.blkorder && inotify_wd >= 0 && (idle & 1)) {
 			struct inotify_event *event;
-			char inotify_buf[EVENT_BUF_LEN];
+			char inotify_buf[EVENT_BUF_LEN] = {0};
 
-			memset((void *)inotify_buf, 0x0, EVENT_BUF_LEN);
 			i = read(inotify_fd, inotify_buf, EVENT_BUF_LEN);
 			if (i > 0) {
 				for (char *ptr = inotify_buf;
@@ -3097,9 +3096,8 @@ try_quit:
 		}
 #elif defined(BSD_KQUEUE)
 		if (!cfg.blkorder && event_fd >= 0 && (idle & 1)) {
-			struct kevent event_data[NUM_EVENT_SLOTS];
+			struct kevent event_data[NUM_EVENT_SLOTS] = {0};
 
-			memset((void *)event_data, 0x0, sizeof(struct kevent) * NUM_EVENT_SLOTS);
 			if (kevent(kq, events_to_monitor, NUM_EVENT_SLOTS,
 				   event_data, NUM_EVENT_FDS, &gtimeout) > 0)
 				c = handle_event();
@@ -4236,12 +4234,10 @@ static void savecurctx(char *path, char *curname, int nextctx)
 static void save_session(const char *sname, int *presel)
 {
 	int fd, i;
-	session_header_t header;
+	session_header_t header = {0};
 	bool status = FALSE;
 	char ssnpath[PATH_MAX];
 	char spath[PATH_MAX];
-
-	memset(&header, 0, sizeof(session_header_t));
 
 	header.ver = SESSIONS_VERSION;
 
@@ -6589,7 +6585,7 @@ static bool browse(char *ipath, const char *session, int pkey)
 
 #ifndef NOMOUSE
 	MEVENT event = {0};
-	struct timespec mousetimings[2] = {{.tv_sec = 0, .tv_nsec = 0}, {.tv_sec = 0, .tv_nsec = 0} };
+	struct timespec mousetimings[2] = {0};
 	int mousedent[2] = {-1, -1};
 	bool currentmouse = 1, rightclicksel = 0;
 #endif

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -314,7 +314,6 @@ typedef struct {
 
 /*
  * Settings
- * NOTE: update default values if changing order
  */
 typedef struct {
 	uint_t filtermode : 1;  /* Set to enter filter mode */
@@ -399,33 +398,10 @@ typedef struct {
 
 /* Configuration, contexts */
 static settings cfg = {
-	0, /* filtermode */
-	0, /* timeorder */
-	0, /* sizeorder */
-	0, /* apparentsz */
-	0, /* blkorder */
-	0, /* extnorder */
-	0, /* showhidden */
-	0, /* reserved0 */
-	0, /* showdetail */
-	1, /* ctxactive */
-	0, /* reverse */
-	0, /* version */
-	0, /* reserved1 */
-	0, /* curctx */
-	0, /* prefersel */
-	0, /* fileinfo */
-	0, /* nonavopen */
-	1, /* autoenter */
-	0, /* reserved2 */
-	0, /* useeditor */
-	0, /* reserved3 */
-	0, /* regex */
-	0, /* x11 */
-	2, /* timetype (T_MOD) */
-	0, /* cliopener */
-	0, /* waitedit */
-	1, /* rollover */
+	.ctxactive = 1,
+	.autoenter = 1,
+	.timetype = 2, /* T_MOD */
+	.rollover = 1,
 };
 
 static context g_ctx[CTX_MAX] __attribute__ ((aligned));

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -1033,7 +1033,7 @@ static inline bool is_prefix(const char *restrict str, const char *restrict pref
 
 /*
  * The poor man's implementation of memrchr(3).
- * We are only looking for '/' in this program.
+ * We are only looking for '/' and '.' in this program.
  * And we are NOT expecting a '/' at the end.
  * Ideally 0 < n <= xstrlen(s).
  */


### PR DESCRIPTION
A couple small changes to get rid of some unnecessary code, no changes in functionality intended:

* Fix an incorrect comment on `xmemrchr()`.
* Use designated initializer instead of initializing `cfg` manually.
* Initialize to 0 instead of `memset`-ing to 0.