### PR TITLE
Fix colemak patch

### DIFF
--- a/patches/colemak/mainline.diff
+++ b/patches/colemak/mainline.diff
@@ -3,10 +3,10 @@
 #
 # Author: github.com/jacmoe
 diff --git a/src/nnn.c b/src/nnn.c
-index ecedee43..fdf5a80e 100644
+index 21a7370b..2ddb4053 100644
 --- a/src/nnn.c
 +++ b/src/nnn.c
-@@ -5098,32 +5098,32 @@ static void show_help(const char *path)
+@@ -5109,12 +5109,12 @@ static void show_help(const char *path)
  	"2(___n))\n"
  	"0\n"
  	"1NAVIGATION\n"
@@ -23,8 +23,9 @@ index ecedee43..fdf5a80e 100644
 +	       "9G ^N  End%20^J  Toggle auto-advance on open\n"
  	      "8B (,)  Book(mark)%11b ^/  Select bookmark\n"
  		"a1-4  Context%11(Sh)Tab  Cycle/new context\n"
- 	    "62Esc ^Q  Quit%20q  Quit context\n"
- 		 "b^G  QuitCD%18Q  Pick/err, quit\n"
+ 	    "62Esc ^Q  Quit%19^y  Next young\n"
+@@ -5122,20 +5122,20 @@ static void show_help(const char *path)
+ 		  "cq  Quit context\n"
  	"0\n"
  	"1FILTER & PROMPT\n"
 -		  "c/  Filter%17^N  Toggle type-to-nav\n"


### PR DESCRIPTION
At Gentoo (gentoo/gentoo#32472), we found that the Colemak and Colemak-DH patches do not apply cleanly on the latest 4.9 release nor on `master`:

```
$ make O_COLEMAK=1
patching file src/nnn.c
Hunk #1 FAILED at 5098.
1 out of 1 hunk FAILED -- saving rejects to file src/nnn.c.rej
patching file src/nnn.h
Hunk #1 succeeded at 138 (offset 1 line).
Hunk #2 succeeded at 156 (offset 1 line).
Hunk #3 succeeded at 201 (offset 2 lines).
Hunk #4 succeeded at 228 (offset 2 lines).
Hunk #5 succeeded at 245 (offset 2 lines).
Hunk #6 succeeded at 257 (offset 2 lines).
make[1]: *** [Makefile:343: prepatch] Error 1
make: *** [Makefile:211: nnn] Error 2
```

Strangely, the `check-patches.sh` script does not detect this and claims success for all patches/patch combinations. I did not investigate that, though.

This PR fixes the Colemak patch to apply to `master`.