### PR TITLE
General simplification

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -4490,12 +4490,29 @@ static bool get_output(char *file, char *arg1, char *arg2, int fdout, bool page)
 	pid = fork();
 	if (pid == 0) {
 		/* In child */
+		char *bufptr = file;
+
 		close(cmd_in_fd);
 		dup2(cmd_out_fd, STDOUT_FILENO);
 		dup2(cmd_out_fd, STDERR_FILENO);
 		close(cmd_out_fd);
 
-		spawn(utils[UTIL_SH_EXEC], file, arg1, arg2, F_MULTI);
+		if (bufptr && arg1) {
+			char argbuf[CMD_LEN_MAX];
+
+			len = xstrsncpy(argbuf, file, xstrlen(file) + 1);
+			argbuf[len - 1] = ' ';
+			bufptr = argbuf + len;
+			len = xstrsncpy(bufptr, arg1, xstrlen(arg1) + 1);
+			if (arg2) {
+				bufptr[len - 1] = ' ';
+				xstrsncpy(bufptr + len, arg2, xstrlen(arg2) + 1);
+			}
+
+			bufptr = argbuf;
+		}
+
+		spawn(utils[UTIL_SH_EXEC], bufptr, NULL, NULL, F_MULTI);
 		_exit(EXIT_SUCCESS);
 	}
 

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -4511,7 +4511,9 @@ static bool get_output(char *file, char *arg1, char *arg2, int fdout, bool page)
 
 		unlink(g_tmpfpath);
 		return TRUE;
-	} else if (have_file)
+	}
+
+	if (have_file)
 		// Case 3
 		return TRUE;
 


### PR DESCRIPTION
`get_output()`:
- The function now uses `UTIL_SH_EXEC` to execute the command.
- The command writes directly to a tmp file where applicable.
- Got rid of parameter `multi` as it's no longer needed.
- A bad use case is now blocked.
- Got rid of `cmd` and `fd` as they are no longer needed. Correct me if I'm wrong, but `fd` wasn't ever used and there is a path to call `free(cmd)` while it's `NULL` (`multi == FALSE` and `pipe()` failing).
- The comment above wasn't accurate, now it is.
- `g_buf` is now clobbered only in some cases. Not that it would matter much, I imagine.

@jarun I still need to look into using `UTIL_SH_EXEC` for running GUI apps as plugins as you suggested, but I thought I should share this regardless.

I only tried the simple case of setting `NNN_HELP` and opening the help screen. I might do more extensive testing later, or if someone wants to give it a shot as well that would be great.