### PR TITLE
icons-hash: fix bitwise rotation

### DIFF
--- a/src/icons-hash.c
+++ b/src/icons-hash.c
@@ -109,7 +109,7 @@ pcg(uint64_t *state)
 	*state *= GOLDEN_RATIO_64;
 	uint32_t r = (oldstate >> 59);
 	uint32_t v = (oldstate ^ (oldstate >> 18)) >> 27;
-	return (v >> (32 - r)) | (v << r);
+	return (v >> (-r & 31)) | (v << r);
 }
 
 int


### PR DESCRIPTION
in case the rotation is 0, `v >> (32 - r)` would end up doing a 32 right shift which is equal to the width of `v` and thus undefined behavior.

ref: https://blog.regehr.org/archives/1063