### PR TITLE
Remove some unnecessary ifdefs

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -28,13 +28,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#define _FILE_OFFSET_BITS 64 /* Support large files on 32-bit glibc */
+
 #if defined(__linux__) || defined(MINGW) || defined(__MINGW32__) \
 	|| defined(__MINGW64__) || defined(__CYGWIN__)
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
-#endif
-#if defined(__arm__) || defined(__i386__)
-#define _FILE_OFFSET_BITS 64 /* Support large files on 32-bit */
 #endif
 #if defined(__linux__)
 #include <sys/inotify.h>


### PR DESCRIPTION
### define _FILE_OFFSET_BITS 64 unconditionally

according to the manpage, it won't have any effect on 64bit system
anyways. and musl always uses 64bit so this macro doesn't have any
effect there either.
