### PR TITLE
picker & fifomode: on 'l' press, pick file instead of opening it

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -7139,13 +7139,19 @@ nochange:
 			}
 
 #ifndef NOFIFO
-			if (g_state.fifomode && (sel == SEL_OPEN)) {
+			if (g_state.fifomode) {
+				/* Open file disabled on right arrow or `l` */
+				if (cfg.nonavopen && sel == SEL_NAV_IN)
+					goto nochange;
 				send_to_explorer(&presel); /* Write selection to explorer fifo */
 				break;
 			}
 #endif
-			/* If opened as vim plugin and Enter/^M pressed, pick */
-			if (g_state.picker && (sel == SEL_OPEN)) {
+			/* If opened as vim plugin and Enter/^M/Double-click or l/Right pressed, pick */
+			if (g_state.picker) {
+				/* Open file disabled on right arrow or `l` */
+				if (cfg.nonavopen && sel == SEL_NAV_IN)
+					goto nochange;
 				if (nselected == 0) /* Pick if none selected */
 					appendfpath(newpath, mkpath(path, pent->name, newpath));
 				return EXIT_SUCCESS;


### PR DESCRIPTION
This enables a user to pick files by pressing `l` key when using nnn as a picker or in fifomode, which is used by vim plugins such as [`mcchrish/nnn.vim`](https://github.com/mcchrish/nnn.vim) and [`luukvbaal/nnn.nvim`](https://github.com/luukvbaal/nnn.nvim). It also prevents nnn from opening a file when `l` key is pressed, which is unexpected and unwanted behavior form the user's perspective (IMO).

I explained the use case in #1827 (so not going to copy-paste or rewrite it here) and also tried to discuss whether it is acceptable to make nnn pick files by pressing `l` in a way which I am presenting in this PR, but I guess it turned out to be vague, so I decided to straight file a PR to show what I want.