### PR TITLE
Add cpoverwrite plugin

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -19,6 +19,7 @@ Plugins extend the capabilities of `nnn`. They are _executable_ scripts (or bina
 | [cdpath](cdpath) | `cd` to the directory from `CDPATH` | sh | fzf |
 | [chksum](chksum) | Create and verify checksums [✓] | sh | md5sum,<br>sha256sum |
 | [cmusq](cmusq) | Queue/play files/dirs in cmus player [✓] | sh | cmus, pgrep |
+| [cpoverwrite](cpoverwrite) | Overwrite (or not) without always specifying 'y' [✓] | sh | cp, rsync |
 | [diffs](diffs) | Diff for selection (limited to 2 for directories) [✓] | sh | vimdiff, mktemp |
 | [dragdrop](dragdrop) | Drag/drop files from/into nnn | sh | [dragon](https://github.com/mwh/dragon) |
 | [dups](dups) | List non-empty duplicate files in current dir | bash | find, md5sum,<br>sort uniq xargs |

--- a/plugins/cpoverwrite
+++ b/plugins/cpoverwrite
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+
+#set -x
+# Description: Enables you to copy(overwrite) files without needing 
+#              to explicitely state 'y' option for every file
+#
+# Dependencies: cp, rsync
+#
+# Shell: POSIX compliant
+# Author: Darukutsu 
+selection=${NNN_SEL:-${XDG_CONFIG_HOME:-$HOME/.config}/nnn/.selection}
+
+echo "
+Do you wish to overwrite existing files? y/N/d 
+y-yes; n-no(default); d-overwrites directory 
+input anything else to cancel ('q' for example)"
+
+read option
+
+case $option in
+     y | yes | Y | YES) option='if [ -d {} ]; then cp -r {} .; else cp {} .; fi';;
+  "" | n | no | N | NO) option='if [ -d {} ]; then cp -nr {} .; else cp {} .; fi';;
+		 d | D) option='if [ -d {} ]; then rsync -a --delete {} .; else cp {} .; fi';;
+		     *) echo "Nothing to do..." exit;;
+esac
+
+xargs -0 < "$selection" -I{} sh -c "$option"
+# Clear selection
+printf "-" > "$NNN_PIPE"
+

--- a/plugins/cpoverwrite
+++ b/plugins/cpoverwrite
@@ -15,7 +15,7 @@ Do you wish to overwrite existing files? y/N/d
 y-yes; n-no(default); d-overwrites directory 
 input anything else to cancel ('q' for example)"
 
-read option
+read -r option
 
 case $option in
      y | yes | Y | YES) option='if [ -d {} ]; then cp -r {} .; else cp {} .; fi';;


### PR DESCRIPTION
I stumbled across this closed [issue #810 ](https://github.com/jarun/nnn/issues/810) and tried to achieved something like that with plugin. Not sure if it's POSIX compliant since `cp -n`. I read somewhere it has some issues on mac or maybe not... I don't remember. I tested it, hopefully didn't forget something.

I was having some seizures while typing 'y' 'enter', 'y' 'enter'... The thing is if **nnn** has this feature built-in then I don't know about it.

Also what does "[✓]" mean? I didn't find reference.