### PR TITLE
feat(preview-tui): allow image previews inside tmux on kitty terminal

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -72,6 +72,12 @@
 #   With ImageMagick installed, this terminal can use the icat kitten to display images.
 #   Refer to kitty documentation for further details.
 #
+#   Users with both tmux and kitty can leverage image previews inside tmux with kitty's icat kitten
+#   - setup kitty as stated above
+#   - tmux >= v3.3a required
+#   - add the following to your tmux.conf:
+#     - `set -g allow-passthrough on`
+#
 #   Wezterm should work out of the box. If `NNN_PREVIEWIMGPROG` is not specified it will use
 #   built in iTerm2 image protocol.
 #
@@ -435,6 +441,8 @@ image_preview() {
     exec >/dev/tty
     if [ "$NNN_TERMINAL" = "kitty" ] && [[ "$NNN_PREVIEWIMGPROG" == +(|icat) ]]; then
         kitty +kitten icat --silent --scale-up --place "$1"x"$2"@0x0 --transfer-mode=stream --stdin=no "$3" &
+    elif [ "$NNN_TERMINAL" = "tmux" ] && [[ -n "$KITTY_LISTEN_ON" ]] && [[ "$NNN_PREVIEWIMGPROG" == +(|icat) ]]; then
+        kitty +kitten icat --silent --scale-up --place "$(($1 - 1))x$(($2 - 1))"@0x0 --transfer-mode=memory --stdin=no "$3" &
     elif [ "$NNN_TERMINAL" = "wezterm" ] && [[ "$NNN_PREVIEWIMGPROG" == +(|imgcat) ]]; then
         wezterm imgcat "$3" &
     elif exists ueberzug && [[ "$NNN_PREVIEWIMGPROG" == +(|ueberzug) ]]; then


### PR DESCRIPTION
Image previews can work correctly inside tmux while using kitty terminal by using `--transfer-mode=memory` and adding the following to your tmux config:
`set -g allow-passthrough on`

requires tmux 3.3a

i have added a clause to check if terminal is tmux and $KITTY_LISTEN_ON is defined, if so use the icat kitten inside tmux