### PR TITLE
Fix CI

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,5 +1,30 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,readability-*,modernize-*,bugprone-*,misc-*,-misc-unused-parameters,google-runtime-int,-llvm-header-guard,fuchsia-restrict-system-includes,-clang-analyzer-valist.Uninitialized,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,-clang-analyzer-security.insecureAPI.rand,-clang-analyzer-alpha.*,-modernize-macro-to-enum,-readability-magic-numbers,-readability-braces-around-statements,-readability-function-cognitive-complexity,-readability-identifier-length,-readability-isolate-declaration,-readability-suspicious-call-argument,-bugprone-easily-swappable-parameters,-bugprone-narrowing-conversions,-bugprone-reserved-identifier'
+Checks: >
+    clang-diagnostic-*,
+    clang-analyzer-*,
+    readability-*,
+    modernize-*,
+    bugprone-*,
+    misc-*,
+    google-runtime-int,
+    fuchsia-restrict-system-includes,
+    -misc-unused-parameters,
+    -llvm-header-guard,
+    -clang-analyzer-valist.Uninitialized,
+    -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
+    -clang-analyzer-security.insecureAPI.rand,
+    -clang-analyzer-alpha.*,
+    -modernize-macro-to-enum,
+    -readability-magic-numbers,
+    -readability-braces-around-statements,
+    -readability-function-cognitive-complexity,
+    -readability-identifier-length,
+    -readability-isolate-declaration,
+    -readability-suspicious-call-argument,
+    -bugprone-easily-swappable-parameters,
+    -bugprone-narrowing-conversions,
+    -bugprone-reserved-identifier,
+
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*(?<!lookup3.c)$'
 FormatStyle: 'file'

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -9,6 +9,7 @@ Checks: >
     google-runtime-int,
     fuchsia-restrict-system-includes,
     -misc-unused-parameters,
+    -misc-include-cleaner,
     -llvm-header-guard,
     -clang-analyzer-valist.Uninitialized,
     -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
@@ -24,6 +25,7 @@ Checks: >
     -bugprone-easily-swappable-parameters,
     -bugprone-narrowing-conversions,
     -bugprone-reserved-identifier,
+    -bugprone-switch-missing-default-case,
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*(?<!lookup3.c)$'


### PR DESCRIPTION
Also splits the list of checks into multiple lines. IMO makes it more easily readable and editable. And produces better diff when editing.