### PR TITLE
Added dashes to progress versions of cp and mv

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -741,8 +741,8 @@ static const char * const envs[] = {
 #define T_CHANGE 1
 #define T_MOD    2
 
-#define PROGRESS_CP   "cpg -giRp"
-#define PROGRESS_MV   "mvg -gi"
+#define PROGRESS_CP   "cpg -giRp --"
+#define PROGRESS_MV   "mvg -gi --"
 static char cp[sizeof PROGRESS_CP] = "cp -iRp --";
 static char mv[sizeof PROGRESS_MV] = "mv -i --";
 


### PR DESCRIPTION
I did a grep for cp and mv, but that didn't pick up these two which messed up the size of the strings below.