### PR TITLE
restore sort function pointers when restoring cfg

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -4308,6 +4308,9 @@ static void savecurctx(char *path, char *curname, int nextctx)
 
 	tmpcfg.curctx = nextctx;
 	cfg = tmpcfg;
+	/* Restore the global function pointers alongside the cfg. */
+	entrycmpfn = cfg.reverse ? &reventrycmp : &entrycmp;
+	namecmpfn = cfg.version ? &xstrverscasecmp : &xstricmp;
 }
 
 #ifndef NOSSN
@@ -6248,11 +6251,8 @@ static int set_sort_flags(int r)
 			r = 'd';
 		}
 
-		if (cfg.version)
-			namecmpfn = &xstrverscasecmp;
-
-		if (cfg.reverse)
-			entrycmpfn = &reventrycmp;
+		entrycmpfn = cfg.reverse ? &reventrycmp : &entrycmp;
+		namecmpfn = cfg.version ? &xstrverscasecmp : &xstricmp;
 	} else if (r == CONTROL('T')) {
 		/* Cycling order: clear -> size -> time -> clear */
 		if (cfg.timeorder)
@@ -8018,6 +8018,9 @@ nochange:
 					lastname = g_ctx[r].c_name;
 
 					cfg = g_ctx[r].c_cfg;
+					/* Restore the global function pointers alongside the cfg. */
+					entrycmpfn = cfg.reverse ? &reventrycmp : &entrycmp;
+					namecmpfn = cfg.version ? &xstrverscasecmp : &xstricmp;
 
 					cfg.curctx = r;
 					setdirwatch();

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -4276,6 +4276,18 @@ static void printent(const struct entry *ent, uint_t namecols, bool sel)
 		addch(ind);
 }
 
+/**
+ * Sets the global cfg variable and restores related state to match the new
+ * cfg.
+ */
+static void setcfg(settings newcfg)
+{
+	cfg = newcfg;
+	/* Synchronize the global function pointers to match the new cfg. */
+	entrycmpfn = cfg.reverse ? &reventrycmp : &entrycmp;
+	namecmpfn = cfg.version ? &xstrverscasecmp : &xstricmp;
+}
+
 static void savecurctx(char *path, char *curname, int nextctx)
 {
 	settings tmpcfg = cfg;
@@ -4307,10 +4319,7 @@ static void savecurctx(char *path, char *curname, int nextctx)
 	}
 
 	tmpcfg.curctx = nextctx;
-	cfg = tmpcfg;
-	/* Restore the global function pointers alongside the cfg. */
-	entrycmpfn = cfg.reverse ? &reventrycmp : &entrycmp;
-	namecmpfn = cfg.version ? &xstrverscasecmp : &xstricmp;
+	setcfg(tmpcfg);
 }
 
 #ifndef NOSSN
@@ -6251,6 +6260,7 @@ static int set_sort_flags(int r)
 			r = 'd';
 		}
 
+		/* Ensure function pointers are in sync with cfg. */
 		entrycmpfn = cfg.reverse ? &reventrycmp : &entrycmp;
 		namecmpfn = cfg.version ? &xstrverscasecmp : &xstricmp;
 	} else if (r == CONTROL('T')) {
@@ -8017,12 +8027,9 @@ nochange:
 					lastdir = g_ctx[r].c_last;
 					lastname = g_ctx[r].c_name;
 
-					cfg = g_ctx[r].c_cfg;
-					/* Restore the global function pointers alongside the cfg. */
-					entrycmpfn = cfg.reverse ? &reventrycmp : &entrycmp;
-					namecmpfn = cfg.version ? &xstrverscasecmp : &xstricmp;
+					g_ctx[r].c_cfg.curctx = r;
+					setcfg(g_ctx[r].c_cfg);
 
-					cfg.curctx = r;
 					setdirwatch();
 					goto begin;
 				}


### PR DESCRIPTION
closes #1757 

This PR fixes a sorting synchronization issue.

The root cause of the bug in #1757 is that the sorting function `entrycmpfn` is not restored when changing contexts, causing `reverse` (and `version`) to be "global" in that setting them on one context caused them to be set on all contexts.

This PR fixes the bug by setting `entrycmpfn` and `namecmpfn` to the correct pointers whenever `cfg` is set.

---

simulation of state variables in the bugged scenario:

1. starting state
   - `cfg0.reverse = 0`, `entrycmpfn = &entrycmp`
2. set context 1 to `r`
   - `cfg0.reverse = 1`, `entrycmpfn = &reventrycmp`
3. create context 2. context 2 should default to `r`.
   - `cfg0.reverse = 1`, `cfg1.reverse = 1`, `entrycmpfn = &reventrycmp`
4. unset `r` in context 2.
   - `cfg0.reverse = 1`, `cfg1.reverse = 0`, `entrycmpfn = &entrycmp`
5. switch back to context 1. context 1 should not appear to be `r`.
   - `cfg0.reverse = 1`, `cfg1.reverse = 0`, `entrycmpfn = &entrycmp`
6. try to set `r` again. no-ops when it should do something.
   - `cfg0.reverse = 0`, `cfg1.reverse = 0`, `entrycmpfn = &entrycmp`

the "double unset" behavior is because the statusbar uses a function pointer comparison to print `R` and `V`. it does not use `cfg.reverse` or `cfg.version`. if the statusbar used `cfg.reverse`, we would see `R` in the statusbar, yet no reverse sort in the entrylist.

video :)

https://github.com/jarun/nnn/assets/51880422/5832c1c4-91d4-4460-842d-dad59c54a186