### PR TITLE
Preview-tui restore current working directory

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -344,6 +344,7 @@ preview_file() {
         else
             fifo_pager ls -F --group-directories-first --color=always
         fi
+        cd ..
     elif [ "${encoding#*)}" = "binary" ]; then
         handle_mime "$1" "$mimetype" "$ext" "bin"
     else


### PR DESCRIPTION
This could result in writing the wrong selection to `$CURSEL` here:
https://github.com/jarun/nnn/blob/ade477e705630660baf9ee2345001233047741b5/plugins/preview-tui#L469

I think @michaelzusev described a problem as a result from this on gitter(which I checked out after you mentioned it on the dev-list @jarun, I hadn't before).