### PR TITLE
quitcd.bash_zsh: make POSIX compliant; minor fixes and style changes

### DIFF
--- a/misc/quitcd/quitcd.bash_sh_zsh
+++ b/misc/quitcd/quitcd.bash_sh_zsh
@@ -1,16 +1,16 @@
 n ()
 {
     # Block nesting of nnn in subshells
-    if [[ "${NNNLVL:-0}" -ge 1 ]]; then
+    [ "${NNNLVL:-0}" -eq 0 ] || {
         echo "nnn is already running"
         return
-    fi
+    }
 
     # The behaviour is set to cd on quit (nnn checks if NNN_TMPFILE is set)
     # If NNN_TMPFILE is set to a custom path, it must be exported for nnn to
     # see. To cd on quit only on ^G, remove the "export" and make sure not to
     # use a custom path, i.e. set NNN_TMPFILE *exactly* as follows:
-    #     NNN_TMPFILE="${XDG_CONFIG_HOME:-$HOME/.config}/nnn/.lastd"
+    #      NNN_TMPFILE="${XDG_CONFIG_HOME:-$HOME/.config}/nnn/.lastd"
     export NNN_TMPFILE="${XDG_CONFIG_HOME:-$HOME/.config}/nnn/.lastd"
 
     # Unmask ^Q (, ^V etc.) (if required, see `stty -a`) to Quit nnn
@@ -19,12 +19,12 @@ n ()
     # stty lwrap undef
     # stty lnext undef
 
-    # The backslash allows one to alias n to nnn if desired without making an
-    # infinitely recursive alias
-    \nnn "$@"
+    # The command builtin allows one to alias nnn to n, if desired, without
+    # making an infinitely recursive alias
+    command nnn "$@"
 
-    if [ -f "$NNN_TMPFILE" ]; then
-            . "$NNN_TMPFILE"
-            rm -f "$NNN_TMPFILE" > /dev/null
-    fi
+    [ ! -f "$NNN_TMPFILE" ] || {
+        . "$NNN_TMPFILE"
+        rm -f "$NNN_TMPFILE" > /dev/null
+    }
 }


### PR DESCRIPTION
This commit makes the following changes to quitcd.bash_zsh:
- POSIX compliance and an according rename of the script
- Enforces consistent if-then statements and indentation
- Minor comment fixes