### PR TITLE
Fix crash when PWD is set to empty string

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -8716,7 +8716,7 @@ int main(int argc, char *argv[])
 			/* Start in the current directory */
 			char *startpath = getenv("PWD");
 
-			initpath = startpath ? xstrdup(startpath) : getcwd(NULL, 0);
+			initpath = (startpath && *startpath) ? xstrdup(startpath) : getcwd(NULL, 0);
 			if (!initpath)
 				initpath = "/";
 		} else { /* Open a file */


### PR DESCRIPTION
nnn crashes when PWD is set to empty string: `PWD="" nnn`