### PR TITLE
Makefile: use -g3 for debug builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ endif
 
 ifeq ($(strip $(O_DEBUG)),1)
 	CPPFLAGS += -DDEBUG
-	CFLAGS += -g
+	CFLAGS += -g3
 endif
 
 ifeq ($(strip $(O_NORL)),1)


### PR DESCRIPTION
-g3 builds additional information such as macro definition and so on.