### PR TITLE
Miscellaneous improvements to nmount plugin

### DIFF
--- a/plugins/nmount
+++ b/plugins/nmount
@@ -43,7 +43,7 @@ while [ -n "$dev" ]; do
         elif [ -b "/dev/$dev" ]; then
             pmount "/dev/$dev"
             sleep 1
-            echo "/dev/$dev" mounted to "$(lsblk -n /dev/"$dev" | rev | cut -d' ' -f1 | rev)".
+            echo "/dev/$dev mounted to $(lsblk -n "/dev/$dev" -o MOUNTPOINT | sed "/^$/d")."
         else
             echo "/dev/$dev does not exist or is not a block device."
         fi

--- a/plugins/nmount
+++ b/plugins/nmount
@@ -40,9 +40,11 @@ while [ -n "$dev" ]; do
                     echo "/dev/$dev" ejected.
                 fi
             fi
-        else
+        elif [ -b "/dev/$dev" ]; then
             pmount "/dev/$dev"
             echo "/dev/$dev" mounted to "$(lsblk -n /dev/"$dev" | rev | cut -d' ' -f1 | rev)".
+        else
+            echo "/dev/$dev does not exist or is not a block device."
         fi
     fi
 

--- a/plugins/nmount
+++ b/plugins/nmount
@@ -36,8 +36,7 @@ while [ -n "$dev" ]; do
             sync "$(lsblk -n "/dev/$dev" -o MOUNTPOINT | sed "/^$/d")"
             if pumount "/dev/$dev"; then
                 echo "/dev/$dev" unmounted.
-                if udisksctl power-off -b /dev/"$dev"
-                then
+                if udisksctl power-off -b "/dev/$dev" --no-user-interaction; then
                     echo "/dev/$dev" ejected.
                 fi
             fi

--- a/plugins/nmount
+++ b/plugins/nmount
@@ -34,17 +34,16 @@ while [ -n "$dev" ]; do
     else
         if grep -qs "$dev " /proc/mounts; then
             sync "$(lsblk -n "/dev/$dev" -o MOUNTPOINT | sed "/^$/d")"
-            if pumount "$dev"
-            then
-                echo "$dev" unmounted.
+            if pumount "/dev/$dev"; then
+                echo "/dev/$dev" unmounted.
                 if udisksctl power-off -b /dev/"$dev"
                 then
-                    echo "$dev" ejected.
+                    echo "/dev/$dev" ejected.
                 fi
             fi
         else
-            pmount "$dev"
-            echo "$dev" mounted to "$(lsblk -n /dev/"$dev" | rev | cut -d' ' -f1 | rev)".
+            pmount "/dev/$dev"
+            echo "/dev/$dev" mounted to "$(lsblk -n /dev/"$dev" | rev | cut -d' ' -f1 | rev)".
         fi
     fi
 

--- a/plugins/nmount
+++ b/plugins/nmount
@@ -33,7 +33,7 @@ while [ -n "$dev" ]; do
         exit
     else
         if grep -qs "$dev " /proc/mounts; then
-            sync
+            sync "$(lsblk -n "/dev/$dev" -o MOUNTPOINT | sed "/^$/d")"
             if pumount "$dev"
             then
                 echo "$dev" unmounted.

--- a/plugins/nmount
+++ b/plugins/nmount
@@ -35,9 +35,9 @@ while [ -n "$dev" ]; do
         if grep -qs "$dev " /proc/mounts; then
             sync "$(lsblk -n "/dev/$dev" -o MOUNTPOINT | sed "/^$/d")"
             if pumount "/dev/$dev"; then
-                echo "/dev/$dev" unmounted.
+                echo "/dev/$dev unmounted."
                 if udisksctl power-off -b "/dev/$dev" --no-user-interaction; then
-                    echo "/dev/$dev" ejected.
+                    echo "/dev/$dev ejected."
                 fi
             fi
         elif [ -b "/dev/$dev" ]; then

--- a/plugins/nmount
+++ b/plugins/nmount
@@ -42,6 +42,7 @@ while [ -n "$dev" ]; do
             fi
         elif [ -b "/dev/$dev" ]; then
             pmount "/dev/$dev"
+            sleep 1
             echo "/dev/$dev" mounted to "$(lsblk -n /dev/"$dev" | rev | cut -d' ' -f1 | rev)".
         else
             echo "/dev/$dev does not exist or is not a block device."

--- a/plugins/nmount
+++ b/plugins/nmount
@@ -26,8 +26,7 @@ printf "\nEnsure you aren't still in the mounted device.\n"
 printf "%s" "$prompt"
 read -r dev
 
-while [ -n "$dev" ]
-do
+while [ -n "$dev" ]; do
     if [ "$dev" = "l" ]; then
         lsblk
     elif [ "$dev" = "q" ]; then

--- a/plugins/nmount
+++ b/plugins/nmount
@@ -41,9 +41,10 @@ while [ -n "$dev" ]; do
                 fi
             fi
         elif [ -b "/dev/$dev" ]; then
-            pmount "/dev/$dev"
-            sleep 1
-            echo "/dev/$dev mounted to $(lsblk -n "/dev/$dev" -o MOUNTPOINT | sed "/^$/d")."
+            if pmount "/dev/$dev"; then
+                sleep 1
+                echo "/dev/$dev mounted to $(lsblk -n "/dev/$dev" -o MOUNTPOINT | sed "/^$/d")."
+            fi
         else
             echo "/dev/$dev does not exist or is not a block device."
         fi


### PR DESCRIPTION
- Prevent `sync` from syncing all devices, instead of syncing just the single one chosen by user;
- Fix interactive authentication request by `udiskctl` when trying to power-off HDD;
- Fix instances when `lsblk` fails to provide mountpoint;
- Check if user-provided device exists and is a block device, otherwise fallback gracefully.
- Make some stylistic changes to the code for overall consistency.