### PR TITLE
icons: Add support for FontAwesome6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ O_NOFIFO := 0  # no FIFO previewer support
 O_CTX8 := 0  # enable 8 contexts
 O_ICONS := 0  # support icons-in-terminal
 O_NERD := 0  # support icons-nerdfont
+O_FONTAWESOME := 0  # support icons-fontawesome
 O_EMOJI := 0  # support emoji
 O_QSORT := 0  # use Alexey Tourbin's QSORT implementation
 O_BENCH := 0  # benchmark mode (stops at first user input)
@@ -71,6 +72,8 @@ ifeq ($(strip $(O_NOLC)),1)
 $(info *** Ignoring O_NOLC since O_ICONS is set ***)
 	else ifeq ($(strip $(O_NERD)),1)
 $(info *** Ignoring O_NOLC since O_NERD is set ***)
+	else ifeq ($(strip $(O_FONTAWESOME)),1)
+$(info *** Ignoring O_NOLC since O_FONTAWESOME is set ***)
 	else ifeq ($(strip $(O_EMOJI)),1)
 $(info *** Ignoring O_NOLC since O_EMOJI is set ***)
 	else
@@ -100,6 +103,10 @@ endif
 
 ifeq ($(strip $(O_NERD)),1)
 	CPPFLAGS += -DNERD
+endif
+
+ifeq ($(strip $(O_FONTAWESOME)),1)
+	CPPFLAGS += -DFONTAWESOME
 endif
 
 ifeq ($(strip $(O_EMOJI)),1)
@@ -193,6 +200,9 @@ endif
 ifeq ($(strip $(O_NERD)),1)
 	HEADERS += src/icons.h src/icons-nerdfont.h
 endif
+ifeq ($(strip $(O_FONTAWESOME)),1)
+	HEADERS += src/icons.h src/icons-fontawesome.h
+endif
 ifeq ($(strip $(O_ICONS)),1)
 	HEADERS += src/icons.h src/icons-in-terminal.h
 endif
@@ -252,6 +262,9 @@ static:
 	# static binary with patched nerd font support
 	make O_STATIC=1 O_NERD=1 strip
 	mv $(BIN) $(BIN)-nerd-static
+	# static binary with patched fontawesome support
+	make O_STATIC=1 O_FONTAWESOME=1 strip
+	mv $(BIN) $(BIN)-fontawesome-static
 	# static binary with emoji support
 	make O_STATIC=1 O_EMOJI=1 strip
 	mv $(BIN) $(BIN)-emoji-static

--- a/src/icons-fontawesome.h
+++ b/src/icons-fontawesome.h
@@ -2,7 +2,7 @@
 #define ICONS_FONTAWESOME
 
 // You can find hex codes for nerd fonts here
-// https://www.nerdfonts.com/cheat-sheet
+// https://fontawesome.com/icons/
 
 // Arrows
 #define MD_ARROW_UPWARD    "\uf062"
@@ -27,7 +27,7 @@
 #define ICON_DATABASE      "\uf1c0"
 #define ICON_DESKTOP       "\uf390"
 #define ICON_DIFF          "\uf440" //
-#define ICON_DOCUMENT      "\uf0b1"
+#define ICON_DOCUMENT      "\uf15c"
 #define ICON_DOWNLOADS     "\uf019"
 #define ICON_ENCRYPT       "\uf084"
 #define ICON_FSHARP        "\ue7a7" //

--- a/src/icons-fontawesome.h
+++ b/src/icons-fontawesome.h
@@ -1,0 +1,277 @@
+#ifndef ICONS_FONTAWESOME
+#define ICONS_FONTAWESOME
+
+// You can find hex codes for nerd fonts here
+// https://www.nerdfonts.com/cheat-sheet
+
+// Arrows
+#define MD_ARROW_UPWARD    "\uf062"
+#define MD_ARROW_FORWARD   "\uf061"
+#define MD_ARROW_DOWNWARD  "\uf063"
+
+// Generics
+#define ICON_DIRECTORY     "\uf07b"
+#define ICON_FILE          "\uf15b"
+#define ICON_EXEC          "\uf144"
+#define ICON_MANUAL        "\uf518"
+
+// Top level and common icons
+#define ICON_ARCHIVE       "\uf1c6"
+#define ICON_BRIEFCASE     "\uf0b1"
+#define ICON_C             "\ue61e"
+#define ICON_CHANGELOG     "\uf1da"
+#define ICON_CHESS         "\uf441"
+#define ICON_CLOJURE       "\ue76a" //
+#define ICON_CONFIGURE     "\uf013"
+#define ICON_CPLUSPLUS     "\ue61d" //
+#define ICON_DATABASE      "\uf1c0"
+#define ICON_DESKTOP       "\uf390"
+#define ICON_DIFF          "\uf440" //
+#define ICON_DOCUMENT      "\uf0b1"
+#define ICON_DOWNLOADS     "\uf019"
+#define ICON_ENCRYPT       "\uf084"
+#define ICON_FSHARP        "\ue7a7" //
+#define ICON_GIT           "\uf841"
+#define ICON_HASKELL       "\ue777"
+#define ICON_HTML          "\uf13b"
+#define ICON_JAVA          "\uf4e4"
+#define ICON_JAVASCRIPT    "\uf3b9"
+#define ICON_LICENSE       "\uf56c"
+#define ICON_LINUX         "\uf17c"
+#define ICON_MAKEFILE      "\uf68c" //
+#define ICON_MUSIC         "\uf001"
+#define ICON_MUSICFILE     "\uf1c7"
+#define ICON_OPTICALDISK   "\uf51f"
+#define ICON_PICTUREFILE   "\uf1c5"
+#define ICON_PICTURES      "\uf302"
+#define ICON_PLAYLIST      "\uf910"
+#define ICON_PUBLIC        ICON_DIRECTORY
+#define ICON_PYTHON        "\uf3e2"
+#define ICON_REACT         "\uf41b"
+#define ICON_RUBY          "\ue23e" //
+#define ICON_SCRIPT        "\uf120"
+#define ICON_TEMPLATES     "\ufac6" //
+#define ICON_TEX           "\ufb68" //
+#define ICON_VIDEOFILE     "\uf1c8"
+#define ICON_VIDEOS        "\uf03d"
+#define ICON_WORDDOC       "\uf1c2"
+
+
+/* Numbers */
+#define ICON_EXT_1         ICON_MANUAL
+#define ICON_EXT_7Z        ICON_ARCHIVE
+
+/* A */
+#define ICON_EXT_A         ICON_MANUAL
+#define ICON_EXT_APK       ICON_ARCHIVE
+#define ICON_EXT_ASM       ICON_FILE
+#define ICON_EXT_AUP       ICON_MUSICFILE
+#define ICON_EXT_AVI       ICON_VIDEOFILE
+
+/* B */
+#define ICON_EXT_BAT       ICON_SCRIPT
+#define ICON_EXT_BIB       ICON_TEX
+#define ICON_EXT_BIN       "\uf471" //
+#define ICON_EXT_BMP       ICON_PICTUREFILE
+#define ICON_EXT_BZ2       ICON_ARCHIVE
+
+/* C */
+#define ICON_EXT_C         ICON_C
+#define ICON_EXT_CPLUSPLUS ICON_CPLUSPLUS
+#define ICON_EXT_CAB       ICON_ARCHIVE
+#define ICON_EXT_CABAL     ICON_HASKELL
+#define ICON_EXT_CBR       ICON_ARCHIVE
+#define ICON_EXT_CBZ       ICON_ARCHIVE
+#define ICON_EXT_CC        ICON_CPLUSPLUS
+#define ICON_EXT_CLASS     ICON_JAVA
+#define ICON_EXT_CLJ       ICON_CLOJURE
+#define ICON_EXT_CLJC      ICON_CLOJURE
+#define ICON_EXT_CLJS      ICON_CLOJURE
+#define ICON_EXT_CLS       ICON_TEX
+#define ICON_EXT_CMAKE     ICON_MAKEFILE
+#define ICON_EXT_COFFEE    "\uf7b6"
+#define ICON_EXT_CONF      ICON_CONFIGURE
+#define ICON_EXT_CPIO      ICON_ARCHIVE
+#define ICON_EXT_CPP       ICON_CPLUSPLUS
+#define ICON_EXT_CSS       "\uf38b"
+#define ICON_EXT_CUE       ICON_PLAYLIST
+#define ICON_EXT_CVS       ICON_CONFIGURE
+#define ICON_EXT_CXX       ICON_CPLUSPLUS
+
+/* D */
+#define ICON_EXT_DB        ICON_DATABASE
+#define ICON_EXT_DEB       "\ue77d" //
+#define ICON_EXT_DIFF      ICON_DIFF
+#define ICON_EXT_DLL       ICON_SCRIPT
+#define ICON_EXT_DOC       ICON_WORDDOC
+#define ICON_EXT_DOCX      ICON_WORDDOC
+
+/* E */
+#define ICON_EXT_EJS       ICON_JAVASCRIPT
+#define ICON_EXT_ELF       ICON_LINUX
+#define ICON_EXT_EPUB      ICON_MANUAL
+#define ICON_EXT_EXE       ICON_EXEC
+
+/* F */
+#define ICON_EXT_FEN       ICON_CHESS
+#define ICON_EXT_FSHARP    ICON_FSHARP
+#define ICON_EXT_FLAC      ICON_MUSICFILE
+#define ICON_EXT_FLV       ICON_VIDEOFILE
+#define ICON_EXT_FS        ICON_FSHARP
+#define ICON_EXT_FSI       ICON_FSHARP
+#define ICON_EXT_FSSCRIPT  ICON_FSHARP
+#define ICON_EXT_FSX       ICON_FSHARP
+
+/* G */
+#define ICON_EXT_GEM       ICON_RUBY
+#define ICON_EXT_GIF       ICON_PICTUREFILE
+#define ICON_EXT_GO        "\ue40f"
+#define ICON_EXT_GPG       ICON_ENCRYPT
+#define ICON_EXT_GZ        ICON_ARCHIVE
+#define ICON_EXT_GZIP      ICON_ARCHIVE
+
+/* H */
+#define ICON_EXT_H         ICON_C
+#define ICON_EXT_HH        ICON_CPLUSPLUS
+#define ICON_EXT_HPP       ICON_CPLUSPLUS
+#define ICON_EXT_HS        ICON_HASKELL
+#define ICON_EXT_HTACCESS  ICON_CONFIGURE
+#define ICON_EXT_HTPASSWD  ICON_CONFIGURE
+#define ICON_EXT_HTM       ICON_HTML
+#define ICON_EXT_HTML      ICON_HTML
+#define ICON_EXT_HXX       ICON_CPLUSPLUS
+
+/* I */
+#define ICON_EXT_ICO       ICON_PICTUREFILE
+#define ICON_EXT_IMG       ICON_OPTICALDISK
+#define ICON_EXT_INI       ICON_CONFIGURE
+#define ICON_EXT_ISO       ICON_OPTICALDISK
+
+/* J */
+#define ICON_EXT_JAR       ICON_JAVA
+#define ICON_EXT_JAVA      ICON_JAVA
+#define ICON_EXT_JL        ICON_CONFIGURE
+#define ICON_EXT_JPEG      ICON_PICTUREFILE
+#define ICON_EXT_JPG       ICON_PICTUREFILE
+#define ICON_EXT_JS        ICON_JAVASCRIPT
+#define ICON_EXT_JSON      "\ufb25" //
+#define ICON_EXT_JSX       ICON_REACT
+
+/* K */
+
+/* L */
+#define ICON_EXT_LHA       ICON_ARCHIVE
+#define ICON_EXT_LHS       ICON_HASKELL
+#define ICON_EXT_LOG       ICON_DOCUMENT
+#define ICON_EXT_LUA       "\ue620" //
+#define ICON_EXT_LZH       ICON_ARCHIVE
+#define ICON_EXT_LZMA      ICON_ARCHIVE
+
+/* M */
+#define ICON_EXT_M4A       ICON_MUSICFILE
+#define ICON_EXT_M4V       ICON_VIDEOFILE
+#define ICON_EXT_M         "\ufd1c" //
+#define ICON_EXT_MAT       "\uf0ce"
+#define ICON_EXT_MD        "\uf60f"
+#define ICON_EXT_MK        ICON_MAKEFILE
+#define ICON_EXT_MKV       ICON_VIDEOFILE
+#define ICON_EXT_MOV       ICON_VIDEOFILE
+#define ICON_EXT_MP3       ICON_MUSICFILE
+#define ICON_EXT_MP4       ICON_VIDEOFILE
+#define ICON_EXT_MPEG      ICON_VIDEOFILE
+#define ICON_EXT_MPG       ICON_VIDEOFILE
+#define ICON_EXT_MSI       "\uf3ca"
+
+/* N */
+#define ICON_EXT_NIX       "\uf313" //
+
+/* O */
+#define ICON_EXT_O         ICON_MANUAL
+#define ICON_EXT_OGG       ICON_MUSICFILE
+#define ICON_EXT_OPUS      ICON_MUSICFILE
+#define ICON_EXT_ODOWNLOAD ICON_DOWNLOADS
+#define ICON_EXT_OUT       ICON_LINUX
+
+/* P */
+#define ICON_EXT_PART      ICON_DOWNLOADS
+#define ICON_EXT_PATCH     ICON_DIFF
+#define ICON_EXT_PDF       "\uf1c1"
+#define ICON_EXT_PGN       ICON_CHESS
+#define ICON_EXT_PHP       "\uf457"
+#define ICON_EXT_PNG       ICON_PICTUREFILE
+#define ICON_EXT_PPT       "\uf1c4"
+#define ICON_EXT_PPTX      "\uf1c4"
+#define ICON_EXT_PSB       "\ue7b8" //
+#define ICON_EXT_PSD       "\ue7b8" //
+#define ICON_EXT_PY        ICON_PYTHON
+#define ICON_EXT_PYC       ICON_PYTHON
+#define ICON_EXT_PYD       ICON_PYTHON
+#define ICON_EXT_PYO       ICON_PYTHON
+
+/* Q */
+
+/* R */
+#define ICON_EXT_RAR       ICON_ARCHIVE
+#define ICON_EXT_RC        ICON_CONFIGURE
+#define ICON_EXT_ROM       "\uf11b"
+#define ICON_EXT_RPM       ICON_ARCHIVE
+#define ICON_EXT_RSS       "\uf143"
+#define ICON_EXT_RTF       "\uf1c1"
+#define ICON_EXT_RB        ICON_RUBY
+
+/* S */
+#define ICON_EXT_SASS      "\uf41e"
+#define ICON_EXT_SCSS      "\uf41e"
+#define ICON_EXT_SO        ICON_MANUAL
+#define ICON_EXT_SCALA     "\ue737" //
+#define ICON_EXT_SH        ICON_SCRIPT
+#define ICON_EXT_SLIM      ICON_SCRIPT
+#define ICON_EXT_SLN       "\ue70c" //
+#define ICON_EXT_SQL       ICON_DATABASE
+#define ICON_EXT_SRT       "\uf20a"
+#define ICON_EXT_STY       ICON_TEX
+#define ICON_EXT_SUB       "\uf20a"
+#define ICON_EXT_SVG       ICON_PICTUREFILE
+
+/* T */
+#define ICON_EXT_TAR       ICON_ARCHIVE
+#define ICON_EXT_TEX       ICON_TEX
+#define ICON_EXT_TGZ       ICON_ARCHIVE
+#define ICON_EXT_TS        "\ue628" //
+#define ICON_EXT_TSX       ICON_REACT
+#define ICON_EXT_TXT       ICON_DOCUMENT
+#define ICON_EXT_TXZ       ICON_ARCHIVE
+
+/* U */
+
+/* V */
+#define ICON_EXT_VID       ICON_VIDEOFILE
+#define ICON_EXT_VIM       "\ue62b" //
+#define ICON_EXT_VIMRC     "\ue62b" //
+
+/* W */
+#define ICON_EXT_WAV       ICON_MUSICFILE
+#define ICON_EXT_WEBM      ICON_VIDEOFILE
+#define ICON_EXT_WEBP      ICON_PICTUREFILE
+#define ICON_EXT_WMA       ICON_VIDEOFILE
+#define ICON_EXT_WMV       ICON_VIDEOFILE
+
+/* X */
+#define ICON_EXT_XBPS      ICON_ARCHIVE
+#define ICON_EXT_XCF       ICON_PICTUREFILE
+#define ICON_EXT_XHTML     ICON_HTML
+#define ICON_EXT_XLS       "\uf1c3"
+#define ICON_EXT_XLSX      "\uf1c3"
+#define ICON_EXT_XML       ICON_HTML
+#define ICON_EXT_XZ        ICON_ARCHIVE
+
+/* Y */
+#define ICON_EXT_YAML      ICON_CONFIGURE
+#define ICON_EXT_YML       ICON_CONFIGURE
+
+/* Z */
+#define ICON_EXT_ZIP       ICON_ARCHIVE
+#define ICON_EXT_ZSH       ICON_SCRIPT
+#define ICON_EXT_ZST       ICON_ARCHIVE
+
+#endif // ICONS_FONTAWESOME

--- a/src/icons.h
+++ b/src/icons.h
@@ -4,6 +4,8 @@
 #include "icons-in-terminal.h"
 #elif defined(NERD)
 #include "icons-nerdfont.h"
+#elif defined(FONTAWESOME)
+#include "icons-fontawesome.h"
 #elif defined(EMOJI)
 #include "icons-emoji.h"
 #endif
@@ -71,7 +73,7 @@ struct icon_pair {
 static const struct icon_pair dir_icon  = {"", FA_FOLDER, 0};
 static const struct icon_pair file_icon = {"", FA_FILE_O, 0};
 static const struct icon_pair exec_icon = {"", FA_COG,    0};
-#elif defined(NERD)
+#elif defined(NERD) || defined(FONTAWESOME)
 static const struct icon_pair dir_icon  = {"", ICON_DIRECTORY, 0};
 static const struct icon_pair file_icon = {"", ICON_FILE,      0};
 static const struct icon_pair exec_icon = {"", ICON_EXEC,      0};
@@ -98,7 +100,7 @@ static const struct icon_pair icons_name[] = {
 	{"configure",    FILE_CONFIG,   0},
 	{"License",      FA_COPYRIGHT,  COLOR_DOCS},
 	{"Makefile",     FILE_CMAKE,    0},
-#elif defined(NERD)
+#elif defined(NERD) || defined(FONTAWESOME)
 	{".git",         ICON_GIT,       0},
 	{"Desktop",      ICON_DESKTOP,   0},
 	{"Documents",    ICON_BRIEFCASE, 0},
@@ -343,7 +345,7 @@ static const struct icon_pair icons_ext[] = {
 	{"zip",      FA_FILE_ARCHIVE_O,    COLOR_ARCHIVE},
 
 	/* Other */
-#elif defined(NERD)
+#elif defined(NERD) || defined(FONTAWESOME)
 	/* Numbers */
 	{"1",          ICON_EXT_1,         COLOR_DOCS},
 	{"7z",         ICON_EXT_7Z,        COLOR_ARCHIVE},

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -123,7 +123,7 @@
 #include "nnn.h"
 #include "dbg.h"
 
-#if defined(ICONS) || defined(NERD) || defined(EMOJI)
+#if defined(ICONS) || defined(NERD) || defined(FONTAWESOME) || defined(EMOJI)
 #include "icons.h"
 #define ICONS_ENABLED
 #endif


### PR DESCRIPTION
This PR adds support for icons through FontAwesome 6. This has been done because Nerd font and icons-in-terminal are pretty old and don't include Font Awesome 6 glyphs.

There are only a few glyphs which aren't covered by Font Awesome 6 (followed by // in icons-fontawesome.h), for which a fallback of Nerd font symbols is expected. I use the following fontconfig rule myself:

```xml
    <alias>
        <family>monospace</family>
        <prefer>
            <family>JetBrainsMono</family>
            <family>icons</family>
        </prefer>
    </alias>
    <alias binding="same">
        <family>icons</family>
        <prefer>
            <family>Font Awesome 6 Free Solid</family>
            <family>Font Awesome 6 Brands</family>
            <family>Symbols Nerd Font</family>
        </prefer>
    </alias>
```