### PR TITLE
Added the ability to use 'C-g' to open with a specified editor

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -7306,8 +7306,14 @@ nochange:
 					spawn(editor, newpath, NULL, NULL, F_CLI);
 				continue;
             case SEL_CEDIT:
-                static char *ceditor;
-                spawn("nvim", newpath, NULL, NULL, F_CLI);
+                static char *ceditor; // specify editor here
+                if (!ceditor) {
+                    if (!(g_state.picker || g_state.fifomode))
+                        spawn(editor, newpath, NULL, NULL, F_CLI);
+                } else {
+                    if (!(g_state.picker || g_state.fifomode))
+                        spawn(ceditor, newpath, NULL, NULL, F_CLI);
+                }
                 continue;
 			default: /* SEL_LOCK */
 				lock_terminal();

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -7261,6 +7261,7 @@ nochange:
 		case SEL_HELP: // fallthrough
 		case SEL_AUTONEXT: // fallthrough
 		case SEL_EDIT: // fallthrough
+        case SEL_CEDIT: // fallthrough
 		case SEL_LOCK:
 		{
 			bool refresh = FALSE;
@@ -7304,6 +7305,10 @@ nochange:
 				if (!(g_state.picker || g_state.fifomode))
 					spawn(editor, newpath, NULL, NULL, F_CLI);
 				continue;
+            case SEL_CEDIT:
+                static char *ceditor;
+                spawn("nvim", newpath, NULL, NULL, F_CLI);
+                continue;
 			default: /* SEL_LOCK */
 				lock_terminal();
 				break;

--- a/src/nnn.h
+++ b/src/nnn.h
@@ -116,6 +116,7 @@ enum action {
 	SEL_QUITCD,
 	SEL_QUIT,
 	SEL_QUITERR,
+    SEL_CEDIT,
 #ifndef NOMOUSE
 	SEL_CLICK,
 #endif
@@ -154,6 +155,8 @@ static struct key bindings[] = {
 	/* First entry */
 	{ KEY_HOME,       SEL_HOME },
 	{ 'g',            SEL_HOME },
+    /* Open in specified editor */
+    { CONTROL('G'),   SEL_CEDIT },
 	{ CONTROL('A'),   SEL_HOME },
 	/* Last entry */
 	{ KEY_END,        SEL_END },


### PR DESCRIPTION
I patched in the ability to use a specified editor which is specified in src/nnn.c, and use C-g to summon it.