### PR TITLE
preview-tui SSH compatibility

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -418,7 +418,7 @@ image_preview() {
         kitty +kitten icat --silent --scale-up --place "$1"x"$2"@0x0 --transfer-mode=stream --stdin=no "$3" &
     elif [ "$NNN_TERMINAL" = "wezterm" ] && [ -z "$NNN_PREVIEWIMGPROG" ]; then
         wezterm imgcat "$3" &
-    elif exists ueberzug && { [ -z "$NNN_PREVIEWIMGPROG" ] || [ "$NNN_PREVIEWIMGPROG" = "ueberzug" ] ;} && [ -z "$SSH_CONNECTION" ] ; then⏎
+    elif exists ueberzug && { [ -z "$NNN_PREVIEWIMGPROG" ] || [ "$NNN_PREVIEWIMGPROG" = "ueberzug" ] ;} && [ -z "$SSH_CONNECTION" ] ; then
         ueberzug_layer "$1" "$2" "$3" && return
     elif exists catimg   && { [ -z "$NNN_PREVIEWIMGPROG" ] || [ "$NNN_PREVIEWIMGPROG" = "catimg" ] ;}; then
         catimg "$3" &

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -418,7 +418,7 @@ image_preview() {
         kitty +kitten icat --silent --scale-up --place "$1"x"$2"@0x0 --transfer-mode=stream --stdin=no "$3" &
     elif [ "$NNN_TERMINAL" = "wezterm" ] && [ -z "$NNN_PREVIEWIMGPROG" ]; then
         wezterm imgcat "$3" &
-    elif exists ueberzug && { [ -z "$NNN_PREVIEWIMGPROG" ] || [ "$NNN_PREVIEWIMGPROG" = "ueberzug" ] ;}; then
+    elif exists ueberzug && { [ -z "$NNN_PREVIEWIMGPROG" ] || [ "$NNN_PREVIEWIMGPROG" = "ueberzug" ] ;} && [ -z "$SSH_CONNECTION" ] ; then⏎
         ueberzug_layer "$1" "$2" "$3" && return
     elif exists catimg   && { [ -z "$NNN_PREVIEWIMGPROG" ] || [ "$NNN_PREVIEWIMGPROG" = "catimg" ] ;}; then
         catimg "$3" &


### PR DESCRIPTION
When accessing the remote machine through SSH, skip ueberzug preview method which does not support preview in SSH, even though ueberzug in installed on the remote machine.