### PR TITLE
show linenumber when in SEL_JUMP

### DIFF
--- a/patches/gitstatus/mainline.diff
+++ b/patches/gitstatus/mainline.diff
@@ -35,14 +35,15 @@ index 83ecdb90..4397944a 100644
  /* TYPE DEFINITIONS */
  typedef unsigned int uint_t;
  typedef unsigned char uchar_t;
-@@ -294,6 +313,7 @@ typedef struct entry {
- 	uid_t uid; /* 4 bytes */
- 	gid_t gid; /* 4 bytes */
+@@ -307,6 +326,7 @@ typedef struct entry {
+        gid_t gid; /* 4 bytes */
  #endif
-+	char git_status[2][5];
+        int ncount;
++       char git_status[2][5];
  } *pEntry;
-
+ 
  /* Selection marker */
+
 @@ -349,6 +369,7 @@ typedef struct {
  	uint_t cliopener  : 1;  /* All-CLI app opener */
  	uint_t waitedit   : 1;  /* For ops that can't be detached, used EDITOR */


### PR DESCRIPTION
Related [discussion](https://github.com/jarun/nnn/discussions/1708).
I reworked my previous answer a bit. I think this should be part of nnn, since it's (IMO) hard to manually count down. Or at least include as native patch.

We could also show relative/absolute linenumber always(with minor tweaks), but that doesn't seem to be useful in any way yet.

![linenumber](https://github.com/jarun/nnn/assets/54768193/91173f6f-efa3-404e-891d-985f28d199bd)
