### PR TITLE
Add "$NNN_TERMINAL_ARGS" for "preview-tui" plugin

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -78,6 +78,11 @@
 #   Windows Terminal users can set "Profile termination behavior" under "Profile > Advanced" settings
 #   to automatically close pane on quit when exit code is 0.
 #
+#   When specifying a different terminal, additional arguments are supported. In particular, you can
+#   append a specific title to the terminal and set it to "nofocus" in your WM config.
+#   E.g for alacritty and i3, you can set $NNN_TERMINAL to 'alacritty --title preview-tui' and add
+#   'no_focus [title="preview-tui"]' to your i3 config file.
+#
 # Shell: Bash (for environment manipulation through arrays)
 # Authors: Todd Yamakawa, Léo Villeveygoux, @Recidiviste, Mario Ortiz Manero, Luuk van Baal, @WanderLanz
 
@@ -185,7 +190,8 @@ EOF
         *)  if [ -n "$2" ]; then
                 env "${ENVVARS[@]}" QUICKLOOK=1 "$0" "$1" &
             else
-                env "${ENVVARS[@]}" "$NNN_TERMINAL" -e "$0" "$1" &
+                # shellcheck disable=SC2086 # (allow arguments)
+                env "${ENVVARS[@]}" $NNN_TERMINAL -e "$0" "$1" &
             fi ;;
     esac
 }


### PR DESCRIPTION
Hello.

I would like to document a workaround when using `i3` with a terminal not officially supported by the `preview-tui` plugin. In such case, the focus is switched to the opened window when previewer is started, which is kind of frustrating. Fortunately, this can be circumvented with the right config option and terminal arguments (as explained in the changed file).

Note that:
- because usage of `$NNN_TERMINAL` is quoted in the code, I could not just set `$NNN_TERMINAL` to `alacritty --title preview-tui` ;
- because `env` is used to launch the terminal used by the previewer, I couldn't just add `alias previewer='alacritty --title preview-tui'` (command would not be found).

Do you see any alternative solution? I've tested it and it seems to work well.