### PR TITLE
Update Haskell icon colour

### DIFF
--- a/src/icons.h
+++ b/src/icons.h
@@ -286,7 +286,7 @@ static const struct icon_pair icons_ext[] = { /* All entries are case-insensitiv
 	{"h",          ICON_C,              COLOR_C},
 	{"hh",         ICON_CPLUSPLUS,      COLOR_C},
 	{"hpp",        ICON_CPLUSPLUS,      COLOR_C},
-	{"hs",         ICON_HASKELL,        COLOR_VIM},
+	{"hs",         ICON_HASKELL,        COLOR_ELIXIR},
 	{"htaccess",   ICON_CONFIGURE,      0},
 	{"htpasswd",   ICON_CONFIGURE,      0},
 	{"htm",        ICON_HTML,           0},


### PR DESCRIPTION
Using the purple used for Elixir makes a little more sense than green. I can change this to add a new color to avoid mixing names if you want but I don't see the need to.