### PR TITLE
make it easy to check for failing patches locally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,4 @@ jobs:
         env:
           CC: gcc
         run: |
-          export PATCH_OPTS="--merge"
-          patches=("O_GITSTATUS" "O_NAMEFIRST" "O_RESTOREPREVIEW")
-          z=$(( 1 << ${#patches[@]} ))
-          for ((n=1; n < z; ++n)); do
-            for ((i=0; i < ${#patches[@]}; ++i)); do
-              printf "%s=%d " "${patches[$i]}" "$(( (n & (1 << i)) != 0 ))"
-            done | tee "tmp" ; echo
-            make clean -s
-            xargs make <"tmp"
-          done
+          make checkpatches

--- a/Makefile
+++ b/Makefile
@@ -310,6 +310,9 @@ upload-local: sign static musl
 clean:
 	$(RM) -f $(BIN) nnn-$(VERSION).tar.gz *.sig $(BIN)-static $(BIN)-static-$(VERSION).x86_64.tar.gz $(BIN)-icons-static $(BIN)-icons-static-$(VERSION).x86_64.tar.gz $(BIN)-nerd-static $(BIN)-nerd-static-$(VERSION).x86_64.tar.gz $(BIN)-emoji-static $(BIN)-emoji-static-$(VERSION).x86_64.tar.gz $(BIN)-musl-static $(BIN)-musl-static-$(VERSION).x86_64.tar.gz
 
+checkpatches:
+	./patches/check-patches.sh
+
 prepatch:
 ifeq ($(strip $(O_NAMEFIRST)),1)
 	patch --forward $(PATCH_OPTS) --strip=1 --input=$(NAMEFIRST)/mainline.diff

--- a/patches/README.md
+++ b/patches/README.md
@@ -16,7 +16,11 @@ To apply a patch, use the corresponding make variable, e.g.:
 
     make O_NAMEFIRST=1
 
+When contributing/adding a new patch, make sure to add the make variable to the patches array in `./misc/test/check-patches.sh` as well so that patch failures can be easily tested.
+
 ## Resolving patch conflicts
+
+Patch conflicts can be checked locally by running `make checkpatches` or by running `./patches/check-patches.sh` manually.
 
 Whenever patch conflicts occur on the latest master, pull requests resolving them are welcome. Let's say a conflict occurs in the `restorepreview` patch. The best way to resolve this conflict would be something along the lines of:
 

--- a/patches/check-patches.sh
+++ b/patches/check-patches.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Usage: ./misc/test/check-patches.sh
+#
+# Bash script that checks for any of the patches failing to apply.
+# Read patches/README.md for more information.
+
+export PATCH_OPTS="--merge"
+patches=("O_GITSTATUS" "O_NAMEFIRST" "O_RESTOREPREVIEW")
+z=$(( 1 << ${#patches[@]} ))
+pid=$$
+ret=0
+trap 'ret=1' SIGUSR1
+
+for ((n=1; n < z; ++n)); do
+    for ((i=0; i < ${#patches[@]}; ++i)); do
+        printf "%s=%d " "${patches[$i]}" "$(( (n & (1 << i)) != 0 ))"
+    done | tee "/dev/stderr" | (
+        make clean -s
+        xargs make 2>&1
+        if [ "$?" -ne 0 ]; then
+            echo "[FAILED]" >&2
+            kill -SIGUSR1 "$pid"
+        else
+            echo "[SUCCESS]" >&2
+        fi
+        git restore src
+    ) >/dev/null
+done
+exit "$ret"


### PR DESCRIPTION
adds a script `check-patches.sh` to check for patch failures and also
adds a make target `checkpatches` which will invoke the check-patches
script.