### PR TITLE
fix(preview-tui): fix message leakage cause by kill signal

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -148,7 +148,7 @@ done; unset IFS
 
 exists() { type "$1" >/dev/null 2>&1 ;}
 pkill() { command pkill "$@" >/dev/null 2>&1 ;}
-pidkill() { [ -f "$1" ] && kill "$(cat "$1" 2>/dev/null)" >/dev/null 2>&1 ;}
+pidkill() { [ -f "$1" ] && kill -2 "$(cat "$1" 2>/dev/null)" >/dev/null 2>&1 ;}
 prompt() { printf "%b" "$@"; cfg=$(stty -g); stty raw -echo; head -c 1; stty "$cfg" ;}
 
 start_preview() {
@@ -215,6 +215,7 @@ fifo_pager() {
     mkfifo "$FIFOPATH" || return
 
     $NNN_PAGER < "$FIFOPATH" &
+    printf "%s" "$!" > "$PREVIEWPID"
 
     (
         exec > "$FIFOPATH"

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -215,7 +215,6 @@ fifo_pager() {
     mkfifo "$FIFOPATH" || return
 
     $NNN_PAGER < "$FIFOPATH" &
-    printf "%s" "$!" > "$PREVIEWPID"
 
     (
         exec > "$FIFOPATH"


### PR DESCRIPTION
Honestly, I'm not sure what this `printf` does, but it fixes https://github.com/jarun/nnn/issues/1583

So far, I haven't seen any different behaviour other than no more that flashing error on preview pane.

I have test on following terminal

1. ✅ Wezterm
2. ✅ Kitty
3. ✅ iTerm2
4. ✅ Tmux

All work fine.