### PR TITLE
When handling bookmark, use readlink, not realpath

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -7053,7 +7053,7 @@ nochange:
 
 			pent = &pdents[cur];
 			if (!g_state.selbm || !(S_ISLNK(pent->mode) &&
-			                        realpath(pent->name, newpath) &&
+			                        readlink(pent->name, newpath, PATH_MAX) &&
 			                        xstrsncpy(path, lastdir, PATH_MAX)))
 				mkpath(path, pent->name, newpath);
 			g_state.selbm = 0;


### PR DESCRIPTION
This is to cd to path as it pointed by symlink, not to it's real path. Bookmarked directory may itself contain symlinks in path, which should be respected.

For example: if directory is physically in `/mnt/storage/some` and it's symlinked to `~/some` and directory `~/some/dir` added to bookmarks, it's expected that when following bookmark directory will be changed to `~/some/dir` (as in bookmark's link) not to `/mnt/storage/some/dir` (as dir real path).