### PR TITLE
fix nu quitcd: switched quotes

### DIFF
--- a/misc/quitcd/quitcd.nu
+++ b/misc/quitcd/quitcd.nu
@@ -7,6 +7,7 @@ def-env n [...x] {
   ^nnn ($x | str join)
   let newpath = (
     if ($env.NNN_TMPFILE | path exists) {
+      # FIXME: fails if path contains single-quote
       let newpath = (open $env.NNN_TMPFILE | parse "cd '{nnnpath}'").0.nnnpath
       ^rm -f $env.NNN_TMPFILE
       echo $newpath

--- a/misc/quitcd/quitcd.nu
+++ b/misc/quitcd/quitcd.nu
@@ -7,7 +7,7 @@ def-env n [...x] {
   ^nnn ($x | str join)
   let newpath = (
     if ($env.NNN_TMPFILE | path exists) {
-      let newpath = (open $env.NNN_TMPFILE | parse 'cd "{nnnpath}"').0.nnnpath
+      let newpath = (open $env.NNN_TMPFILE | parse "cd '{nnnpath}'").0.nnnpath
       ^rm -f $env.NNN_TMPFILE
       echo $newpath
     } else {

--- a/misc/quitcd/quitcd.nu
+++ b/misc/quitcd/quitcd.nu
@@ -7,8 +7,8 @@ def-env n [...x] {
   ^nnn ($x | str join)
   let newpath = (
     if ($env.NNN_TMPFILE | path exists) {
-      let rawpath = (open $env.NNN_TMPFILE | parse --regex 'cd (?P<dir>.+)').0.dir
-      let newpath = ($rawpath | $"echo ($in)" | /bin/bash -s)
+      # FIXME: fails if path contains single-quote
+      let newpath = (open $env.NNN_TMPFILE | parse "cd '{nnnpath}'").0.nnnpath
       ^rm -f $env.NNN_TMPFILE
       echo $newpath
     } else {

--- a/misc/quitcd/quitcd.nu
+++ b/misc/quitcd/quitcd.nu
@@ -7,8 +7,8 @@ def-env n [...x] {
   ^nnn ($x | str join)
   let newpath = (
     if ($env.NNN_TMPFILE | path exists) {
-      # FIXME: fails if path contains single-quote
-      let newpath = (open $env.NNN_TMPFILE | parse "cd '{nnnpath}'").0.nnnpath
+      let rawpath = (open $env.NNN_TMPFILE | parse --regex 'cd (?P<dir>.+)').0.dir
+      let newpath = ($rawpath | $"echo ($in)" | /bin/bash -s)
       ^rm -f $env.NNN_TMPFILE
       echo $newpath
     } else {


### PR DESCRIPTION
- quitcd target directory has been in single quotes since 57882ff
- I updated the nushell snippet to correctly parse it. This should close #1736