### PR TITLE
imgview: handle arguments as strings

### DIFF
--- a/plugins/imgview
+++ b/plugins/imgview
@@ -31,7 +31,7 @@ exit_prompt() {
 
 make_thumbs() {
     mkdir -p "$NNN_PREVIEWDIR$dir" || return
-    if [ "$1" -eq 3 ]; then
+    if [ "$1" = "3" ]; then
         [ -d "$target" ] && exit_prompt "$2 can only display a single image"
         mime="$(file -bL --mime-type -- "$target")"
         case "$mime" in
@@ -45,8 +45,8 @@ make_thumbs() {
     for file in "$dir"/*; do
         if [ ! -f "$NNN_PREVIEWDIR$file.jpg" ]; then
             case "$(file -bL --mime-type -- "$file")" in
-                audio/*) [ "$1" -ne 0 ] && ffmpeg -i "$file" "$NNN_PREVIEWDIR$file.jpg" -y >/dev/null 2>&1 ;;
-                video/*) [ "$1" -ne 1 ] && ffmpegthumbnailer -i "$file" -o "$NNN_PREVIEWDIR$file.jpg" 2> /dev/null ;;
+                audio/*) [ "$1" != "0" ] && ffmpeg -i "$file" "$NNN_PREVIEWDIR$file.jpg" -y >/dev/null 2>&1 ;;
+                video/*) [ "$1" != "1" ] && ffmpegthumbnailer -i "$file" -o "$NNN_PREVIEWDIR$file.jpg" 2> /dev/null ;;
             esac
         fi
     done
@@ -83,13 +83,13 @@ elif type lsix >/dev/null 2>&1; then
     cd "$NNN_PREVIEWDIR$dir" && lsix
     exit_prompt
 elif type ucollage >/dev/null 2>&1; then
-    type ffmpeg >/dev/null 2>&1 && make_thumbs 1
+    type ffmpeg >/dev/null 2>&1 && make_thumbs "1"
     UCOLLAGE_EXPAND_DIRS=1 ucollage "$dir" "$NNN_PREVIEWDIR$dir" || exit_prompt
 elif type sxiv >/dev/null 2>&1; then
-    type ffmpegthumbnailer >/dev/null 2>&1 && make_thumbs 0
+    type ffmpegthumbnailer >/dev/null 2>&1 && make_thumbs "0"
     view_files sxiv >/dev/null 2>&1 &
 elif type nsxiv >/dev/null 2>&1; then
-    type ffmpegthumbnailer >/dev/null 2>&1 && make_thumbs 0
+    type ffmpegthumbnailer >/dev/null 2>&1 && make_thumbs "0"
     view_files nsxiv >/dev/null 2>&1 &
 elif type imv >/dev/null 2>&1; then
     make_thumbs ""
@@ -99,11 +99,11 @@ elif type imvr >/dev/null 2>&1; then
     view_files imvr >/dev/null 2>&1 &
 elif type viu >/dev/null 2>&1; then
     clear
-    make_thumbs 3 viu
+    make_thumbs "3" viu
     viu -n "$ret"
     exit_prompt
 elif type catimg >/dev/null 2>&1; then
-    make_thumbs 3 catimg
+    make_thumbs "3" catimg
     catimg "$ret"
     exit_prompt
 else

--- a/plugins/imgview
+++ b/plugins/imgview
@@ -31,8 +31,8 @@ exit_prompt() {
 
 make_thumbs() {
     mkdir -p "$NNN_PREVIEWDIR$dir" || return
-    if [ "$1" = "3" ]; then
-        [ -d "$target" ] && exit_prompt "$2 can only display a single image"
+    if [ "$1" = "viu" ] || [ "$1" = "catimg" ]; then
+        [ -d "$target" ] && exit_prompt "$1 can only display a single image"
         mime="$(file -bL --mime-type -- "$target")"
         case "$mime" in
           audio/*) ffmpeg -i "$target" "$NNN_PREVIEWDIR$target.jpg" -y >/dev/null 2>&1
@@ -45,8 +45,10 @@ make_thumbs() {
     for file in "$dir"/*; do
         if [ ! -f "$NNN_PREVIEWDIR$file.jpg" ]; then
             case "$(file -bL --mime-type -- "$file")" in
-                audio/*) [ "$1" != "0" ] && ffmpeg -i "$file" "$NNN_PREVIEWDIR$file.jpg" -y >/dev/null 2>&1 ;;
-                video/*) [ "$1" != "1" ] && ffmpegthumbnailer -i "$file" -o "$NNN_PREVIEWDIR$file.jpg" 2> /dev/null ;;
+                audio/*) [ "$1" != "sxiv" ] &&
+                    ffmpeg -i "$file" "$NNN_PREVIEWDIR$file.jpg" -y >/dev/null 2>&1 ;;
+                video/*) [ "$1" != "ucollage" ] &&
+                    ffmpegthumbnailer -i "$file" -o "$NNN_PREVIEWDIR$file.jpg" 2> /dev/null ;;
             esac
         fi
     done
@@ -77,33 +79,33 @@ elif type lsix >/dev/null 2>&1; then
     if [ -d "$target" ]; then
         cd "$target" || exit_prompt
     fi
-    make_thumbs ""
+    make_thumbs lsix
     clear
     lsix
     cd "$NNN_PREVIEWDIR$dir" && lsix
     exit_prompt
 elif type ucollage >/dev/null 2>&1; then
-    type ffmpeg >/dev/null 2>&1 && make_thumbs "1"
+    type ffmpeg >/dev/null 2>&1 && make_thumbs ucollage
     UCOLLAGE_EXPAND_DIRS=1 ucollage "$dir" "$NNN_PREVIEWDIR$dir" || exit_prompt
 elif type sxiv >/dev/null 2>&1; then
-    type ffmpegthumbnailer >/dev/null 2>&1 && make_thumbs "0"
+    type ffmpegthumbnailer >/dev/null 2>&1 && make_thumbs sxiv
     view_files sxiv >/dev/null 2>&1 &
 elif type nsxiv >/dev/null 2>&1; then
-    type ffmpegthumbnailer >/dev/null 2>&1 && make_thumbs "0"
+    type ffmpegthumbnailer >/dev/null 2>&1 && make_thumbs sxiv
     view_files nsxiv >/dev/null 2>&1 &
 elif type imv >/dev/null 2>&1; then
-    make_thumbs ""
+    make_thumbs imv
     view_files imv >/dev/null 2>&1 &
 elif type imvr >/dev/null 2>&1; then
-    make_thumbs ""
+    make_thumbs imv
     view_files imvr >/dev/null 2>&1 &
 elif type viu >/dev/null 2>&1; then
     clear
-    make_thumbs "3" viu
+    make_thumbs viu
     viu -n "$ret"
     exit_prompt
 elif type catimg >/dev/null 2>&1; then
-    make_thumbs "3" catimg
+    make_thumbs catimg
     catimg "$ret"
     exit_prompt
 else


### PR DESCRIPTION
Exit `make_thumbs` early when invoked with an empty first argument `""` to avoid a syntax error.