### PR TITLE
Fix bug in fzopen when selection is canceled

### DIFF
--- a/plugins/fzopen
+++ b/plugins/fzopen
@@ -59,25 +59,27 @@ if [ "$3" ]; then
     exit 0
 fi
 
-if [ "$USE_NUKE" -ne 0 ]; then
-    "$NUKE" "$entry"
-    exit 0
-fi
+if [ "$entry" ]; then
+    if [ "$USE_NUKE" -ne 0 ]; then
+        "$NUKE" "$entry"
+        exit 0
+    fi
 
-# Open the file (works for a single file only)
-cmd_file=""
-cmd_open=""
-if uname | grep -q "Darwin"; then
-    cmd_file="file -bIL"
-    cmd_open="open"
-else
-    cmd_file="file -biL"
-    cmd_open="xdg-open"
-fi
+    # Open the file (works for a single file only)
+    cmd_file=""
+    cmd_open=""
+    if uname | grep -q "Darwin"; then
+        cmd_file="file -bIL"
+        cmd_open="open"
+    else
+        cmd_file="file -biL"
+        cmd_open="xdg-open"
+    fi
 
-case "$($cmd_file "$entry")" in
-    *text*)
-        "${VISUAL:-$EDITOR}" "$entry" ;;
-    *)
-        $cmd_open "$entry" >/dev/null 2>&1 ;;
-esac
+    case "$($cmd_file "$entry")" in
+        *text*)
+            "${VISUAL:-$EDITOR}" "$entry" ;;
+        *)
+            $cmd_open "$entry" >/dev/null 2>&1 ;;
+    esac
+fi


### PR DESCRIPTION
Empty selection is not handled in the current version of fzopen. This means that error is printed when nuke is used and, even worse, on macOS the current directory is opened in Finder. This is a tiny commit to fix that.