### PR TITLE
patches/gitstatus: Fix nerd fonts broken by 3.0.0 update

### DIFF
--- a/patches/gitstatus/mainline.diff
+++ b/patches/gitstatus/mainline.diff
@@ -18,10 +18,10 @@ index 83ecdb90..4397944a 100644
 +#define GIT_ADD ""
 +#define GIT_DEL ""
 +#define GIT_IGN ""
-+#define GIT_MOD ""
++#define GIT_MOD ""
 +#define GIT_NEW ""
 +#define GIT_NON "-"
-+#define GIT_UPD "ﮮ"
++#define GIT_UPD "󰚰"
 +#else
 +#define GIT_ADD "A"
 +#define GIT_DEL "D"

--- a/patches/gitstatus/namefirst.diff
+++ b/patches/gitstatus/namefirst.diff
@@ -19,10 +19,10 @@ index 88538787..d4af7c43 100644
 +#define GIT_ADD ""
 +#define GIT_DEL ""
 +#define GIT_IGN ""
-+#define GIT_MOD ""
++#define GIT_MOD ""
 +#define GIT_NEW ""
 +#define GIT_NON "-"
-+#define GIT_UPD "ﮮ"
++#define GIT_UPD "󰚰"
 +#else
 +#define GIT_ADD "A"
 +#define GIT_DEL "D"


### PR DESCRIPTION
The gitstatus patch has option to use nerd fonts, in which some of the icons used were also borked by the 3.0.0 update but were not fixed alongside the rest of the icons used in nnn.