### PR TITLE
Update plugin name in Configuration section

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -103,7 +103,7 @@ Plugins are installed to `${XDG_CONFIG_HOME:-$HOME/.config}/nnn/plugins`.
 Set environment variable `NNN_PLUG` to assign keybinds and invoke plugins directly using the plugin shortcut (<kbd>;</kbd>) followed by the assigned key character. E.g., with the below config:
 
 ```sh
-export NNN_PLUG='f:finder;o:fzopen;p:mocplay;d:diffs;t:nmount;v:imgview'
+export NNN_PLUG='f:finder;o:fzopen;p:mocq;d:diffs;t:nmount;v:imgview'
 ```
 
 plugin `finder` can be invoked with the keybind <kbd>;f</kbd>, `fzopen` can be run with <kbd>;o</kbd> and so on... The key vs. plugin pairs are shown in the help and config screen.


### PR DESCRIPTION
As the plugin was renamed from 'mocplay' to 'mocq' in 4dcefcc4d4a1f4b0d3c62d6c842eb5ced4c26d5b