### PR TITLE
Fix paths in nushell quitcd script

### DIFF
--- a/misc/quitcd/quitcd.nu
+++ b/misc/quitcd/quitcd.nu
@@ -1,6 +1,6 @@
 # The behaviour is set to cd on quit (nnn checks if NNN_TMPFILE is set)
-let cfgHome = ($env | default $env.HOME XDG_CONFIG_HOME | get XDG_CONFIG_HOME)
-let-env NNN_TMPFILE = $"($cfgHome)/.config/nnn/.lastd"
+let cfgHome = ($env | default $"($env.HOME)/.config" XDG_CONFIG_HOME | get XDG_CONFIG_HOME)
+let-env NNN_TMPFILE = $"($cfgHome)/nnn/.lastd"
 
 def-env n [...x] {
   # Launch nnn. Add desired flags after `^nnn`, ex: `^nnn -eda ($x | str join)`


### PR DESCRIPTION
This set the correct path to the temp nnn file when XDG_CONFIG_HOME is set. It fixes https://github.com/jarun/nnn/discussions/1605