### PR TITLE
Preview-tui hide wezterm split-pane output

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -163,7 +163,7 @@ start_preview() {
                 --cwd "$PWD" "$ENVSTRING" --location "${NNN_SPLIT}split" "$0" "$1" 1 ;;
         wezterm)
             if [ "$NNN_SPLIT" = "v" ]; then split="--horizontal"; else split="--bottom"; fi
-            wezterm cli split-pane --cwd "$PWD" $split "$0" "$1" 1
+            wezterm cli split-pane --cwd "$PWD" $split "$0" "$1" 1 >/dev/null
             wezterm cli activate-pane-direction Prev ;;
         iterm)
             command="$SHELL -c 'cd $PWD; env $ENVSTRING $0 $1 1'"


### PR DESCRIPTION
Avoids wezterm's split-pane command from writing it's output over nnn (note the `18`):
![image](https://user-images.githubusercontent.com/31730729/219521117-73c7ef30-77a7-4ae6-bb11-f2e4a2e2c6e8.png)
