### PR TITLE
Add support for eza as a replacement for exa

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -13,7 +13,7 @@
 #       - Windows Terminal (https://github.com/Microsoft/Terminal | https://aka.ms/terminal) with WSL, or
 #       - $NNN_TERMINAL set to a terminal (it's xterm by default).
 #   - less or $NNN_PAGER
-#   - tree or exa or (GNU) ls
+#   - tree or exa/eza or (GNU) ls
 #   - mediainfo or file
 #   - mktemp
 #   - unzip
@@ -350,6 +350,8 @@ preview_file() {
             fifo_pager tree --filelimit "$(find . -maxdepth 1 | wc -l)" -L 3 -C -F --dirsfirst --noreport
         elif exists exa; then
             exa -G --group-directories-first --colour=always
+        elif exists eza; then # eza is a community fork of exa (exa is unmaintained)
+            eza -G --group-directories-first --colour=always
         else
             fifo_pager ls -F --group-directories-first --color=always
         fi


### PR DESCRIPTION
exa is unmaintained (see https://github.com/ogham/exa), and https://github.com/eza-community/eza is the community-maintained successor.

This PR adds support for eza as a replacement to exa.