### PR TITLE
add support for multiple files using ffsend

### DIFF
--- a/plugins/upload
+++ b/plugins/upload
@@ -4,27 +4,40 @@
 #              Paste contents of a text a file http://ix.io
 #              Upload a binary file to file.io
 #
-# Dependencies: ffsend (https://github.com/timvisee/ffsend), curl, jq, tr
+# Dependencies: ffsend (https://github.com/timvisee/ffsend), curl, jq, tr, sed
 #
 # Note: Binary file set to expire after a week
 #
 # Shell: POSIX compliant
 # Author: Arun Prakash Jana
 
-if [ -n "$1" ] && [ -s "$1" ]; then
+selection=${NNN_SEL:-${XDG_CONFIG_HOME:-$HOME/.config}/nnn/.selection}
+if [ -s "$selection" ]; then
     if type ffsend >/dev/null 2>&1; then
-        ffsend -fiq u "$1"
-    elif [ "$(mimetype --output-format %m "$1" | awk -F '/' '{print $1}')" = "text" ]; then
-        curl -F "f:1=@$1" ix.io
+      # File name will be randomized foo.tar
+      xargs -0 < "$selection" ffsend u
     else
-        # Upload the file, show the download link and wait till user presses any key
-        curl -s -F "file=@$1" https://file.io/?expires=1w | jq '.link' | tr -d '"'
-
-        # To write download link to "$1".loc and exit
-        # curl -s -F "file=@$1" https://file.io/?expires=1w -o `basename "$1"`.loc
+      printf "For sending multiple(marked) files, ffsend is required."
     fi
+
+    # Clear selection
+    printf "-" > "$NNN_PIPE"
 else
-    printf "empty file!"
+    if [ -n "$1" ] && [ -s "$1" ]; then
+	if type ffsend >/dev/null 2>&1; then
+	    ffsend -fiq u "$1"
+	elif [ "$(mimetype --output-format %m "$1" | awk -F '/' '{print $1}')" = "text" ]; then
+	    curl -F "f:1=@$1" ix.io
+	else
+	    # Upload the file, show the download link and wait till user presses any key
+	    curl -s -F "file=@$1" https://file.io/?expires=1w | jq '.link' | tr -d '"'
+
+	    # To write download link to "$1".loc and exit
+	    # curl -s -F "file=@$1" https://file.io/?expires=1w -o `basename "$1"`.loc
+	fi
+    else
+	printf "empty file!"
+    fi
 fi
 
 read -r _

--- a/plugins/upload
+++ b/plugins/upload
@@ -7,7 +7,7 @@
 # Dependencies: ffsend (https://github.com/timvisee/ffsend), curl, jq, tr
 #
 # Note: Binary file set to expire after a week
-# 	Sending multiple files at once is handled exclusively using ffsend.
+# 	 Uploading selection is handled using ffsend.
 #
 # Shell: POSIX compliant
 # Author: Arun Prakash Jana

--- a/plugins/upload
+++ b/plugins/upload
@@ -4,9 +4,10 @@
 #              Paste contents of a text a file http://ix.io
 #              Upload a binary file to file.io
 #
-# Dependencies: ffsend (https://github.com/timvisee/ffsend), curl, jq, tr, sed
+# Dependencies: ffsend (https://github.com/timvisee/ffsend), curl, jq, tr
 #
 # Note: Binary file set to expire after a week
+# 	Sending multiple files at once is handled exclusively using ffsend.
 #
 # Shell: POSIX compliant
 # Author: Arun Prakash Jana
@@ -17,7 +18,7 @@ if [ -s "$selection" ]; then
       # File name will be randomized foo.tar
       xargs -0 < "$selection" ffsend u
     else
-      printf "For sending multiple(marked) files, ffsend is required."
+      printf "ffsend is required to upload selection."
     fi
 
     # Clear selection


### PR DESCRIPTION
Maybe not needed since you can archive, compress, send and then delete archive on your own. This ffsend feature only archives without compression.