### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -117,7 +117,7 @@ nnn v4.3 Martini
 - add `bookmarks` directory for flexible symlinked bookmarks
 - new key <kbd>B</kbd> to add a symlinked bookmark for current dir
 - special variables `$dN`, `$fN` available for plugins/prompt/shell to access
-  dir/hovered file in each conext
+  dir/hovered file in each context
 - config `NNN_ORDER` to set directory-specific ordering
 - show/hide hidden files as per context state in plugin based batch rename
 - retain search filter history for plugin `finder`

--- a/misc/macos-legacy/mach_gettime.c
+++ b/misc/macos-legacy/mach_gettime.c
@@ -24,7 +24,7 @@ int clock_gettime(clockid_t clk_id, struct timespec *tp)
 		double diff = (mach_absolute_time() - mt_timestart) * mt_timebase;
 		tp->tv_sec = diff * MT_NANO;
 		tp->tv_nsec = diff - (tp->tv_sec * MT_GIGA);
-	} else { // other clk_ids are mapped to the coresponding mach clock_service
+	} else { // other clk_ids are mapped to the corresponding mach clock_service
 		clock_serv_t cclock;
 		mach_timespec_t mts;
 

--- a/misc/macos-legacy/mach_gettime.h
+++ b/misc/macos-legacy/mach_gettime.h
@@ -18,7 +18,7 @@
 typedef int clockid_t;
 
 /* the mach kernel uses struct mach_timespec, so struct timespec
-	is loaded from <sys/_types/_timespec.h> for compatability */
+	is loaded from <sys/_types/_timespec.h> for compatibility */
 // struct timespec { time_t tv_sec; long tv_nsec; };
 
 int clock_gettime(clockid_t clk_id, struct timespec *tp);

--- a/patches/README.md
+++ b/patches/README.md
@@ -2,7 +2,7 @@
 
 This directory contains sizable user submitted patches that were rejected from mainline as they tend to be more subjective in nature.
 
-The patches will be adapted on each release when necessary (v4.1 onwards). Each patch can be applied through its respective make variable during compilation. In case inter-patch merge conflicts occur, a compatability patch is provided and will automatically be applied.
+The patches will be adapted on each release when necessary (v4.1 onwards). Each patch can be applied through its respective make variable during compilation. In case inter-patch merge conflicts occur, a compatibility patch is provided and will automatically be applied.
 
 ## List of patches
 

--- a/plugins/cdpath
+++ b/plugins/cdpath
@@ -2,7 +2,7 @@
 
 # Description: 'cd' to the directory from CDPATH
 #
-# Details: If the CDPATH environmet variable is not set, the default value of
+# Details: If the CDPATH environment variable is not set, the default value of
 #          ${XDG_CONFIG_HOME:-$HOME/.config}/nnn/bookmarks will be used.
 #          You can create this directory and fill it with symbolic links to your
 #          favorite directories. It's a good idea to add it to CDPATH so that it

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -33,7 +33,7 @@
 #   - optional: glow or lowdown for markdown
 #   - optional: w3m or lynx or elinks for html
 #   - optional: set/export NNN_ICONLOOKUP as 1 to enable file icons in front of directory previews with .iconlookup
-#       Icons and colors are configureable in .iconlookup
+#       Icons and colors are configurable in .iconlookup
 #   - optional: scope.sh file viewer from ranger.
 #       1. drop scope.sh executable in $PATH
 #       2. set/export $NNN_SCOPE as 1
@@ -78,7 +78,7 @@
 #   Iterm2 users are recommended to use viu to view images without getting pixelated.
 #
 #   Windows Terminal users can set "Profile termination behavior" under "Profile > Advanced" settings
-#   to automaticaly close pane on quit when exit code is 0.
+#   to automatically close pane on quit when exit code is 0.
 #
 # Shell: POSIX compliant
 # Authors: Todd Yamakawa, Léo Villeveygoux, @Recidiviste, Mario Ortiz Manero, Luuk van Baal, @WanderLanz

--- a/plugins/splitjoin
+++ b/plugins/splitjoin
@@ -26,7 +26,7 @@ if [ "$resp" = "j" ]; then
         for entry in $arr
         do
             if [ -d "$entry" ]; then
-                echo "cant join directories"
+                echo "can't join directories"
                 exit
             fi
         done

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -4472,7 +4472,7 @@ static void set_smart_ctx(int ctx, char *nextpath, char **path, char *file, char
  *  1) fdout == -1 && !page: Write up to CMD_LEN_MAX bytes of command output into g_buf
  *  2) fdout == -1 && page: Create a temp file, write full command output into it and show in pager.
  *  3) fdout != -1 && !page: Write full command output into the provided file.
- *  4) fdout != -1 && page: Don't use! Returns FASLE.
+ *  4) fdout != -1 && page: Don't use! Returns FALSE.
  *
  * g_buf is modified only in case 1.
  * g_tmpfpath is modified only in case 2.
@@ -6460,7 +6460,7 @@ static void statusbar(char *path)
 	}
 
 	attroff(COLOR_PAIR(cfg.curctx + 1));
-	/* Plase HW cursor on current for Braille systems */
+	/* Place HW cursor on current for Braille systems */
 	tocursor();
 }
 


### PR DESCRIPTION
Found via `codespell -L noice,nd,fils,numer,caf,iterm`