### PR TITLE
fix nushell quitcd script: remove deprecated keywords

### DIFF
--- a/misc/quitcd/quitcd.nu
+++ b/misc/quitcd/quitcd.nu
@@ -1,8 +1,8 @@
 # The behaviour is set to cd on quit (nnn checks if NNN_TMPFILE is set)
 let cfgHome = ($env | default $"($env.HOME)/.config" XDG_CONFIG_HOME | get XDG_CONFIG_HOME)
-let-env NNN_TMPFILE = $"($cfgHome)/nnn/.lastd"
+$env.NNN_TMPFILE = $"($cfgHome)/nnn/.lastd"
 
-def-env n [...x] {
+def --env n [...x] {
   # Launch nnn. Add desired flags after `^nnn`, ex: `^nnn -eda ($x | str join)`
   ^nnn ($x | str join)
   let newpath = (


### PR DESCRIPTION
`def-env` was removed, correct use now is `def --env`.
`let-env` was deprecated, correct use now is `$env.`.