### PR TITLE
slightly improve n.fish

### DIFF
--- a/misc/quitcd/quitcd.fish
+++ b/misc/quitcd/quitcd.fish
@@ -4,11 +4,9 @@
 
 function n --wraps nnn --description 'support nnn quit and change directory'
     # Block nesting of nnn in subshells
-    if test -n "$NNNLVL"
-        if [ (expr $NNNLVL + 0) -ge 1 ]
-            echo "nnn is already running"
-            return
-        end
+    if test -n "$NNNLVL" && test $NNNLVL -ge 1
+        echo "nnn is already running"
+        return
     end
 
     # The behaviour is set to cd on quit (nnn checks if NNN_TMPFILE is set)

--- a/misc/quitcd/quitcd.fish
+++ b/misc/quitcd/quitcd.fish
@@ -4,7 +4,7 @@
 
 function n --wraps nnn --description 'support nnn quit and change directory'
     # Block nesting of nnn in subshells
-    if test -n "$NNNLVL" && test $NNNLVL -ge 1
+    if test -n "$NNNLVL" -a $NNNLVL -ge 1
         echo "nnn is already running"
         return
     end

--- a/misc/quitcd/quitcd.fish
+++ b/misc/quitcd/quitcd.fish
@@ -4,7 +4,7 @@
 
 function n --wraps nnn --description 'support nnn quit and change directory'
     # Block nesting of nnn in subshells
-    if test -n "$NNNLVL" -a $NNNLVL -ge 1
+    if test -n "$NNNLVL" -a "$NNNLVL" -ge 1
         echo "nnn is already running"
         return
     end


### PR DESCRIPTION
The expr is redundant because `test -ge` treats strings as numbers already. I combined the two tests into one line because it is slightly more idiomatic (adhering universal coding phrase of check if null, and if not null then check value equality).

Tested on fish by spinning up `n`, spawning a shell, and then executing `n` again.
Other tests
```
set NNNLVL 1
test -n "$NNNLVL" -a "$NNNLVL" -ge 1 # true
set NNNLVL 2
test -n "$NNNLVL" -a "$NNNLVL" -ge 1 # true
set NNNLVL 0
test -n "$NNNLVL" -a "$NNNLVL" -ge 1 # false
set --erase NNNLVL
test -n "$NNNLVL" -a "$NNNLVL" -ge 1 # false
```