### PR TITLE
Support more trash utility

### DIFF
--- a/nnn.1
+++ b/nnn.1
@@ -562,7 +562,7 @@ separated by \fI;\fR:
 \fBNNN_TRASH:\fR trash (instead of \fIrm -rf\fR) files to desktop Trash.
 .Bd -literal
     export NNN_TRASH=n
-    # n=1: trash-cli, n=2: gio trash
+    # n=1: trash-cli, n=2: gio trash, n=3: sindresorhus/macos-trash
 .Ed
 .Pp
 \fBNNN_SEL:\fR absolute path to custom selection file.


### PR DESCRIPTION
This PR add more options for the environment variable `NNN_TRASH`.

Currently, `NNN_TRASH` only support two external utilities: `1` for `trash-put` in [andreafrancia/trash-cli](https://github.com/andreafrancia/trash-cli), `2` for `gio trash`. These two doesn't seem to act perfectly in macOS.

In macOS, there are trash utilities like [sindresorhus/macos-trash](https://github.com/sindresorhus/macos-trash) and [trash](https://hasseg.org/trash/), which just move files/folders to the native trash bin. The two utilities can be installed with:
```sh
brew install macos-trash
brew install trash
```
These two both provide the command interface `trash`. They are useful when an user prefer to use the native trash folder.

Thanks for your review.