### PR TITLE
nmv: prefer selection if -u is active

### DIFF
--- a/plugins/.nmv
+++ b/plugins/.nmv
@@ -17,10 +17,12 @@
 # Shell: bash
 # Author: KlzXS
 
+# shellcheck disable=SC1090,SC1091
+. "$(dirname "$0")"/.nnn-plugin-helper
+
 EDITOR="${EDITOR:-vi}"
 TMPDIR="${TMPDIR:-/tmp}"
 NNN_INCLUDE_HIDDEN="${NNN_INCLUDE_HIDDEN:-0}"
-NNN_PREFER_SELECTION="${NNN_PREFER_SELECTION:-0}"
 VERBOSE="${VERBOSE:-0}"
 RECURSIVE="${RECURSIVE:-0}"
 
@@ -33,25 +35,11 @@ case "$NNN_TRASH" in
 		RM_UTIL="rm -ri" ;;
 esac
 
-selection=${NNN_SEL:-${XDG_CONFIG_HOME:-$HOME/.config}/nnn/.selection}
 exit_status=0
 
 dst_file=$(mktemp "$TMPDIR/.nnnXXXXXX")
 
-if [ -s "$selection" ]; then
-	if [ "$NNN_PREFER_SELECTION" -eq 1 ]; then
-		resp="s"
-	else
-		printf "Rename 'c'urrent / 's'election? "
-		read -r resp
-
-		if ! [ "$resp" = "c" ] && ! [ "$resp" = "s" ]; then
-			exit 1
-		fi
-	fi
-fi
-
-if [ "$resp" = "s" ]; then
+if nnn_use_selection "Rename"; then
 	arr=$(tr '\0' '\n' < "$selection")
 else
 	findcmd="find . ! -name ."

--- a/plugins/.nmv
+++ b/plugins/.nmv
@@ -20,6 +20,7 @@
 EDITOR="${EDITOR:-vi}"
 TMPDIR="${TMPDIR:-/tmp}"
 NNN_INCLUDE_HIDDEN="${NNN_INCLUDE_HIDDEN:-0}"
+NNN_PREFER_SELECTION="${NNN_PREFER_SELECTION:-0}"
 VERBOSE="${VERBOSE:-0}"
 RECURSIVE="${RECURSIVE:-0}"
 
@@ -38,12 +39,16 @@ exit_status=0
 dst_file=$(mktemp "$TMPDIR/.nnnXXXXXX")
 
 if [ -s "$selection" ]; then
-	printf "Rename 'c'urrent / 's'election? "
-	read -r resp
+	if [ "$NNN_PREFER_SELECTION" -eq 1 ]; then
+		resp="s"
+	else
+		printf "Rename 'c'urrent / 's'election? "
+		read -r resp
 
-    if ! [ "$resp" = "c" ] && ! [ "$resp" = "s" ]; then
-        exit 1
-    fi
+		if ! [ "$resp" = "c" ] && ! [ "$resp" = "s" ]; then
+			exit 1
+		fi
+	fi
 fi
 
 if [ "$resp" = "s" ]; then

--- a/plugins/.nnn-plugin-helper
+++ b/plugins/.nnn-plugin-helper
@@ -12,6 +12,9 @@ export selection
 CUR_CTX=0
 export CUR_CTX
 
+NNN_PREFER_SELECTION="${NNN_PREFER_SELECTION:-0}"
+export NNN_PREFER_SELECTION
+
 ## Ask nnn to switch to directory $1 in context $2.
 ## If $2 is not provided, the function asks explicitly.
 nnn_cd () {
@@ -35,4 +38,24 @@ nnn_cd () {
 cmd_exists () {
     type "$1" > /dev/null 2>&1
     echo $?
+}
+
+nnn_use_selection() {
+    if ! [ -s "$selection" ]; then
+        return 1
+    fi
+
+    if [ "$NNN_PREFER_SELECTION" -eq 1 ]; then
+        return 0
+    else
+        [ -n "$1" ] && printf "$1 "
+        printf "(s)election/(c)urrent? [default=c] "
+        read -r resp__
+
+        if [ "$resp__" = "s" ]; then
+            return 0
+        else
+            return 1
+        fi
+    fi
 }

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -212,6 +212,7 @@ When `nnn` executes a plugin, it does the following:
     3. `$3`: The picker mode output file (`-` for stdout) if `nnn` is executed as a file picker.
 - Sets the environment variable `NNN_PIPE` used to control `nnn` active directory.
 - Sets the environment variable `NNN_INCLUDE_HIDDEN` to `1` if hidden files are active, `0` otherwise.
+- Sets the environment variable `NNN_PREFER_SELECTION` to `1` if user prefers to use selection (see nnn's `-u` flag), `0` otherwise.
 - Exports the [special variables](https://github.com/jarun/nnn/wiki/Concepts#special-variables).
 
 Plugins can also read the `.selection` file in the config directory.

--- a/plugins/gpge
+++ b/plugins/gpge
@@ -10,7 +10,8 @@
 # Shell: POSIX compliant
 # Author: KlzXS
 
-selection=${NNN_SEL:-${XDG_CONFIG_HOME:-$HOME/.config}/nnn/.selection}
+# shellcheck disable=SC1090,SC1091
+. "$(dirname "$0")"/.nnn-plugin-helper
 
 printf "(s)ymmetric, (a)symmetric? [default=a] "
 read -r symmetry
@@ -18,12 +19,11 @@ read -r symmetry
 if [ "$symmetry" = "s" ]; then
 	gpg --symmetric "$1"
 else
-	printf "(s)election/(c)urrent? [default=c] "
-	read -r resp
-
-	if [ "$resp" = "s" ]; then
+	if nnn_use_selection; then
+		clear_sel=1
 		files=$(tr '\0' '\n' < "$selection")
 	else
+		clear_sel=0
 		files=$1
 	fi
 
@@ -37,8 +37,8 @@ else
 
 	printf "%s" "$files" | xargs -n1 gpg --encrypt --recipient "$recipient"
 
-    # Clear selection
-    if [ "$resp" = "s" ] && [ -p "$NNN_PIPE" ]; then
-        printf "-" > "$NNN_PIPE"
-    fi
+	# Clear selection
+	if [ "$clear_sel" -eq 1 ] && [ -p "$NNN_PIPE" ]; then
+		printf "-" > "$NNN_PIPE"
+	fi
 fi

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -7368,6 +7368,7 @@ nochange:
 			case SEL_RENAMEMUL:
 				endselection(TRUE);
 				setenv("NNN_INCLUDE_HIDDEN", xitoa(cfg.showhidden), 1);
+				setenv("NNN_PREFER_SELECTION", xitoa(cfg.prefersel), 1);
 				setenv("NNN_LIST", listpath ? listroot : "", 1);
 
 				if (!(getutil(utils[UTIL_BASH])

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -5174,6 +5174,7 @@ static void setexports(void)
 		}
 	}
 	setenv("NNN_INCLUDE_HIDDEN", xitoa(cfg.showhidden), 1);
+	setenv("NNN_PREFER_SELECTION", xitoa(cfg.prefersel), 1);
 }
 
 static void run_cmd_as_plugin(const char *file, uchar_t flags)


### PR DESCRIPTION
the rename plugin always asks for "selection vs current" even when -u flag is active. pass it to the plugin via `NNN_PREFER_SELECTION` so that there's less distracting prompts.