### PR TITLE
Setting PWD: set on use case, not on browse

### DIFF
--- a/patches/restorepreview/mainline.diff
+++ b/patches/restorepreview/mainline.diff
@@ -238,7 +238,7 @@ index 0388b23c..66d3316a 100644
  		case SEL_PROMPT:
 +			if (g_state.previewer)
 +				notify_fifo(FALSE, TRUE);
- 			r = handle_cmd(sel, newpath);
+ 			r = handle_cmd(sel, path, newpath);
 +			if (g_state.previewer) {
 +				pkey = previewkey;
 +				goto run_plugin;

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -5237,7 +5237,7 @@ static void show_help(const char *path)
 	unlink(g_tmpfpath);
 }
 
-static void setexports(void)
+static void setexports(const char *path)
 {
 	char dvar[] = "d0";
 	char fvar[] = "f0";
@@ -5261,6 +5261,7 @@ static void setexports(void)
 	}
 	setenv("NNN_INCLUDE_HIDDEN", xitoa(cfg.showhidden), 1);
 	setenv("NNN_PREFER_SELECTION", xitoa(cfg.prefersel), 1);
+	setenv("PWD", path, 1);
 }
 
 static void run_cmd_as_plugin(const char *file, uchar_t flags)
@@ -5391,7 +5392,7 @@ static bool run_plugin(char **path, const char *file, char *runfile, char **last
 		g_state.pluginit = 1;
 	}
 
-	setexports();
+	setexports(*path);
 
 	/* Check for run-cmd-as-plugin mode */
 	if (*file == '!') {
@@ -5565,14 +5566,14 @@ static bool prompt_run(void)
 	return ret;
 }
 
-static bool handle_cmd(enum action sel, char *newpath)
+static bool handle_cmd(enum action sel, char *path, char *newpath)
 {
 	endselection(FALSE);
 
 	if (sel == SEL_LAUNCH)
 		return launch_app(newpath);
 
-	setexports();
+	setexports(path);
 
 	if (sel == SEL_PROMPT)
 		return prompt_run();
@@ -6835,8 +6836,6 @@ begin:
 		setdirwatch();
 	}
 
-	setenv("PWD", path, TRUE);
-
 #ifndef NOX11
 	xterm_cfg(path);
 #endif
@@ -7969,7 +7968,7 @@ nochange:
 		case SEL_SHELL: // fallthrough
 		case SEL_LAUNCH: // fallthrough
 		case SEL_PROMPT:
-			r = handle_cmd(sel, newpath);
+			r = handle_cmd(sel, path, newpath);
 
 			/* Continue in type-to-nav mode, if enabled */
 			if (cfg.filtermode)


### PR DESCRIPTION
This moves setting PWD environment variable closer to the places where child process (that needs PWD correctly set) is started instead of set it on browse.

@jarun this is alternative for https://github.com/jarun/nnn/pull/1778. This moves setting of `PWD` to "setexports" function which is being called before calling subshell and before spawning plugin.

I'm not 100% sure that this will cause `PWD` properly set for _every_ case (i.e. there are cases when "spawn" called without "setexports" being called before - for example when plugin is called as command handling, like `.cbcp`, or when running edit of selection), but this covers all use cases I initially wanted to fix. 

I also tried to put setting of `PWD` directly into `spawn` but that caused a lot of changes, as this function used in a lot of places, and in most of them this variable actually was not needed (like with `.cbcp`).

What do you think? 