### PR TITLE
When handling SEL_NEW pass `path` to `abspath` call

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -7801,7 +7801,7 @@ nochange:
 			}
 
 			if (!(r == 's' || r == 'h')) {
-				tmp = abspath(tmp, NULL, newpath);
+				tmp = abspath(tmp, path, newpath);
 				if (!tmp) {
 					printwarn(&presel);
 					goto nochange;


### PR DESCRIPTION
If `path` is not provided to `abspath`, later will do `getcwd`, and it's result will differ from `path`. This causes problem that when creating directory inside path reached with symlink, subsequent call to get_cwd_entry does not recognize newly created path as subpath of current path, thus not selecting newly created element.