### PR TITLE
fix O_NERD and O_EMOJI on macOS

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -6493,6 +6493,7 @@ static int adjust_cols(int n)
 	return (n - 2);
 }
 
+#if !defined(ICONS_ENABLED) || !defined(__APPLE__)
 static void draw_line(int ncols)
 {
 	bool dir = FALSE;
@@ -6526,6 +6527,7 @@ static void draw_line(int ncols)
 
 	markhovered();
 }
+#endif
 
 static void redraw(char *path)
 {
@@ -6539,14 +6541,20 @@ static void redraw(char *path)
 	if (g_state.move) {
 		g_state.move = 0;
 
+#if !defined(ICONS_ENABLED) || !defined(__APPLE__)
 		if (ndents && (last_curscroll == curscroll))
 			return draw_line(ncols);
+#endif
 	}
 
 	DPRINTF_S(__func__);
 
 	/* Clear screen */
-	erase();
+#if defined(ICONS_ENABLED) && defined(__APPLE__)
+	clear();
+#else
+  erase();
+#endif
 
 	/* Enforce scroll/cursor invariants */
 	move_cursor(cur, 1);


### PR DESCRIPTION
This fixes the problem discussed in #1692 

I had to remove the "fast redraw" path on macOS, I don't know if this is a problem.
The important thing seems to be the `clear()` call. I have also tried to keep the "fast redraw" path by utilizing `clrtoeol` but that did not work.

I think this is more of a mitigation than a fix and shows that it may be a problem in ncurses on macOS.

Edit: I have updated the PR to only affect the code generated for macOS