### PR TITLE
Adding many new icons and colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 nnn
 src/icons-generated*.h
 src/icons-hash-gen
+test
+

--- a/src/icons.h
+++ b/src/icons.h
@@ -66,6 +66,7 @@
 #define ICON_DOCUMENT      ICON_STR(FA_FILE_TEXT_O, "\uf718", "🗒 ")
 #define ICON_DOWNLOADS     ICON_STR(FA_DOWNLOAD, "\uf5d7", "📥")
 #define ICON_ELIXIR        ICON_STR(MFIZZ_ELIXIR, "\ue62d", "💧")
+#define ICON_EMACS         ICON_STR(DEV_GNU, "\ue779", "")
 #define ICON_ENCRYPT       ICON_STR("", "\uf805", "🔒")
 #define ICON_FSHARP        ICON_STR(DEV_FSHARP, "\ue7a7", "")
 #define ICON_GIT           ICON_STR(FA_GIT, "\ue5fb", "🌱")
@@ -75,11 +76,13 @@
 #define ICON_JAVASCRIPT    ICON_STR(FA_FILE_CODE_O, "\uf81d", "")
 #define ICON_LICENSE       ICON_STR(FA_COPYRIGHT, "\uf718", "⚖️ ")
 #define ICON_LINUX         ICON_STR(FA_LINUX, "\uf83c", "🐧")
+#define ICON_LISP          ICON_STR(DEV_GNU, "\uf671", "")
 #define ICON_MAKEFILE      ICON_STR(FILE_CMAKE, "\uf68c", "🛠 ")
 #define ICON_MANUAL        ICON_STR(FILE_MANPAGE, "\uf5bd", "❓")
 #define ICON_MS_EXCEL      ICON_STR(FILE_EXCEL, "\uf71a", ICON_WORDDOC)
 #define ICON_MUSIC         ICON_STR(FA_MUSIC, "\uf832", "🎧")
 #define ICON_MUSICFILE     ICON_STR(FA_FILE_AUDIO_O, "\uf886", ICON_MUSIC)
+#define ICON_NODE          ICON_STR(DEV_NODEJS, "\ue718", "")
 #define ICON_OPTICALDISK   ICON_STR(LINEA_MUSIC_CD, "\ue271", "💿")
 #define ICON_PDF           ICON_STR(FA_FILE_PDF_O, "\uf724", "📕")
 #define ICON_PHOTOSHOP     ICON_STR(DEV_PHOTOSHOP, "\ue7b8", ICON_PICTUREFILE)
@@ -102,6 +105,7 @@
 #define ICON_VIM           ICON_STR(DEV_VIM, "\ue62b", "")
 #define ICON_WORDDOC       ICON_STR(FILE_WORD, "\uf72b", "📘")
 
+#define ICON_EXT_O         ICON_STR("", "\ue624", "")
 #define ICON_EXT_ASM       ICON_STR(FILE_NASM, "", "")
 #define ICON_EXT_BIN       ICON_STR(OCT_FILE_BINARY, "\uf471", "📓")
 #define ICON_EXT_COFFEE    ICON_STR(MFIZZ_COFFEE_BEAN, "\ue751", "")
@@ -117,7 +121,7 @@
 #define ICON_EXT_MSI       ICON_STR(FA_WINDOWS, "\uf871", "🪟")
 #define ICON_EXT_NIX       ICON_STR("", "\uf313", "")
 #define ICON_EXT_PATCH     ICON_STR(FILE_PATCH, "\uf440", "🩹")
-#define ICON_EXT_PHP       ICON_STR(MFIZZ_PHP, "\ue73d", "🌐")
+#define ICON_EXT_PHP       ICON_STR(MFIZZ_PHP, "\ue608", "🌐")
 #define ICON_EXT_ROM       ICON_STR(FA_LOCK, "\uf795", "")
 #define ICON_EXT_RSS       ICON_STR(FA_RSS_SQUARE, "\uf143", "📡")
 #define ICON_EXT_RTF       ICON_STR(ICON_PDF, "\uf724", ICON_PDF)
@@ -188,7 +192,13 @@ static const struct icon_pair icons_name[] = {
 	{"Templates",   ICON_TEMPLATES, 0},
 	{"Videos",      ICON_VIDEOS,    0},
 	{"CHANGELOG",   ICON_CHANGELOG, COLOR_DOCS},
+	{"composer.json", ICON_EXT_PHP, 0},
 	{"configure",   ICON_CONFIGURE, 0},
+	{"config.el",   ICON_EMACS, 0},
+	{"packages.el", ICON_EMACS, 0},
+	{".doom.d",     ICON_EMACS, 0},
+	{".emacs.d",    ICON_EMACS, 0},
+	{"package.json", ICON_NODE, 0},
 	{"License",     ICON_LICENSE,   COLOR_DOCS},
 	{"Makefile",    ICON_MAKEFILE,  0},
 };
@@ -249,6 +259,8 @@ static const struct icon_pair icons_ext[] = {
 
 	/* E */
 	{"ejs",        ICON_JAVASCRIPT,     COLOR_JAVASCRIPT},
+	{"el",         ICON_LISP,           0},
+	{"elc",        ICON_LISP,           0},
 	{"elf",        ICON_LINUX,          0},
 	{"epub",       ICON_PDF,            COLOR_DOCS},
 	{"exe",        ICON_EXEC,           0},
@@ -332,8 +344,9 @@ static const struct icon_pair icons_ext[] = {
 	{"nix",        ICON_EXT_NIX,        COLOR_FSHARP},
 
 	/* O */
-	{"o",          ICON_MANUAL,         0},
+	{"o",          ICON_EXT_O,          0},
 	{"ogg",        ICON_MUSICFILE,      COLOR_AUDIO},
+	{"org",        ICON_EMACS,          0},
 	{"opus",       ICON_MUSICFILE,      COLOR_AUDIO},
 	{"opdownload", ICON_DOWNLOADS,      0},
 	{"out",        ICON_LINUX,          0},

--- a/src/icons.h
+++ b/src/icons.h
@@ -61,6 +61,7 @@
 #define ICON_CHESS         ICON_STR("", "\uf639", "")
 #define ICON_CLOJURE       ICON_STR(MFIZZ_CLOJURE, "\ue76a", "")
 #define ICON_CONFIGURE     ICON_STR(FILE_CONFIG, "\uf423", "🔧")
+#define ICON_CONFFOLDER    ICON_STR(FILE_CONFIG, "\ue5fc", "🔧")
 #define ICON_CPLUSPLUS     ICON_STR(MFIZZ_CPLUSPLUS, "\ue61d", ICON_C)
 #define ICON_DATABASE      ICON_STR(MFIZZ_DATABASE_ALT2, "\uf6b7", "🗃️ ")
 #define ICON_DESKTOP       ICON_STR(FA_DESKTOP, "\ufcbe", "🖥️ ")
@@ -213,13 +214,15 @@ static const struct icon_pair icons_name[] = {
 	{".bash_profile",      ICON_CONFIGURE,     COLOR_CONFIGURE},
 	{".bashrc",            ICON_SCRIPT,        COLOR_SHELL},
 	{".cargo",             ICON_RUST,          COLOR_RUST},
+	{".config",            ICON_CONFFOLDER,    COLOR_CONFIGURE},
 	{".doom.d",            ICON_EMACS,         COLOR_EMACS},
 	{".emacs.d",           ICON_EMACS,         COLOR_EMACS},
 	{".git",               ICON_GIT_FOLDER,    0},
 	{".github",            ICON_GITHUB_FOLDER, 0},
 	{".gitignore",         ICON_GIT,           0},
 	{".gnupg",             ICON_LOCK,          COLOR_LOCK},
-	{".node_repl_history", ICON_NODE,          0},
+	{".local",             ICON_CONFFOLDER,    COLOR_CONFIGURE},
+	{".node_repl_history", ICON_NODE,          COLOR_JAVASCRIPT},
 	{".npmignore",         ICON_NPM,           0},
 	{".python_history",    ICON_PYTHON,        COLOR_PYTHON},
 	{".release.toml",      ICON_RUST,          COLOR_RUST},
@@ -227,30 +230,33 @@ static const struct icon_pair icons_name[] = {
 	{".viminfo",           ICON_VIM,           COLOR_VIM},
 	{".xinitrc",           ICON_CONFIGURE,     COLOR_CONFIGURE},
 	{".Xresources",        ICON_CONFIGURE,     COLOR_CONFIGURE},
+	{"authorized_keys",    ICON_KEY,           COLOR_KEY},
 	{"bspwmrc",            ICON_CONFIGURE,     COLOR_CONFIGURE},
 	{"Cargo.toml",         ICON_RUST,          COLOR_RUST},
 	{"CHANGELOG",          ICON_CHANGELOG,     COLOR_DOCS},
 	{"composer.json",      ICON_EXT_PHP,       COLOR_CPLUSPLUS},
-	{"configure",          ICON_CONFIGURE,     0},
+	{"conf.d",             ICON_CONFFOLDER,    COLOR_CONFIGURE},
+	{"configure",          ICON_CONFIGURE,     COLOR_CONFIGURE},
 	{"config.el",          ICON_EMACS,         COLOR_EMACS},
 	{"custom.el",          ICON_EMACS,         COLOR_EMACS},
 	{"Desktop",            ICON_DESKTOP,       0},
 	{"Documents",          ICON_BRIEFCASE,     0},
-	{"Downloads",          ICON_DOWNLOADS,     0},
+	{"Downloads",          ICON_DOWNLOADS,     COLOR_O},
 	{"funding.yml",        ICON_GITHUB,        0},
 	{"init.el",            ICON_EMACS,         COLOR_EMACS},
+	{"known_hosts",        ICON_CONFIGURE,     COLOR_CONFIGURE},
 	{"License",            ICON_LICENSE,       COLOR_DOCS},
 	{"Makefile",           ICON_MAKEFILE,      COLOR_CONFIGURE},
-	{"Music",              ICON_MUSIC,         0},
+	{"Music",              ICON_MUSIC,         COLOR_AUDIO1},
 	{"node_modules",       ICON_NODE_FOLDER,   0},
 	{"packages.el",        ICON_EMACS,         COLOR_EMACS},
 	{"package.json",       ICON_NODE,          COLOR_JAVASCRIPT},
 	{"package-lock.json",  ICON_NODE,          COLOR_JAVASCRIPT},
-	{"Pictures",           ICON_PICTURES,      0},
+	{"Pictures",           ICON_PICTURES,      COLOR_IMAGE},
 	{"Public",             ICON_PUBLIC,        0},
 	{"sxhkdrc",            ICON_CONFIGURE,     COLOR_CONFIGURE},
 	{"Templates",          ICON_TEMPLATES,     0},
-	{"Videos",             ICON_VIDEOS,        0},
+	{"Videos",             ICON_VIDEOS,        COLOR_VIDEO},
 	{"webpack.config.js",  ICON_WEBPACK,       COLOR_JAVASCRIPT},
 };
 

--- a/src/icons.h
+++ b/src/icons.h
@@ -53,10 +53,11 @@
 #define ICON_EXEC          ICON_STR(FA_COG, "\uf144", "⚙️ ")
 
 /* Top level and common icons */
-#define ICON_ARCHIVE       ICON_STR(FA_FILE_ARCHIVE_O, "\uf53b", "📦")
+#define ICON_ARCHIVE       ICON_STR("", "\uf410"," 📦")
 #define ICON_BRIEFCASE     ICON_STR(FA_BRIEFCASE, "\uf5d5", "💼")
 #define ICON_C             ICON_STR(MFIZZ_C, "\ue61e", "🇨 ")
 #define ICON_CHANGELOG     ICON_STR(FA_HISTORY, "\uf7d9", "🔺")
+#define ICON_CHEADER       ICON_STR(MFIZZ_C, "\uf0fd", ICON_C)
 #define ICON_CHESS         ICON_STR("", "\uf639", "")
 #define ICON_CLOJURE       ICON_STR(MFIZZ_CLOJURE, "\ue76a", "")
 #define ICON_CONFIGURE     ICON_STR(FILE_CONFIG, "\uf423", "🔧")
@@ -68,6 +69,7 @@
 #define ICON_ELIXIR        ICON_STR(MFIZZ_ELIXIR, "\ue62d", "💧")
 #define ICON_EMACS         ICON_STR(DEV_GNU, "\ue779", "")
 #define ICON_ENCRYPT       ICON_STR("", "\uf805", "🔒")
+#define ICON_FONT          ICON_STR(FILE_FONT, "\uf031", "")
 #define ICON_FSHARP        ICON_STR(DEV_FSHARP, "\ue7a7", "")
 #define ICON_GIT           ICON_STR(FA_GIT, "\uf1d3", "")
 #define ICON_GIT_FOLDER    ICON_STR(FA_GIT, "\ue5fb", "🌱")
@@ -76,13 +78,15 @@
 #define ICON_HASKELL       ICON_STR("", "\ue777", "")
 #define ICON_HTML          ICON_STR(FA_FILE_CODE_O, "\uf72d", "")
 #define ICON_JAVA          ICON_STR(MFIZZ_JAVA, "\ue738", "☕")
-#define ICON_JAVASCRIPT    ICON_STR(FA_FILE_CODE_O, "\uf81d", "")
+#define ICON_JAVASCRIPT    ICON_STR(FA_FILE_CODE_O, "\ue74e", "")
+#define ICON_KEY           ICON_STR(FA_KEY, "\ue60a", "")
 #define ICON_LICENSE       ICON_STR(FA_COPYRIGHT, "\uf718", "⚖️ ")
 #define ICON_LINUX         ICON_STR(FA_LINUX, "\uf83c", "🐧")
 #define ICON_LISP          ICON_STR(DEV_GNU, "\uf671", "")
+#define ICON_LOCK          ICON_STR(FA_LOCK, "\uf023", "🔒")
 #define ICON_MAKEFILE      ICON_STR(FILE_CMAKE, "\uf68c", "🛠 ")
 #define ICON_MANUAL        ICON_STR(FILE_MANPAGE, "\uf5bd", "❓")
-#define ICON_MS_EXCEL      ICON_STR(FILE_EXCEL, "\uf71a", ICON_WORDDOC)
+#define ICON_MS_EXCEL      ICON_STR(FILE_EXCEL, "\uf1c3", ICON_WORDDOC)
 #define ICON_MUSIC         ICON_STR(FA_MUSIC, "\uf832", "🎧")
 #define ICON_MUSICFILE     ICON_STR(FA_FILE_AUDIO_O, "\uf886", ICON_MUSIC)
 #define ICON_NPM           ICON_STR(DEV_NPM, "\ue71e", "")
@@ -90,6 +94,7 @@
 #define ICON_NODE_FOLDER   ICON_STR(DEV_NODEJS, "\ue5fa", "")
 #define ICON_OPTICALDISK   ICON_STR(LINEA_MUSIC_CD, "\ue271", "💿")
 #define ICON_PDF           ICON_STR(FA_FILE_PDF_O, "\uf724", "📕")
+#define ICON_PKG           ICON_STR(FA_FILE_ARCHIVE_O, "\uf53b", "📦")
 #define ICON_PHOTOSHOP     ICON_STR(DEV_PHOTOSHOP, "\ue7b8", ICON_PICTUREFILE)
 #define ICON_PICTUREFILE   ICON_STR(FA_FILE_IMAGE_O, "\uf71e", ICON_PICTURES)
 #define ICON_PICTURES      ICON_STR(MD_CAMERA_ALT, "\uf753", "🎨")
@@ -100,18 +105,22 @@
 #define ICON_REACT         ICON_STR(FILE_JSX, "\ue625", ICON_JAVASCRIPT)
 #define ICON_RUBY          ICON_STR(MFIZZ_RUBY, "\ue23e", "💎")
 #define ICON_RUST          ICON_STR(DEV_RUST, "\ue7a8", "")
-#define ICON_SASS          ICON_STR("", "\ue603", "")
+#define ICON_SASS          ICON_STR(DEV_SASS, "\ue603", "")
 #define ICON_SCRIPT        ICON_STR(MFIZZ_SCRIPT, "\ue795", "📜")
 #define ICON_SUBTITLE      ICON_STR(FA_COMMENTS_O, "\uf679", "💬")
+#define ICON_SWIFT         ICON_STR(DEV_SWIFT, "\ue755", "")
 #define ICON_TEMPLATES     ICON_STR(FA_PAPERCLIP, "\ufac6", "📎")
 #define ICON_TEX           ICON_STR(FILE_TEX, "\ufb68", ICON_DOCUMENT)
+#define ICON_TORRENT       ICON_STR("", "\uf98c", "")
 #define ICON_VIDEOFILE     ICON_STR(FA_FILE_MOVIE_O, "\uf72a", ICON_VIDEOS)
 #define ICON_VIDEOS        ICON_STR(FA_FILM, "\uf72f", "🎞 ")
 #define ICON_VIM           ICON_STR(DEV_VIM, "\ue62b", "")
+#define ICON_VUE           ICON_STR("", "\ufd42", "")
+#define ICON_WEBPACK       ICON_STR(FILE_WEBPACK, "\ufc29", "")
 #define ICON_WORDDOC       ICON_STR(FILE_WORD, "\uf72b", "📘")
 
 #define ICON_EXT_O         ICON_STR("", "\ue624", "")
-#define ICON_EXT_ASM       ICON_STR(FILE_NASM, "", "")
+#define ICON_EXT_ASM       ICON_STR(FILE_NASM, "\ue614", "")
 #define ICON_EXT_BIN       ICON_STR(OCT_FILE_BINARY, "\uf471", "📓")
 #define ICON_EXT_COFFEE    ICON_STR(MFIZZ_COFFEE_BEAN, "\ue751", "")
 #define ICON_EXT_CSS       ICON_STR(MFIZZ_CSS3, "\ue749", "🦋")
@@ -195,6 +204,8 @@ static const struct icon_pair icons_name[] = {
 	{".gitignore",         ICON_GIT,           0},
 	{".node_repl_history", ICON_NODE,          0},
 	{".npmignore",         ICON_NPM,           0},
+	{".release.toml",      ICON_RUST,          0},
+	{"Cargo.toml",         ICON_RUST,          0},
 	{"CHANGELOG",          ICON_CHANGELOG,     COLOR_DOCS},
 	{"composer.json",      ICON_EXT_PHP,       0},
 	{"configure",          ICON_CONFIGURE,     0},
@@ -214,6 +225,7 @@ static const struct icon_pair icons_name[] = {
 	{"Public",             ICON_PUBLIC,        0},
 	{"Templates",          ICON_TEMPLATES,     0},
 	{"Videos",             ICON_VIDEOS,        0},
+	{"webpack.config.js",  ICON_WEBPACK,       0},
 };
 
 #ifdef ICONS_GENERATE
@@ -228,6 +240,7 @@ static const struct icon_pair icons_ext[] = {
 	/* A */
 	{"a",          ICON_MANUAL,         0},
 	{"apk",        ICON_ARCHIVE,        COLOR_ARCHIVE},
+	{"asc",        ICON_LOCK,           0},
 	{"asm",        ICON_EXT_ASM,        0},
 	{"aup",        ICON_MUSICFILE,      COLOR_AUDIO},
 	{"avi",        ICON_VIDEOFILE,      COLOR_VIDEO},
@@ -300,9 +313,10 @@ static const struct icon_pair icons_ext[] = {
 	{"gzip",       ICON_ARCHIVE,        COLOR_ARCHIVE},
 
 	/* H */
-	{"h",          ICON_C,              COLOR_C},
-	{"hh",         ICON_CPLUSPLUS,      COLOR_C},
-	{"hpp",        ICON_CPLUSPLUS,      COLOR_C},
+	{"h",          ICON_CHEADER,        COLOR_C},
+	{"hh",         ICON_CHEADER,        COLOR_C},
+	{"hpp",        ICON_CHEADER,        COLOR_C},
+	{"hxx",        ICON_CHEADER,        COLOR_C},
 	{"hs",         ICON_HASKELL,        COLOR_VIM},
 	{"htaccess",   ICON_CONFIGURE,      0},
 	{"htpasswd",   ICON_CONFIGURE,      0},
@@ -328,10 +342,13 @@ static const struct icon_pair icons_ext[] = {
 	{"jsx",        ICON_REACT,          COLOR_REACT},
 
 	/* K */
+	{"kbx",        ICON_KEY,            0},
+	{"key",        ICON_KEY,            0},
 
 	/* L */
 	{"lha",        ICON_ARCHIVE,        COLOR_ARCHIVE},
 	{"lhs",        ICON_HASKELL,        COLOR_VIM},
+	{"lock",       ICON_LOCK,           0},
 	{"log",        ICON_DOCUMENT,       0},
 	{"lua",        ICON_EXT_LUA,        COLOR_LUA},
 	{"lzh",        ICON_ARCHIVE,        COLOR_ARCHIVE},
@@ -344,6 +361,7 @@ static const struct icon_pair icons_ext[] = {
 	{"markdown",   ICON_EXT_MD,         COLOR_DOCS},
 	{"mat",        ICON_EXT_MAT,        COLOR_C},
 	{"md",         ICON_EXT_MD,         COLOR_DOCS},
+	{"md5",        ICON_LOCK,           0},
 	{"mk",         ICON_MAKEFILE,       0},
 	{"mkv",        ICON_VIDEOFILE,      COLOR_VIDEO},
 	{"mov",        ICON_VIDEOFILE,      COLOR_VIDEO},
@@ -362,6 +380,7 @@ static const struct icon_pair icons_ext[] = {
 	{"org",        ICON_EMACS,          0},
 	{"opus",       ICON_MUSICFILE,      COLOR_AUDIO},
 	{"opdownload", ICON_DOWNLOADS,      0},
+	{"otf",        ICON_FONT,           0},
 	{"out",        ICON_LINUX,          0},
 
 	/* P */
@@ -381,23 +400,28 @@ static const struct icon_pair icons_ext[] = {
 	{"pyo",        ICON_PYTHON,        COLOR_PYTHON},
 
 	/* Q */
+	{"qss",        ICON_EXT_CSS,       COLOR_CSS},
 
 	/* R */
 	{"rar",        ICON_ARCHIVE,        COLOR_ARCHIVE},
 	{"rb",         ICON_RUBY,           COLOR_RUBY},
 	{"rc",         ICON_CONFIGURE,      0},
 	{"rom",        ICON_EXT_ROM,        0},
-	{"rpm",        ICON_ARCHIVE,        COLOR_ARCHIVE},
+	{"rpm",        ICON_PKG,            COLOR_ARCHIVE},
 	{"rs",         ICON_RUST,           COLOR_DOCS},
 	{"rss",        ICON_EXT_RSS,        0},
 	{"rtf",        ICON_EXT_RTF,        0},
 
 	/* S */
+	{"s",          ICON_EXT_ASM,        0},
 	{"sass",       ICON_SASS,           COLOR_CSS},
 	{"scss",       ICON_SASS,           COLOR_CSS},
 	{"so",         ICON_MANUAL,         0},
 	{"scala",      ICON_EXT_SCALA,      COLOR_SCALA},
 	{"sh",         ICON_SCRIPT,         COLOR_SHELL},
+	{"sha1",       ICON_LOCK,           0},
+	{"sha256",     ICON_LOCK,           0},
+	{"sig",        ICON_KEY,            0},
 	{"slim",       ICON_SCRIPT,         COLOR_DOCUMENT},
 	{"sln",        ICON_EXT_SLN,        0},
 	{"sql",        ICON_DATABASE,       0},
@@ -405,13 +429,21 @@ static const struct icon_pair icons_ext[] = {
 	{"sty",        ICON_TEX,            0},
 	{"sub",        ICON_SUBTITLE,       0},
 	{"svg",        ICON_PICTUREFILE,    COLOR_IMAGE},
+	{"swift",      ICON_SWIFT,          0},
+	{"swp",        ICON_VIM,            0},
+	{"sym",        ICON_EXT_O,          0},
 
 	/* T */
 	{"tar",        ICON_ARCHIVE,        COLOR_ARCHIVE},
 	{"tex",        ICON_TEX,            0},
+	{"tiff",       ICON_PICTUREFILE,    COLOR_IMAGE},
 	{"tgz",        ICON_ARCHIVE,        COLOR_ARCHIVE},
+	{"toml",       ICON_EXT_JSON,       0},
+	{"torrent",    ICON_TORRENT,        COLOR_ARCHIVE},
 	{"ts",         ICON_EXT_TS,        COLOR_JAVASCRIPT},
 	{"tsx",        ICON_REACT,          COLOR_REACT},
+	{"ttc",        ICON_FONT,           0},
+	{"ttf",        ICON_FONT,           0},
 	{"txt",        ICON_DOCUMENT,       COLOR_DOCUMENT},
 	{"txz",        ICON_ARCHIVE,        COLOR_ARCHIVE},
 
@@ -422,6 +454,7 @@ static const struct icon_pair icons_ext[] = {
 	{"vim",        ICON_VIM,            COLOR_VIM},
 	{"vimrc",      ICON_VIM,            COLOR_VIM},
 	{"vtt",        ICON_SUBTITLE,       0},
+	{"vue",        ICON_VUE,            COLOR_JAVASCRIPT},
 
 	/* W */
 	{"wav",        ICON_MUSICFILE,      COLOR_AUDIO},
@@ -431,7 +464,7 @@ static const struct icon_pair icons_ext[] = {
 	{"wmv",        ICON_VIDEOFILE,      COLOR_VIDEO},
 
 	/* X */
-	{"xbps",       ICON_ARCHIVE,        COLOR_ARCHIVE},
+	{"xbps",       ICON_PKG,            COLOR_ARCHIVE},
 	{"xcf",        ICON_PICTUREFILE,    COLOR_IMAGE},
 	{"xhtml",      ICON_HTML,           0},
 	{"xls",        ICON_MS_EXCEL,       0},

--- a/src/icons.h
+++ b/src/icons.h
@@ -63,8 +63,10 @@
 #define ICON_CONFIGURE     ICON_STR(FILE_CONFIG, "\uf423", "🔧")
 #define ICON_CONFFOLDER    ICON_STR(FILE_CONFIG, "\ue5fc", "🔧")
 #define ICON_CPLUSPLUS     ICON_STR(MFIZZ_CPLUSPLUS, "\ue61d", ICON_C)
+#define ICON_CSHARP        ICON_STR(MFIZZ_CSHARP, "\uf81a", "")
 #define ICON_DATABASE      ICON_STR(MFIZZ_DATABASE_ALT2, "\uf6b7", "🗃️ ")
 #define ICON_DESKTOP       ICON_STR(FA_DESKTOP, "\ufcbe", "🖥️ ")
+#define ICON_DOCKER        ICON_STR(FILE_DOCKER, "\uf308", "")
 #define ICON_DOCUMENT      ICON_STR(FA_FILE_TEXT_O, "\uf718", "🗒 ")
 #define ICON_DOWNLOADS     ICON_STR(FA_DOWNLOAD, "\uf5d7", "📥")
 #define ICON_DOWNLOAD      ICON_STR(FA_DOWNLOAD, "\uf43a", "")
@@ -77,6 +79,8 @@
 #define ICON_GIT_FOLDER    ICON_STR(FA_GIT, "\ue5fb", "🌱")
 #define ICON_GITHUB        ICON_STR(FA_GITHUB, "\uf408", "")
 #define ICON_GITHUB_FOLDER ICON_STR(FA_GITHUB, "\ue5fd", "")
+#define ICON_GRUNT         ICON_STR(FILE_GRUNT, "\ue611", "")
+#define ICON_GULP          ICON_STR(FILE_GULP, "\ue610", "")
 #define ICON_HASKELL       ICON_STR("", "\ue777", "")
 #define ICON_HTML          ICON_STR(FA_FILE_CODE_O, "\uf72d", "")
 #define ICON_JAVA          ICON_STR(MFIZZ_JAVA, "\ue738", "☕")
@@ -240,9 +244,17 @@ static const struct icon_pair icons_name[] = {
 	{"config.el",          ICON_EMACS,         COLOR_EMACS},
 	{"custom.el",          ICON_EMACS,         COLOR_EMACS},
 	{"Desktop",            ICON_DESKTOP,       0},
+	{"docker-compose.yml", ICON_DOCKER,        0},
+	{"dockerfile",         ICON_DOCKER,        0},
 	{"Documents",          ICON_BRIEFCASE,     0},
 	{"Downloads",          ICON_DOWNLOADS,     COLOR_O},
 	{"funding.yml",        ICON_GITHUB,        0},
+	{"gruntfile.coffee",   ICON_GRUNT,         0},
+	{"gruntfile.js",       ICON_GRUNT,         0},
+	{"gruntfile.ls",       ICON_GRUNT,         0},
+	{"gulpfile.coffee",    ICON_GULP,          0},
+	{"gulpfile.js",        ICON_GULP,          0},
+	{"gulpfile.ls",        ICON_GULP,          0},
 	{"init.el",            ICON_EMACS,         COLOR_EMACS},
 	{"known_hosts",        ICON_CONFIGURE,     COLOR_CONFIGURE},
 	{"License",            ICON_LICENSE,       COLOR_DOCS},
@@ -254,10 +266,14 @@ static const struct icon_pair icons_name[] = {
 	{"package-lock.json",  ICON_NODE,          COLOR_JAVASCRIPT},
 	{"Pictures",           ICON_PICTURES,      COLOR_IMAGE},
 	{"Public",             ICON_PUBLIC,        0},
+	{"Rakefile",           ICON_RUBY,          COLOR_RUBY},
+	{"rc.lua",             ICON_CONFIGURE,     COLOR_LUA},
 	{"sxhkdrc",            ICON_CONFIGURE,     COLOR_CONFIGURE},
 	{"Templates",          ICON_TEMPLATES,     0},
+	{"Vagrantfile",        ICON_CONFIGURE,     COLOR_CONFIGURE},
 	{"Videos",             ICON_VIDEOS,        COLOR_VIDEO},
 	{"webpack.config.js",  ICON_WEBPACK,       COLOR_JAVASCRIPT},
+	{"xmonad.hs",          ICON_CONFIGURE,     COLOR_CONFIGURE},
 };
 
 #ifdef ICONS_GENERATE
@@ -271,6 +287,7 @@ static const struct icon_pair icons_ext[] = {
 
 	/* A */
 	{"a",          ICON_MANUAL,         0},
+	{"ape",        ICON_MUSICFILE,      COLOR_AUDIO},
 	{"apk",        ICON_ARCHIVE,        COLOR_ARCHIVE},
 	{"asc",        ICON_LOCK,           COLOR_LOCK},
 	{"asm",        ICON_EXT_ASM,        COLOR_ASM},
@@ -294,6 +311,7 @@ static const struct icon_pair icons_ext[] = {
 	{"cbz",        ICON_ARCHIVE,        COLOR_ARCHIVE},
 	{"cc",         ICON_CPLUSPLUS,      COLOR_CPLUSPLUS},
 	{"class",      ICON_JAVA,           COLOR_JAVA},
+	{"cl",         ICON_LISP,           0},
 	{"clj",        ICON_CLOJURE,        0},
 	{"cljc",       ICON_CLOJURE,        0},
 	{"cljs",       ICON_CLOJURE,        0},
@@ -304,7 +322,10 @@ static const struct icon_pair icons_ext[] = {
 	{"cpio",       ICON_ARCHIVE,        COLOR_ARCHIVE},
 	{"cpp",        ICON_CPLUSPLUS,      COLOR_CPLUSPLUS},
 	{"crate",      ICON_PKG,            COLOR_ARCHIVE},
+	{"cs",         ICON_CSHARP,         COLOR_C},
+	{"csproj",     ICON_CSHARP,         COLOR_C},
 	{"css",        ICON_EXT_CSS,        COLOR_CSS},
+	{"csx",        ICON_CSHARP,         COLOR_C},
 	{"cue",        ICON_PLAYLIST,       COLOR_AUDIO},
 	{"cvs",        ICON_CONFIGURE,      0},
 	{"cxx",        ICON_CPLUSPLUS,      COLOR_CPLUSPLUS},
@@ -312,11 +333,14 @@ static const struct icon_pair icons_ext[] = {
 	/* D */
 	{"db",         ICON_DATABASE,       0},
 	{"deb",        ICON_EXT_DEB,        COLOR_ARCHIVE},
+	{"desktop",    ICON_DESKTOP,        0},
 	{"diff",       ICON_EXT_DIFF,       0},
 	{"dll",        ICON_SCRIPT,         0},
+	{"dmg",        ICON_OPTICALDISK,    COLOR_ARCHIVE},
 	{"doc",        ICON_WORDDOC,        COLOR_DOCUMENT},
 	{"docx",       ICON_WORDDOC,        COLOR_DOCUMENT},
 	{"download",   ICON_DOWNLOAD,       COLOR_O},
+	{"dump",       ICON_DATABASE,       0},
 
 	/* E */
 	{"ejs",        ICON_JAVASCRIPT,     COLOR_JAVASCRIPT},
@@ -383,6 +407,7 @@ static const struct icon_pair icons_ext[] = {
 	/* L */
 	{"lha",        ICON_ARCHIVE,        COLOR_ARCHIVE},
 	{"lhs",        ICON_HASKELL,        COLOR_VIM},
+	{"lisp",       ICON_LISP,           0},
 	{"lock",       ICON_LOCK,           COLOR_LOCK},
 	{"log",        ICON_DOCUMENT,       0},
 	{"lua",        ICON_EXT_LUA,        COLOR_LUA},
@@ -399,6 +424,7 @@ static const struct icon_pair icons_ext[] = {
 	{"md5",        ICON_LOCK,           COLOR_LOCK},
 	{"mk",         ICON_MAKEFILE,       0},
 	{"mkv",        ICON_VIDEOFILE,      COLOR_VIDEO},
+	{"mobi",       ICON_PDF,            COLOR_DOCS},
 	{"mov",        ICON_VIDEOFILE,      COLOR_VIDEO},
 	{"mp3",        ICON_MUSICFILE,      COLOR_AUDIO},
 	{"mp4",        ICON_VIDEOFILE,      COLOR_VIDEO1},
@@ -483,7 +509,7 @@ static const struct icon_pair icons_ext[] = {
 	{"tgz",        ICON_ARCHIVE,        COLOR_ARCHIVE},
 	{"toml",       ICON_EXT_JSON,       0},
 	{"torrent",    ICON_TORRENT,        COLOR_ARCHIVE},
-	{"ts",         ICON_EXT_TS,        COLOR_JAVASCRIPT},
+	{"ts",         ICON_EXT_TS,         COLOR_JAVASCRIPT},
 	{"tsx",        ICON_REACT,          COLOR_REACT},
 	{"ttc",        ICON_FONT,           COLOR_O},
 	{"ttf",        ICON_FONT,           COLOR_O},

--- a/src/icons.h
+++ b/src/icons.h
@@ -69,7 +69,10 @@
 #define ICON_EMACS         ICON_STR(DEV_GNU, "\ue779", "")
 #define ICON_ENCRYPT       ICON_STR("", "\uf805", "🔒")
 #define ICON_FSHARP        ICON_STR(DEV_FSHARP, "\ue7a7", "")
-#define ICON_GIT           ICON_STR(FA_GIT, "\ue5fb", "🌱")
+#define ICON_GIT           ICON_STR(FA_GIT, "\uf1d3", "")
+#define ICON_GIT_FOLDER    ICON_STR(FA_GIT, "\ue5fb", "🌱")
+#define ICON_GITHUB        ICON_STR(FA_GITHUB, "\uf408", "")
+#define ICON_GITHUB_FOLDER ICON_STR(FA_GITHUB, "\ue5fd", "")
 #define ICON_HASKELL       ICON_STR("", "\ue777", "")
 #define ICON_HTML          ICON_STR(FA_FILE_CODE_O, "\uf72d", "")
 #define ICON_JAVA          ICON_STR(MFIZZ_JAVA, "\ue738", "☕")
@@ -82,7 +85,9 @@
 #define ICON_MS_EXCEL      ICON_STR(FILE_EXCEL, "\uf71a", ICON_WORDDOC)
 #define ICON_MUSIC         ICON_STR(FA_MUSIC, "\uf832", "🎧")
 #define ICON_MUSICFILE     ICON_STR(FA_FILE_AUDIO_O, "\uf886", ICON_MUSIC)
+#define ICON_NPM           ICON_STR(DEV_NPM, "\ue71e", "")
 #define ICON_NODE          ICON_STR(DEV_NODEJS, "\ue718", "")
+#define ICON_NODE_FOLDER   ICON_STR(DEV_NODEJS, "\ue5fa", "")
 #define ICON_OPTICALDISK   ICON_STR(LINEA_MUSIC_CD, "\ue271", "💿")
 #define ICON_PDF           ICON_STR(FA_FILE_PDF_O, "\uf724", "📕")
 #define ICON_PHOTOSHOP     ICON_STR(DEV_PHOTOSHOP, "\ue7b8", ICON_PICTUREFILE)
@@ -182,25 +187,33 @@ static const struct icon file_icon = {ICON_FILE, 0};
 static const struct icon exec_icon = {ICON_EXEC, 0};
 
 static const struct icon_pair icons_name[] = {
-	{".git",        ICON_GIT,       0},
-	{"Desktop",     ICON_DESKTOP,   0},
-	{"Documents",   ICON_BRIEFCASE, 0},
-	{"Downloads",   ICON_DOWNLOADS, 0},
-	{"Music",       ICON_MUSIC,     0},
-	{"Pictures",    ICON_PICTURES,  0},
-	{"Public",      ICON_PUBLIC,    0},
-	{"Templates",   ICON_TEMPLATES, 0},
-	{"Videos",      ICON_VIDEOS,    0},
-	{"CHANGELOG",   ICON_CHANGELOG, COLOR_DOCS},
-	{"composer.json", ICON_EXT_PHP, 0},
-	{"configure",   ICON_CONFIGURE, 0},
-	{"config.el",   ICON_EMACS, 0},
-	{"packages.el", ICON_EMACS, 0},
-	{".doom.d",     ICON_EMACS, 0},
-	{".emacs.d",    ICON_EMACS, 0},
-	{"package.json", ICON_NODE, 0},
-	{"License",     ICON_LICENSE,   COLOR_DOCS},
-	{"Makefile",    ICON_MAKEFILE,  0},
+	{".cargo",             ICON_RUST,          0},
+	{".doom.d",            ICON_EMACS,         0},
+	{".emacs.d",           ICON_EMACS,         0},
+	{".git",               ICON_GIT_FOLDER,    0},
+	{".github",            ICON_GITHUB_FOLDER, 0},
+	{".gitignore",         ICON_GIT,           0},
+	{".node_repl_history", ICON_NODE,          0},
+	{".npmignore",         ICON_NPM,           0},
+	{"CHANGELOG",          ICON_CHANGELOG,     COLOR_DOCS},
+	{"composer.json",      ICON_EXT_PHP,       0},
+	{"configure",          ICON_CONFIGURE,     0},
+	{"config.el",          ICON_EMACS,         0},
+	{"Desktop",            ICON_DESKTOP,       0},
+	{"Documents",          ICON_BRIEFCASE,     0},
+	{"Downloads",          ICON_DOWNLOADS,     0},
+	{"funding.yml",        ICON_GITHUB,        0},
+	{"License",            ICON_LICENSE,       COLOR_DOCS},
+	{"Makefile",           ICON_MAKEFILE,      0},
+	{"Music",              ICON_MUSIC,         0},
+	{"node_modules",       ICON_NODE_FOLDER,   0},
+	{"packages.el",        ICON_EMACS,         0},
+	{"package.json",       ICON_NODE,          0},
+	{"package-lock.json",  ICON_NODE,          0},
+	{"Pictures",           ICON_PICTURES,      0},
+	{"Public",             ICON_PUBLIC,        0},
+	{"Templates",          ICON_TEMPLATES,     0},
+	{"Videos",             ICON_VIDEOS,        0},
 };
 
 #ifdef ICONS_GENERATE

--- a/src/icons.h
+++ b/src/icons.h
@@ -66,6 +66,7 @@
 #define ICON_DESKTOP       ICON_STR(FA_DESKTOP, "\ufcbe", "🖥️ ")
 #define ICON_DOCUMENT      ICON_STR(FA_FILE_TEXT_O, "\uf718", "🗒 ")
 #define ICON_DOWNLOADS     ICON_STR(FA_DOWNLOAD, "\uf5d7", "📥")
+#define ICON_DOWNLOAD      ICON_STR(FA_DOWNLOAD, "\uf43a", "")
 #define ICON_ELIXIR        ICON_STR(MFIZZ_ELIXIR, "\ue62d", "💧")
 #define ICON_EMACS         ICON_STR(DEV_GNU, "\ue779", "")
 #define ICON_ENCRYPT       ICON_STR("", "\uf805", "🔒")
@@ -102,6 +103,7 @@
 #define ICON_POWERPOINT    ICON_STR(FILE_POWERPOINT, "\uf726", "📊")
 #define ICON_PUBLIC        ICON_STR(FA_INBOX, "\ue5ff", "👀")
 #define ICON_PYTHON        ICON_STR(MFIZZ_PYTHON, "\ue235", "🐍")
+#define ICON_R             ICON_STR(FILE_R, "\ufcd2", "")
 #define ICON_REACT         ICON_STR(FILE_JSX, "\ue625", ICON_JAVASCRIPT)
 #define ICON_RUBY          ICON_STR(MFIZZ_RUBY, "\ue23e", "💎")
 #define ICON_RUST          ICON_STR(DEV_RUST, "\ue7a8", "")
@@ -157,8 +159,10 @@
 	COLOR_X(COLOR_AUDIO1,       205)  /* HotPink */ \
 	COLOR_X(COLOR_IMAGE,         82)  /* Chartreuse2 */ \
 	COLOR_X(COLOR_DOCS,         202)  /* OrangeRed1 */ \
-	COLOR_X(COLOR_ARCHIVE,      209)  /* Salmon1 */ \
+	COLOR_X(COLOR_ARCHIVE,      111)  /* SkyBlue2 */ \
+	COLOR_X(COLOR_PKG,          209)  /* Salmon1 */ \
 	COLOR_X(COLOR_C,             81)  /* SteelBlue1 */ \
+	COLOR_X(COLOR_CPLUSPLUS,    151)  /* DarkSeaGreen2 */ \
 	COLOR_X(COLOR_JAVA,          32)  /* DeepSkyBlue3 */ \
 	COLOR_X(COLOR_JAVASCRIPT,    47)  /* SpringGreen2 */ \
 	COLOR_X(COLOR_REACT,         39)  /* DeepSkyBlue1 */ \
@@ -172,6 +176,14 @@
 	COLOR_X(COLOR_SHELL,         47)  /* SpringGreen2 */ \
 	COLOR_X(COLOR_VIM,           28)  /* Green4 */ \
 	COLOR_X(COLOR_ELIXIR,       104)  /* MediumPurple */ \
+	COLOR_X(COLOR_EMACS,        165)  /* Magenta2 */ \
+	COLOR_X(COLOR_RUST,         203)  /* IndianRed1 */ \
+	COLOR_X(COLOR_KEY,          185)  /* Khaki3 */ \
+	COLOR_X(COLOR_LOCK,         102)  /* Gray53 */ \
+	COLOR_X(COLOR_CONFIGURE,    181)  /* MistyRose3 */ \
+	COLOR_X(COLOR_ASM,          220)  /* Gold1 */ \
+	COLOR_X(COLOR_O,            243)  /* Gray46 */ \
+	COLOR_X(COLOR_HTML,         147)  /* LightSteelBlue */ \
 
 /* X-Macro: https://en.wikipedia.org/wiki/X_Macro */
 #define COLOR_X(N, V) N = (V),
@@ -196,36 +208,50 @@ static const struct icon file_icon = {ICON_FILE, 0};
 static const struct icon exec_icon = {ICON_EXEC, 0};
 
 static const struct icon_pair icons_name[] = {
-	{".cargo",             ICON_RUST,          0},
-	{".doom.d",            ICON_EMACS,         0},
-	{".emacs.d",           ICON_EMACS,         0},
+	{".bash_history",      ICON_CONFIGURE,     COLOR_CONFIGURE},
+	{".bash_logout",       ICON_SCRIPT,        COLOR_SHELL},
+	{".bash_profile",      ICON_CONFIGURE,     COLOR_CONFIGURE},
+	{".bashrc",            ICON_SCRIPT,        COLOR_SHELL},
+	{".cargo",             ICON_RUST,          COLOR_RUST},
+	{".doom.d",            ICON_EMACS,         COLOR_EMACS},
+	{".emacs.d",           ICON_EMACS,         COLOR_EMACS},
 	{".git",               ICON_GIT_FOLDER,    0},
 	{".github",            ICON_GITHUB_FOLDER, 0},
 	{".gitignore",         ICON_GIT,           0},
+	{".gnupg",             ICON_LOCK,          COLOR_LOCK},
 	{".node_repl_history", ICON_NODE,          0},
 	{".npmignore",         ICON_NPM,           0},
-	{".release.toml",      ICON_RUST,          0},
-	{"Cargo.toml",         ICON_RUST,          0},
+	{".python_history",    ICON_PYTHON,        COLOR_PYTHON},
+	{".release.toml",      ICON_RUST,          COLOR_RUST},
+	{".ssh",               ICON_LOCK,          COLOR_LOCK},
+	{".viminfo",           ICON_VIM,           COLOR_VIM},
+	{".xinitrc",           ICON_CONFIGURE,     COLOR_CONFIGURE},
+	{".Xresources",        ICON_CONFIGURE,     COLOR_CONFIGURE},
+	{"bspwmrc",            ICON_CONFIGURE,     COLOR_CONFIGURE},
+	{"Cargo.toml",         ICON_RUST,          COLOR_RUST},
 	{"CHANGELOG",          ICON_CHANGELOG,     COLOR_DOCS},
-	{"composer.json",      ICON_EXT_PHP,       0},
+	{"composer.json",      ICON_EXT_PHP,       COLOR_CPLUSPLUS},
 	{"configure",          ICON_CONFIGURE,     0},
-	{"config.el",          ICON_EMACS,         0},
+	{"config.el",          ICON_EMACS,         COLOR_EMACS},
+	{"custom.el",          ICON_EMACS,         COLOR_EMACS},
 	{"Desktop",            ICON_DESKTOP,       0},
 	{"Documents",          ICON_BRIEFCASE,     0},
 	{"Downloads",          ICON_DOWNLOADS,     0},
 	{"funding.yml",        ICON_GITHUB,        0},
+	{"init.el",            ICON_EMACS,         COLOR_EMACS},
 	{"License",            ICON_LICENSE,       COLOR_DOCS},
-	{"Makefile",           ICON_MAKEFILE,      0},
+	{"Makefile",           ICON_MAKEFILE,      COLOR_CONFIGURE},
 	{"Music",              ICON_MUSIC,         0},
 	{"node_modules",       ICON_NODE_FOLDER,   0},
-	{"packages.el",        ICON_EMACS,         0},
-	{"package.json",       ICON_NODE,          0},
-	{"package-lock.json",  ICON_NODE,          0},
+	{"packages.el",        ICON_EMACS,         COLOR_EMACS},
+	{"package.json",       ICON_NODE,          COLOR_JAVASCRIPT},
+	{"package-lock.json",  ICON_NODE,          COLOR_JAVASCRIPT},
 	{"Pictures",           ICON_PICTURES,      0},
 	{"Public",             ICON_PUBLIC,        0},
+	{"sxhkdrc",            ICON_CONFIGURE,     COLOR_CONFIGURE},
 	{"Templates",          ICON_TEMPLATES,     0},
 	{"Videos",             ICON_VIDEOS,        0},
-	{"webpack.config.js",  ICON_WEBPACK,       0},
+	{"webpack.config.js",  ICON_WEBPACK,       COLOR_JAVASCRIPT},
 };
 
 #ifdef ICONS_GENERATE
@@ -240,12 +266,13 @@ static const struct icon_pair icons_ext[] = {
 	/* A */
 	{"a",          ICON_MANUAL,         0},
 	{"apk",        ICON_ARCHIVE,        COLOR_ARCHIVE},
-	{"asc",        ICON_LOCK,           0},
-	{"asm",        ICON_EXT_ASM,        0},
+	{"asc",        ICON_LOCK,           COLOR_LOCK},
+	{"asm",        ICON_EXT_ASM,        COLOR_ASM},
 	{"aup",        ICON_MUSICFILE,      COLOR_AUDIO},
 	{"avi",        ICON_VIDEOFILE,      COLOR_VIDEO},
 
 	/* B */
+	{"bash",       ICON_SCRIPT,         COLOR_SHELL},
 	{"bat",        ICON_SCRIPT,         0},
 	{"bib",        ICON_TEX,            0},
 	{"bin",        ICON_EXT_BIN,        0},
@@ -254,12 +281,12 @@ static const struct icon_pair icons_ext[] = {
 
 	/* C */
 	{"c",          ICON_C,              COLOR_C},
-	{"c++",        ICON_CPLUSPLUS,      COLOR_C},
+	{"c++",        ICON_CPLUSPLUS,      COLOR_CPLUSPLUS},
 	{"cabal",      ICON_HASKELL,        COLOR_VIDEO},
 	{"cab",        ICON_ARCHIVE,        COLOR_ARCHIVE},
 	{"cbr",        ICON_ARCHIVE,        COLOR_ARCHIVE},
 	{"cbz",        ICON_ARCHIVE,        COLOR_ARCHIVE},
-	{"cc",         ICON_CPLUSPLUS,      COLOR_C},
+	{"cc",         ICON_CPLUSPLUS,      COLOR_CPLUSPLUS},
 	{"class",      ICON_JAVA,           COLOR_JAVA},
 	{"clj",        ICON_CLOJURE,        0},
 	{"cljc",       ICON_CLOJURE,        0},
@@ -267,13 +294,14 @@ static const struct icon_pair icons_ext[] = {
 	{"cls",        ICON_TEX,            0},
 	{"cmake",      ICON_MAKEFILE,       0},
 	{"coffee",     ICON_EXT_COFFEE,     0},
-	{"conf",       ICON_CONFIGURE,      0},
+	{"conf",       ICON_CONFIGURE,      COLOR_CONFIGURE},
 	{"cpio",       ICON_ARCHIVE,        COLOR_ARCHIVE},
-	{"cpp",        ICON_CPLUSPLUS,      COLOR_C},
+	{"cpp",        ICON_CPLUSPLUS,      COLOR_CPLUSPLUS},
+	{"crate",      ICON_PKG,            COLOR_ARCHIVE},
 	{"css",        ICON_EXT_CSS,        COLOR_CSS},
 	{"cue",        ICON_PLAYLIST,       COLOR_AUDIO},
 	{"cvs",        ICON_CONFIGURE,      0},
-	{"cxx",        ICON_CPLUSPLUS,      COLOR_C},
+	{"cxx",        ICON_CPLUSPLUS,      COLOR_CPLUSPLUS},
 
 	/* D */
 	{"db",         ICON_DATABASE,       0},
@@ -282,11 +310,12 @@ static const struct icon_pair icons_ext[] = {
 	{"dll",        ICON_SCRIPT,         0},
 	{"doc",        ICON_WORDDOC,        COLOR_DOCUMENT},
 	{"docx",       ICON_WORDDOC,        COLOR_DOCUMENT},
+	{"download",   ICON_DOWNLOAD,       COLOR_O},
 
 	/* E */
 	{"ejs",        ICON_JAVASCRIPT,     COLOR_JAVASCRIPT},
-	{"el",         ICON_LISP,           0},
-	{"elc",        ICON_LISP,           0},
+	{"el",         ICON_LISP,           COLOR_EMACS},
+	{"elc",        ICON_LISP,           COLOR_EMACS},
 	{"elf",        ICON_LINUX,          0},
 	{"epub",       ICON_PDF,            COLOR_DOCS},
 	{"exe",        ICON_EXEC,           0},
@@ -318,23 +347,22 @@ static const struct icon_pair icons_ext[] = {
 	{"hpp",        ICON_CHEADER,        COLOR_C},
 	{"hxx",        ICON_CHEADER,        COLOR_C},
 	{"hs",         ICON_HASKELL,        COLOR_VIM},
-	{"htaccess",   ICON_CONFIGURE,      0},
-	{"htpasswd",   ICON_CONFIGURE,      0},
-	{"htm",        ICON_HTML,           0},
-	{"html",       ICON_HTML,           0},
-	{"hxx",        ICON_CPLUSPLUS,      COLOR_C},
+	{"htaccess",   ICON_CONFIGURE,      COLOR_CONFIGURE},
+	{"htpasswd",   ICON_CONFIGURE,      COLOR_CONFIGURE},
+	{"htm",        ICON_HTML,           COLOR_HTML},
+	{"html",       ICON_HTML,           COLOR_HTML},
 	{"heex",       ICON_ELIXIR,         COLOR_ELIXIR},
 
 	/* I */
 	{"ico",        ICON_PICTUREFILE,    COLOR_IMAGE},
-	{"ini",        ICON_CONFIGURE,      0},
+	{"ini",        ICON_CONFIGURE,      COLOR_CONFIGURE},
 	{"img",        ICON_OPTICALDISK,    COLOR_ARCHIVE},
 	{"iso",        ICON_OPTICALDISK,    COLOR_ARCHIVE},
 
 	/* J */
 	{"jar",        ICON_JAVA,           COLOR_JAVA},
 	{"java",       ICON_JAVA,           COLOR_JAVA},
-	{"jl",         ICON_CONFIGURE,      0},
+	{"jl",         ICON_CONFIGURE,      COLOR_CONFIGURE},
 	{"jpeg",       ICON_PICTUREFILE,    COLOR_IMAGE},
 	{"jpg",        ICON_PICTUREFILE,    COLOR_IMAGE},
 	{"js",         ICON_JAVASCRIPT,     COLOR_JAVASCRIPT},
@@ -342,13 +370,14 @@ static const struct icon_pair icons_ext[] = {
 	{"jsx",        ICON_REACT,          COLOR_REACT},
 
 	/* K */
-	{"kbx",        ICON_KEY,            0},
-	{"key",        ICON_KEY,            0},
+	{"kbx",        ICON_KEY,            COLOR_KEY},
+	{"key",        ICON_KEY,            COLOR_KEY},
+	{"ksh",        ICON_SCRIPT,         COLOR_SHELL},
 
 	/* L */
 	{"lha",        ICON_ARCHIVE,        COLOR_ARCHIVE},
 	{"lhs",        ICON_HASKELL,        COLOR_VIM},
-	{"lock",       ICON_LOCK,           0},
+	{"lock",       ICON_LOCK,           COLOR_LOCK},
 	{"log",        ICON_DOCUMENT,       0},
 	{"lua",        ICON_EXT_LUA,        COLOR_LUA},
 	{"lzh",        ICON_ARCHIVE,        COLOR_ARCHIVE},
@@ -361,7 +390,7 @@ static const struct icon_pair icons_ext[] = {
 	{"markdown",   ICON_EXT_MD,         COLOR_DOCS},
 	{"mat",        ICON_EXT_MAT,        COLOR_C},
 	{"md",         ICON_EXT_MD,         COLOR_DOCS},
-	{"md5",        ICON_LOCK,           0},
+	{"md5",        ICON_LOCK,           COLOR_LOCK},
 	{"mk",         ICON_MAKEFILE,       0},
 	{"mkv",        ICON_VIDEOFILE,      COLOR_VIDEO},
 	{"mov",        ICON_VIDEOFILE,      COLOR_VIDEO},
@@ -375,53 +404,61 @@ static const struct icon_pair icons_ext[] = {
 	{"nix",        ICON_EXT_NIX,        COLOR_FSHARP},
 
 	/* O */
-	{"o",          ICON_EXT_O,          0},
+	{"o",          ICON_EXT_O,          COLOR_O},
 	{"ogg",        ICON_MUSICFILE,      COLOR_AUDIO},
-	{"org",        ICON_EMACS,          0},
+	{"org",        ICON_EMACS,          COLOR_EMACS},
 	{"opus",       ICON_MUSICFILE,      COLOR_AUDIO},
-	{"opdownload", ICON_DOWNLOADS,      0},
-	{"otf",        ICON_FONT,           0},
+	{"opdownload", ICON_DOWNLOAD,       COLOR_O},
+	{"otf",        ICON_FONT,           COLOR_O},
 	{"out",        ICON_LINUX,          0},
 
 	/* P */
-	{"part",       ICON_DOWNLOADS,      0},
+	{"part",       ICON_DOWNLOAD,       COLOR_O},
 	{"patch",      ICON_EXT_PATCH,      0},
 	{"pdf",        ICON_PDF,            COLOR_DOCS},
 	{"pgn",        ICON_CHESS,          0},
-	{"php",        ICON_EXT_PHP,        0},
+	{"php",        ICON_EXT_PHP,        COLOR_CPLUSPLUS},
+	{"pkg",        ICON_PKG,            COLOR_ARCHIVE},
 	{"png",        ICON_PICTUREFILE,    COLOR_IMAGE},
 	{"ppt",        ICON_POWERPOINT,     0},
 	{"pptx",       ICON_POWERPOINT,     0},
-	{"psb",        ICON_PHOTOSHOP,      0},
-	{"psd",        ICON_PHOTOSHOP,      0},
+	{"psb",        ICON_PHOTOSHOP,      COLOR_IMAGE},
+	{"psd",        ICON_PHOTOSHOP,      COLOR_IMAGE},
+	{"pub",        ICON_KEY,            COLOR_KEY},
 	{"py",         ICON_PYTHON,        COLOR_PYTHON},
 	{"pyc",        ICON_PYTHON,        COLOR_PYTHON},
 	{"pyd",        ICON_PYTHON,        COLOR_PYTHON},
 	{"pyo",        ICON_PYTHON,        COLOR_PYTHON},
 
 	/* Q */
+	{"qcow2",      ICON_OPTICALDISK,   COLOR_ARCHIVE},
 	{"qss",        ICON_EXT_CSS,       COLOR_CSS},
 
 	/* R */
+	{"r",          ICON_R,              0},
 	{"rar",        ICON_ARCHIVE,        COLOR_ARCHIVE},
 	{"rb",         ICON_RUBY,           COLOR_RUBY},
-	{"rc",         ICON_CONFIGURE,      0},
+	{"rc",         ICON_CONFIGURE,      COLOR_CONFIGURE},
+	{"rdata",      ICON_R,              0},
+	{"rlib",       ICON_RUST,           COLOR_RUST},
+	{"rmeta",      ICON_RUST,           COLOR_RUST},
 	{"rom",        ICON_EXT_ROM,        0},
 	{"rpm",        ICON_PKG,            COLOR_ARCHIVE},
-	{"rs",         ICON_RUST,           COLOR_DOCS},
+	{"rs",         ICON_RUST,           COLOR_RUST},
+	{"rspec",      ICON_RUBY,           COLOR_RUBY},
 	{"rss",        ICON_EXT_RSS,        0},
 	{"rtf",        ICON_EXT_RTF,        0},
 
 	/* S */
-	{"s",          ICON_EXT_ASM,        0},
+	{"s",          ICON_EXT_ASM,        COLOR_ASM},
 	{"sass",       ICON_SASS,           COLOR_CSS},
 	{"scss",       ICON_SASS,           COLOR_CSS},
-	{"so",         ICON_MANUAL,         0},
+	{"so",         ICON_EXT_O,          COLOR_O},
 	{"scala",      ICON_EXT_SCALA,      COLOR_SCALA},
 	{"sh",         ICON_SCRIPT,         COLOR_SHELL},
-	{"sha1",       ICON_LOCK,           0},
-	{"sha256",     ICON_LOCK,           0},
-	{"sig",        ICON_KEY,            0},
+	{"sha1",       ICON_LOCK,           COLOR_LOCK},
+	{"sha256",     ICON_LOCK,           COLOR_LOCK},
+	{"sig",        ICON_KEY,            COLOR_KEY},
 	{"slim",       ICON_SCRIPT,         COLOR_DOCUMENT},
 	{"sln",        ICON_EXT_SLN,        0},
 	{"sql",        ICON_DATABASE,       0},
@@ -430,8 +467,8 @@ static const struct icon_pair icons_ext[] = {
 	{"sub",        ICON_SUBTITLE,       0},
 	{"svg",        ICON_PICTUREFILE,    COLOR_IMAGE},
 	{"swift",      ICON_SWIFT,          0},
-	{"swp",        ICON_VIM,            0},
-	{"sym",        ICON_EXT_O,          0},
+	{"swp",        ICON_VIM,            COLOR_VIM},
+	{"sym",        ICON_EXT_O,          COLOR_O},
 
 	/* T */
 	{"tar",        ICON_ARCHIVE,        COLOR_ARCHIVE},
@@ -442,8 +479,8 @@ static const struct icon_pair icons_ext[] = {
 	{"torrent",    ICON_TORRENT,        COLOR_ARCHIVE},
 	{"ts",         ICON_EXT_TS,        COLOR_JAVASCRIPT},
 	{"tsx",        ICON_REACT,          COLOR_REACT},
-	{"ttc",        ICON_FONT,           0},
-	{"ttf",        ICON_FONT,           0},
+	{"ttc",        ICON_FONT,           COLOR_O},
+	{"ttf",        ICON_FONT,           COLOR_O},
 	{"txt",        ICON_DOCUMENT,       COLOR_DOCUMENT},
 	{"txz",        ICON_ARCHIVE,        COLOR_ARCHIVE},
 
@@ -457,6 +494,8 @@ static const struct icon_pair icons_ext[] = {
 	{"vue",        ICON_VUE,            COLOR_JAVASCRIPT},
 
 	/* W */
+	{"wasm",       ICON_EXT_ASM,        COLOR_HTML},
+	{"wat",        ICON_EXT_BIN,        COLOR_HTML},
 	{"wav",        ICON_MUSICFILE,      COLOR_AUDIO},
 	{"webm",       ICON_VIDEOFILE,      COLOR_VIDEO},
 	{"webp",       ICON_PICTUREFILE,    COLOR_IMAGE},
@@ -466,10 +505,10 @@ static const struct icon_pair icons_ext[] = {
 	/* X */
 	{"xbps",       ICON_PKG,            COLOR_ARCHIVE},
 	{"xcf",        ICON_PICTUREFILE,    COLOR_IMAGE},
-	{"xhtml",      ICON_HTML,           0},
+	{"xhtml",      ICON_HTML,           COLOR_HTML},
 	{"xls",        ICON_MS_EXCEL,       0},
 	{"xlsx",       ICON_MS_EXCEL,       0},
-	{"xml",        ICON_HTML,           0},
+	{"xml",        ICON_HTML,           COLOR_HTML},
 	{"xz",         ICON_ARCHIVE,        COLOR_ARCHIVE},
 
 	/* Y */
@@ -479,6 +518,8 @@ static const struct icon_pair icons_ext[] = {
 	/* Z */
 	{"zip",        ICON_ARCHIVE,        COLOR_ARCHIVE},
 	{"zsh",        ICON_SCRIPT,         COLOR_SHELL},
+	{"zshrc",      ICON_SCRIPT,         COLOR_SHELL},
+	{"zsh-theme",  ICON_SCRIPT,         COLOR_SHELL},
 	{"zst",        ICON_ARCHIVE,        COLOR_ARCHIVE},
 
 	/* Other */


### PR DESCRIPTION
[![Screenshot](https://babkock.github.io/images/screenshot.png)](https://babkock.github.io)

Wow people still write programs in C?? Hello I love this program. It has replaced Ranger as a file manager for me, I find it very efficient and fast. I hope this pull request finds you well. Here is a summary of the changes I am proposing:

* Added many new icons, file extensions, and file names
* Added new color for Emacs, lisp, and Org documents (`Magenta2`)
* Added new color for Rust source files (`IndianRed1`)
* C and C++ header files now have their own icon
* C++ is now a slightly different color than C file icon (`DarkSeaGreen2`)
* Added color for various "key" file types (`.pub`, `.key`, `.kbx`) (`Khaki3`)
* Added color for various "lock" file types (`.lock`, `.asc`, `.ssh`)
* Assembly source files now have a color (`Gold1`)
* HTML files now have a color (`LightSteelBlue`)
* Made a separate file icon for archives, to distinguish them from software packages
* Partially-downloaded files now have a clock icon and a color
* The standard home-directory folders "Music", "Downloads", "Pictures", and "Videos" now have the default colors for audio files, downloads, image files, and videos respectively

Please let me know if there are any changes I can make, or any questions you have. If you think something should be a different color, please feel free to suggest it. I tried not to change too much, or change the currently established icons and colors.