### PR TITLE
Set PWD environment variable

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -6835,6 +6835,8 @@ begin:
 		setdirwatch();
 	}
 
+	setenv("PWD", path, TRUE);
+
 #ifndef NOX11
 	xterm_cfg(path);
 #endif


### PR DESCRIPTION
This is to make spawned shells and processes to see "logical" path.

This fixes following issue: 

1. create dir `test-dir`
2. create symlink `test-link` pointing to dir `test-dir`
3. change directory to `test-link`, path now is `test-link`
4. press `!` to open shell
5. run `pwd` it shows path `test-dir` which is not path `nnn` is in.

I also was thinking about setting this variable inside of `spawn` but that causes a lot of changes.