### PR TITLE
plugins/chksum: use exit instead of return

### DIFF
--- a/plugins/chksum
+++ b/plugins/chksum
@@ -61,7 +61,7 @@ elif [ -n "$1" ]; then
             if echo "$1" | grep -q \.${chks}$; then
                 ${chks}sum -c < "$1"
                 read -r _
-                return
+                exit
             fi
         done
         checksum_type


### PR DESCRIPTION
From https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_24:

| The return utility shall cause the shell to stop executing the current
| function or dot script. If the shell is not currently executing a
| function or dot script, the results are unspecified.

Closes: https://github.com/jarun/nnn/issues/1572