### PR TITLE
nuke: use sort -V

### DIFF
--- a/plugins/nuke
+++ b/plugins/nuke
@@ -271,7 +271,7 @@ abspath() {
 listimages() {
     find -L "///${1%/*}" -maxdepth 1 -type f -print0 |
         grep -izZE '\.(jpe?g|png|gif|webp|tiff|bmp|ico|svg)$' |
-        sort -z | tee "$tmp"
+        sort -zV | tee "$tmp"
 }
 
 load_dir() {


### PR DESCRIPTION
```
$ mkdir test
$ for x in {1..20}; do convert xc:red test/$x.png; done
$ nnn test
Press l
```
nnn lists these png files in ascending order, but sxiv doesn't. Adding -V option to sort(1) fixes this.