### PR TITLE
Add -- to cp, mv and rm

### DIFF
--- a/misc/musl/musl-static-ubuntu.sh
+++ b/misc/musl/musl-static-ubuntu.sh
@@ -40,7 +40,7 @@ git checkout v0.3.2
 if [ ! -d "./libs" ]; then
     mkdir libs
 else
-    rm -vf libs/*
+    rm -vf -- libs/*
 fi
 make CC=musl-gcc CFLAGS=-O3 LDFLAGS=-static all-static -j$(($(nproc)+1))
 cp -v libcurses/libcurses.a libterminfo/libterminfo.a libs/
@@ -57,7 +57,7 @@ make CC=musl-gcc CFLAGS=-O3 LDFLAGS=-static -j$(($(nproc)+1))
 
 # Compile nnn
 cd ..
-[ -e "./netbsd-curses" ] || rm "$BIN"
+[ -e "./netbsd-curses" ] || rm -- "$BIN"
 musl-gcc -O3 -DNORL -DNOMOUSE -std=c11 -Wall -Wextra -Wshadow -I./netbsd-curses/libcurses -I./musl-fts -o "$BIN" src/nnn.c -Wl,-Bsymbolic-functions -lpthread -L./netbsd-curses/libs -lcurses -lterminfo -static -L./musl-fts/.libs -lfts
 strip "$BIN"
 

--- a/misc/quitcd/quitcd.bash_sh_zsh
+++ b/misc/quitcd/quitcd.bash_sh_zsh
@@ -25,6 +25,6 @@ n ()
 
     [ ! -f "$NNN_TMPFILE" ] || {
         . "$NNN_TMPFILE"
-        rm -f "$NNN_TMPFILE" > /dev/null
+        rm -f -- "$NNN_TMPFILE" > /dev/null
     }
 }

--- a/misc/quitcd/quitcd.csh
+++ b/misc/quitcd/quitcd.csh
@@ -14,4 +14,4 @@ set NNN_TMPFILE=~/.config/nnn/.lastd
 
 # The backslash allows one to alias n to nnn if desired without making an
 # infinitely recursive alias
-alias n '\nnn; source "$NNN_TMPFILE"; rm -f "$NNN_TMPFILE"'
+alias n '\nnn; source "$NNN_TMPFILE"; rm -f -- "$NNN_TMPFILE"'

--- a/misc/quitcd/quitcd.elv
+++ b/misc/quitcd/quitcd.elv
@@ -36,6 +36,6 @@ fn n {|@a|
 
 	if (path:is-regular $E:NNN_TMPFILE) {
 		eval (slurp < $E:NNN_TMPFILE)
-		rm $E:NNN_TMPFILE
+		rm -- $E:NNN_TMPFILE
 	}
 }

--- a/misc/quitcd/quitcd.fish
+++ b/misc/quitcd/quitcd.fish
@@ -31,6 +31,6 @@ function n --wraps nnn --description 'support nnn quit and change directory'
 
     if test -e $NNN_TMPFILE
         source $NNN_TMPFILE
-        rm $NNN_TMPFILE
+        rm -- $NNN_TMPFILE
     end
 end

--- a/misc/quitcd/quitcd.nu
+++ b/misc/quitcd/quitcd.nu
@@ -30,7 +30,7 @@ export def --env n [
 		# Fix post-processing of nnn's given path that escapes its single quotes with POSIX syntax.
 		let path = open $nnn_tmpfile | str substring 4..-1 | str replace --all `'\''` `'`
 
-		^rm $nnn_tmpfile
+		^rm -- $nnn_tmpfile
 
 		cd $path
 	}

--- a/plugins/.nmv
+++ b/plugins/.nmv
@@ -32,7 +32,7 @@ case "$NNN_TRASH" in
 	2)
 		RM_UTIL="gio trash" ;;
 	*)
-		RM_UTIL="rm -ri" ;;
+		RM_UTIL="rm -ri --" ;;
 esac
 
 exit_status=0
@@ -64,7 +64,7 @@ lines=$(printf "%s\n" "$arr" | wc -l)
 width=${#lines}
 
 dst_file=$(mktemp "$TMPDIR/.nnnXXXXXX")
-trap 'rm -f "$dst_file"' EXIT
+trap 'rm -f -- "$dst_file"' EXIT
 
 printf "%s" "$arr" | awk '{printf("%'"${width}"'d %s\n", NR, $0)}' > "$dst_file"
 
@@ -122,7 +122,7 @@ while read -r num name; do
 				tmp="$tmp~$c"
 			done
 
-			if mv "$name" "$tmp"; then
+			if mv -- "$name" "$tmp"; then
 				if [ "$VERBOSE" -ne 0 ]; then
 					printf "'%s' -> '%s'\n" "$name" "$tmp"
 				fi
@@ -142,7 +142,7 @@ while read -r num name; do
 		if [ ! -d "$dir" ] && ! mkdir -p "$dir"; then
 			printf "%s: failed to create directory tree %s\n" "$0" "$dir" > /dev/stderr
 			exit_status=1
-		elif ! mv -i "$src" "$name"; then
+		elif ! mv -i -- "$src" "$name"; then
 			printf "%s: failed to rename %s to %s: %s\n" "$0" "$name" "$tmp" "$!" > /dev/stderr
 			exit_status=1
 		else

--- a/plugins/bulknew
+++ b/plugins/bulknew
@@ -29,4 +29,4 @@ $EDITOR "$tmpfile"
 
 sed "/^\//d" "$tmpfile" | xargs -n1 -I{} sh -c "$cmd"
 
-rm "$tmpfile"
+rm -- "$tmpfile"

--- a/plugins/cbpaste-mac
+++ b/plugins/cbpaste-mac
@@ -21,4 +21,4 @@ fs=($( osascript -e "use framework \"Foundation\"
     pb's readObjectsForClasses:[NSURL] options:[]
     (result's valueForKey:\"path\") as list as text" ))
 
-cp -R "${fs[@]}" "$2/"
+cp -R -- "${fs[@]}" "$2/"

--- a/plugins/diffs
+++ b/plugins/diffs
@@ -25,7 +25,7 @@ dirdiff() {
     ls -A1 "$1" > "$dir1"
     ls -A1 "$2" > "$dir2"
     $diffcmd "$dir1" "$dir2"
-    rm "$dir1" "$dir2"
+    rm -- "$dir1" "$dir2"
 }
 
 if [ -s "$selection" ]; then

--- a/plugins/dups
+++ b/plugins/dups
@@ -58,13 +58,13 @@ read -r force
 
 if [ "$force" = "f" ]; then
 	#shellcheck disable=SC2016
-	sed -e "$sedcmd" "$tmpfile" | tr '\n' '\0' | xargs -0 -r sh -c 'rm -f "$0" "$@" </dev/tty'
+	sed -e "$sedcmd" "$tmpfile" | tr '\n' '\0' | xargs -0 -r sh -c 'rm -f -- "$0" "$@" </dev/tty'
 else
 	#shellcheck disable=SC2016
-	sed -e "$sedcmd" "$tmpfile" | tr '\n' '\0' | xargs -0 -r sh -c 'rm -i "$0" "$@" </dev/tty'
+	sed -e "$sedcmd" "$tmpfile" | tr '\n' '\0' | xargs -0 -r sh -c 'rm -i -- "$0" "$@" </dev/tty'
 fi
 
-rm "$tmpfile"
+rm -- "$tmpfile"
 
 printf "Press any key to exit"
 read -r _

--- a/plugins/finder
+++ b/plugins/finder
@@ -84,6 +84,6 @@ if [ -n "$fexpr" ]; then
     if [ -n "$fexpr" ]; then
         tail -n"$NNN_FINDHISTLEN" "$NNN_FINDHIST" > "$TMPDIR/finderbms"
         printf "%s\n" "$fexpr" >> "$TMPDIR/finderbms"
-        mv "$TMPDIR/finderbms" "$NNN_FINDHIST"
+        mv -- "$TMPDIR/finderbms" "$NNN_FINDHIST"
     fi
 fi

--- a/plugins/fixname
+++ b/plugins/fixname
@@ -65,7 +65,7 @@ for i in "${targets[@]}"; do
         if [ -e "$(cleanup "$i")" ]; then
             tmp='_'
         fi
-        mv "$i" "$tmp$(cleanup "$i")";
+        mv -- "$i" "$tmp$(cleanup "$i")";
     fi
 done
 

--- a/plugins/fzcd
+++ b/plugins/fzcd
@@ -60,7 +60,7 @@ if [ -n "$LIST" ]; then
         # Alternative for 'fd'
         # sel=$(xargs -d '\n' < "$tmpfile" fd . | fzf --delimiter / --tiebreak=begin --info=hidden)
 
-        rm "$tmpfile"
+        rm -- "$tmpfile"
     else
         printf "find missing"
         read -r _

--- a/plugins/fzhist
+++ b/plugins/fzhist
@@ -46,7 +46,7 @@ if [ -n "$entry" ]; then
         $SHELL -c "$(cat "$tmpfile")"
     fi
 
-    rm "$tmpfile"
+    rm -- "$tmpfile"
 
     printf "Press any key to exit"
     read -r _

--- a/plugins/getplugs
+++ b/plugins/getplugs
@@ -24,7 +24,7 @@ prompt () {
 	if [ "$operation" = "m" ]; then
 		op="merge"
 	elif [ "$operation" = "o" ]; then
-		op="cp -vRf"
+		op="cp -vRf --"
 	else
 		op="true"
 	fi
@@ -62,7 +62,7 @@ for f in $(find . -maxdepth 1 \( ! -iname "." ! -iname "*.md" \)); do
 			$op "$f" ../../plugins/
 		fi
 	else
-		cp -vRf "$f" ../../plugins/
+		cp -vRf -- "$f" ../../plugins/
 	fi
 done
 cd ../.. || exit 1

--- a/plugins/imgur
+++ b/plugins/imgur
@@ -583,7 +583,7 @@ for upload_file in "${upload_files[@]}"; do
   # delete file if configured
   if [ "${keep_file}" = "false" ] && [ -z "${1}" ]; then
     echo "Deleting temp file ${file_dir}/${img_file}"
-    rm -rf "${img_file}"
+    rm -rf -- "${img_file}"
   fi
 
   echo ""

--- a/plugins/imgview
+++ b/plugins/imgview
@@ -54,7 +54,7 @@ make_thumbs() {
     done
     for file in "$NNN_PREVIEWDIR$dir"/*; do
         filename="$(basename "$file" .jpg)"
-        [ ! -e "$dir/$filename" ] && rm "$file" 2>/dev/null
+        [ ! -e "$dir/$filename" ] && rm -- "$file" 2>/dev/null
     done
 }
 

--- a/plugins/nbak
+++ b/plugins/nbak
@@ -34,7 +34,7 @@ fi
 cd "$tempdir/$outdir" || exit 1
 
 # Backing up config dir content
-cp -r "$configdir" . || exit 1
+cp -r -- "$configdir" . || exit 1
 
 # Environment config
 env | sed "s/'/'\\\\''/" |\
@@ -72,4 +72,4 @@ printf "Saving as '%s' ... " "$workdir/$outfile"
 
 tar caf "$workdir/$outfile" "$outdir" && echo "Done" || echo "Failed"
 
-cd "$workdir" && rm -rf "$tempdir"
+cd "$workdir" && rm -rf -- "$tempdir"

--- a/plugins/nuke
+++ b/plugins/nuke
@@ -277,7 +277,7 @@ listimages() {
 load_dir() {
     abspath "$2"
     tmp="${TMPDIR:-/tmp}/nuke_$$"
-    trap 'rm -f $tmp' EXIT
+    trap 'rm -f -- "$tmp"' EXIT
     count="$(listimages "$abs_target" | grep -a -m 1 -ZznF "$abs_target" | cut -d: -f1)"
 
     if [ -n "$count" ]; then
@@ -402,7 +402,7 @@ handle_multimedia() {
         #                  "${FPATH}";
         #     then
         #         convert -- "${preview_png}" "${IMAGE_CACHE_PATH}" \
-        #             && rm "${preview_png}" \
+        #             && rm -- "${preview_png}" \
         #             && exit 6
         #     else
         #         exit 1

--- a/plugins/organize
+++ b/plugins/organize
@@ -13,36 +13,36 @@ organize() {
     case "$(file -biL "$1")" in
         *video*)
             [ ! -d "Videos" ] && mkdir "Videos"
-            mv "$1" "Videos/$1"
+            mv -- "$1" "Videos/$1"
             printf "Moved %s to Videos\n" "$1" ;;
 
         *audio*) [ ! -d "Audio" ] && mkdir "Audio"
-            mv "$1" "Audio/$1"
+            mv -- "$1" "Audio/$1"
             printf "Moved %s to Audio\n" "$1" ;;
 
         *image*)
             [ ! -d "Images" ] && mkdir "Images"
-            mv "$1" "Images/$1"
+            mv -- "$1" "Images/$1"
             printf "Moved %s to Images\n" "$1" ;;
 
         *pdf*|*document*|*epub*|*djvu*|*cb*)
             [ ! -d "Documents" ] && mkdir "Documents"
-            mv "$1" "Documents/$1"
+            mv -- "$1" "Documents/$1"
             printf "Moved %s to Documents\n" "$1" ;;
 
         *text*)
             [ ! -d "Plaintext" ] && mkdir "Plaintext"
-            mv "$1" "Plaintext/$1"
+            mv -- "$1" "Plaintext/$1"
             printf "Moved %s to Plaintext\n" "$1" ;;
 
         *tar*|*xz*|*compress*|*7z*|*rar*|*zip*)
             [ ! -d "Archives" ] && mkdir "Archives"
-            mv "$1" "Archives/$1"
+            mv -- "$1" "Archives/$1"
             printf "Moved %s to Archives\n" "$1" ;;
 
         *binary*)
             [ ! -d "Binaries" ] && mkdir "Binaries"
-            mv "$1" "Binaries/$1"
+            mv -- "$1" "Binaries/$1"
             printf "Moved %s to Binaries\n" "$1" ;;
     esac
 }

--- a/plugins/pdfread
+++ b/plugins/pdfread
@@ -15,7 +15,7 @@ if [ -n "$1" ]; then
 
         pico2wave -w "$tmpf".wav -l en-GB "$(tr '\n' ' ' < "$tmpf".txt)"
 
-        rm "$tmpf".txt
+        rm -- "$tmpf".txt
     else
         pico2wave -w "$tmpf".wav -l en-GB "$(tr '\n' ' ' < "$1")"
     fi
@@ -26,5 +26,5 @@ if [ -n "$1" ]; then
     # flat read but better quality
     # play -qV0 "$tmpf".wav treble 2 gain -l 2
 
-    rm "$tmpf".wav
+    rm -- "$tmpf".wav
 fi

--- a/plugins/preview-tabbed
+++ b/plugins/preview-tabbed
@@ -92,7 +92,7 @@ start_tabbed () {
 
     read -r XID < "$FIFO"
 
-    rm "$FIFO"
+    rm -- "$FIFO"
 }
 
 get_viewer_pid () {

--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -259,7 +259,7 @@ fifo_pager() {
         fi
     )
 
-    rm "$FIFOPATH"
+    rm -- "$FIFOPATH"
 }
 
 # Binary file: show file info inside the pager
@@ -423,7 +423,7 @@ generate_preview() {
                    fi ;;
             office) libreoffice --convert-to jpg "$3" --outdir "$NNN_PREVIEWDIR/${3%/*}"
                     filename="$(printf "%s" "${3##*/}" | cut -d. -f1)"
-                    mv "$NNN_PREVIEWDIR/${3%/*}/$filename.jpg" "$NNN_PREVIEWDIR/$3.jpg" ;;
+                    mv -- "$NNN_PREVIEWDIR/${3%/*}/$filename.jpg" "$NNN_PREVIEWDIR/$3.jpg" ;;
             pdf) pdftoppm -jpeg -f 1 -singlefile "$3" "$NNN_PREVIEWDIR/$3" ;;
             djvu) ddjvu -format=ppm -page=1 "$3" "$NNN_PREVIEWDIR/$3.jpg" ;;
             video) video_preview "$1" "$2" "$3" && return ;;
@@ -467,7 +467,7 @@ video_preview() {
     if [ -n "$NNN_PREVIEWVIDEO" ]; then
         mpv --no-config --really-quiet --vo="$NNN_PREVIEWVIDEO" --profile=sw-fast --loop-file --no-audio "$4" "$3" &
     else
-        ffmpegthumbnailer -m -s0 -i "$3" -o "$NNN_PREVIEWDIR/$3.jpg" || rm "$NNN_PREVIEWDIR/$3.jpg" &
+        ffmpegthumbnailer -m -s0 -i "$3" -o "$NNN_PREVIEWDIR/$3.jpg" || rm -- "$NNN_PREVIEWDIR/$3.jpg" &
     fi
     printf "%s" "$!" > "$PREVIEWPID"
 }
@@ -517,7 +517,7 @@ if [ "$PREVIEW_MODE" -eq 1 ] 2>/dev/null; then
     printf "%s" "$!" > "$FIFOPID"
     printf "%s" "$PWD/$1" > "$CURSEL"
     trap 'winch_handler' WINCH
-    trap 'rm "$PREVIEWPID" "$CURSEL" "$FIFO_UEBERZUG" "$FIFOPID" "$POSOFFSET" 2>/dev/null' INT HUP EXIT
+    trap 'rm -- "$PREVIEWPID" "$CURSEL" "$FIFO_UEBERZUG" "$FIFOPID" "$POSOFFSET" 2>/dev/null' INT HUP EXIT
     while kill -s 0 $WAITPID; do
       wait $WAITPID 2>/dev/null
     done

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -589,7 +589,7 @@ static char * const utils[] = {
 	".nmv",
 	"trash-put",
 	"gio trash",
-	"rm -rf",
+	"rm -rf --",
 	"archivemount",
 };
 
@@ -743,8 +743,8 @@ static const char * const envs[] = {
 
 #define PROGRESS_CP   "cpg -giRp"
 #define PROGRESS_MV   "mvg -gi"
-static char cp[sizeof PROGRESS_CP] = "cp -iRp";
-static char mv[sizeof PROGRESS_MV] = "mv -i";
+static char cp[sizeof PROGRESS_CP] = "cp -iRp --";
+static char mv[sizeof PROGRESS_MV] = "mv -i --";
 
 /* Archive commands */
 static char * const archive_cmd[] = {"atool -a", "bsdtar -acvf", "zip -r", "tar -acvf"};
@@ -2555,7 +2555,7 @@ static bool rmmulstr(char *buf, bool use_trash)
 		return FALSE;
 
 	if (!use_trash)
-		snprintf(buf, CMD_LEN_MAX, "xargs -0 sh -c 'rm -%cr \"$0\" \"$@\" < /dev/tty' < %s",
+		snprintf(buf, CMD_LEN_MAX, "xargs -0 sh -c 'rm -%cr -- \"$0\" \"$@\" < /dev/tty' < %s",
 			 r, selpath);
 	else
 		snprintf(buf, CMD_LEN_MAX, "xargs -0 %s < %s",
@@ -2575,7 +2575,7 @@ static bool xrm(char * const fpath, bool use_trash)
 		char rm_opts[] = "-ir";
 
 		rm_opts[1] = r;
-		spawn("rm", rm_opts, fpath, NULL, F_NORMAL | F_CHKRTN);
+		spawn("rm", rm_opts, "--", fpath, F_NORMAL | F_CHKRTN);
 	} else
 		spawn(utils[(g_state.trash == 1) ? UTIL_TRASH_CLI : UTIL_GIO_TRASH],
 		      fpath, NULL, NULL, F_NORMAL | F_MULTI);
@@ -2728,7 +2728,7 @@ static bool batch_rename(void)
 	bool dir = FALSE, ret = FALSE;
 	char foriginal[TMP_LEN_MAX] = {0};
 	static const char batchrenamecmd[] = "paste -d'\n' %s %s | "SED" 'N; /^\\(.*\\)\\n\\1$/!p;d' | "
-					     "tr '\n' '\\0' | xargs -0 -n2 sh -c 'mv -i \"$0\" \"$@\" <"
+					     "tr '\n' '\\0' | xargs -0 -n2 sh -c 'mv -i -- \"$0\" \"$@\" <"
 					     " /dev/tty'";
 	char buf[sizeof(batchrenamecmd) + (PATH_MAX << 1)];
 	int i = get_cur_or_sel();
@@ -7861,7 +7861,7 @@ nochange:
 			if (sel == SEL_RENAME) {
 				/* Rename the file */
 				if (ret == 'd')
-					spawn("cp -rp", pdents[cur].name, tmp, NULL, F_SILENT);
+					spawn("cp -rp --", pdents[cur].name, tmp, NULL, F_SILENT);
 				else if (rename(pdents[cur].name, tmp) != 0) {
 					printwarn(&presel);
 					goto nochange;


### PR DESCRIPTION
I think these are all the instances where we use `cp`, `mv` and `rm` on user supplied paths, but I want someone else to confirm that as well.

Can someone who regularly uses the more "exotic" shells confirm if they support this syntax and if it's even necessary? They should, but let's make sure. Particularly in regard to quitcd.

I don't foresee any regressions, but I haven't done any testing as of yet.

Fixes #1818