### PR TITLE
Escape call to `nnn` so `nnn` can be used as an alias to `n`

### DIFF
--- a/misc/quitcd/quitcd.bash_zsh
+++ b/misc/quitcd/quitcd.bash_zsh
@@ -19,7 +19,7 @@ n ()
     # stty lwrap undef
     # stty lnext undef
 
-    nnn "$@"
+    \nnn "$@"
 
     if [ -f "$NNN_TMPFILE" ]; then
             . "$NNN_TMPFILE"

--- a/misc/quitcd/quitcd.bash_zsh
+++ b/misc/quitcd/quitcd.bash_zsh
@@ -19,7 +19,7 @@ n ()
     # stty lwrap undef
     # stty lnext undef
 
-    # The backslash allows one to alias nnn to n if desired without making an
+    # The backslash allows one to alias n to nnn if desired without making an
     # infinitely recursive alias
     \nnn "$@"
 

--- a/misc/quitcd/quitcd.bash_zsh
+++ b/misc/quitcd/quitcd.bash_zsh
@@ -19,6 +19,8 @@ n ()
     # stty lwrap undef
     # stty lnext undef
 
+    # The backslash allows one to alias nnn to n if desired without making an
+    # infinitely recursive alias
     \nnn "$@"
 
     if [ -f "$NNN_TMPFILE" ]; then

--- a/misc/quitcd/quitcd.csh
+++ b/misc/quitcd/quitcd.csh
@@ -12,6 +12,6 @@ set NNN_TMPFILE=~/.config/nnn/.lastd
 # stty lwrap undef
 # stty lnext undef
 
-# The backslash allows one to alias nnn to n if desired without making an
+# The backslash allows one to alias n to nnn if desired without making an
 # infinitely recursive alias
 alias n '\nnn; source "$NNN_TMPFILE"; rm -f "$NNN_TMPFILE"'

--- a/misc/quitcd/quitcd.csh
+++ b/misc/quitcd/quitcd.csh
@@ -12,4 +12,6 @@ set NNN_TMPFILE=~/.config/nnn/.lastd
 # stty lwrap undef
 # stty lnext undef
 
-alias n 'nnn; source "$NNN_TMPFILE"; rm -f "$NNN_TMPFILE"'
+# The backslash allows one to alias nnn to n if desired without making an
+# infinitely recursive alias
+alias n '\nnn; source "$NNN_TMPFILE"; rm -f "$NNN_TMPFILE"'

--- a/misc/quitcd/quitcd.elv
+++ b/misc/quitcd/quitcd.elv
@@ -30,7 +30,7 @@ fn n {|@a|
   # stty lwrap undef
   # stty lnext undef
 
-	# The e: prefix allows one to alias nnn to n if desired without making an
+	# The e: prefix allows one to alias n to nnn if desired without making an
 	# infinitely recursive alias
 	e:nnn $@a
 

--- a/misc/quitcd/quitcd.elv
+++ b/misc/quitcd/quitcd.elv
@@ -30,6 +30,8 @@ fn n {|@a|
   # stty lwrap undef
   # stty lnext undef
 
+	# The e: prefix allows one to alias nnn to n if desired without making an
+	# infinitely recursive alias
 	e:nnn $@a
 
 	if (path:is-regular $E:NNN_TMPFILE) {

--- a/misc/quitcd/quitcd.fish
+++ b/misc/quitcd/quitcd.fish
@@ -27,7 +27,7 @@ function n --wraps nnn --description 'support nnn quit and change directory'
     # stty lwrap undef
     # stty lnext undef
 
-    # The command function allowa one to alias nnn to n if desired without
+    # The command function allowa one to alias n to nnn if desired without
     # making an infinitely recursive alias
     command nnn $argv
 

--- a/misc/quitcd/quitcd.fish
+++ b/misc/quitcd/quitcd.fish
@@ -27,7 +27,9 @@ function n --wraps nnn --description 'support nnn quit and change directory'
     # stty lwrap undef
     # stty lnext undef
 
-    nnn $argv
+    # The command function allowa one to alias nnn to n if desired without
+    # making an infinitely recursive alias
+    command nnn $argv
 
     if test -e $NNN_TMPFILE
         source $NNN_TMPFILE


### PR DESCRIPTION
Currently, if you use quitcd and set `nnn` to be an alias of `n` in bash or zsh, you will get the following error if you try to run nnn: `maximum nested function level reached; increase FUNCNEST?`. Escaping the call to `nnn` in quitcd lets you use `nnn` as an alias to `n` without raising this error.