### PR TITLE
Fix file creation on OpenBSD

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -4732,7 +4732,7 @@ next:
 			return FALSE;
 		}
 	} else {
-		int fd = open(path, O_CREAT | O_TRUNC, S_IWUSR | S_IRUSR); /* Forced create mode for files */
+		int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, S_IWUSR | S_IRUSR); /* Forced create mode for files */
 
 		if (fd == -1 && errno != EEXIST) {
 			DPRINTF_S("open!");


### PR DESCRIPTION
On OpenBSD at least one of O_RDONLY, O_WRONLY or O_RDWR is needed to open a file.

In creating a new file none of those is set, which leads to an EINVAL error ("invalid argument").

Since the new file is only created and never read, I chose to use O_WRONLY.