### PR TITLE
remove common prefix before comparing numerical filenames 

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -2854,10 +2854,15 @@ static void write_lastdir(const char *curpath, const char *outfile)
  *
  * If the absolute numeric values are same, we fallback to alphasort.
  */
-static int xstricmp(const char * const s1, const char * const s2)
+static int xstricmp(const char *s1, const char *s2)
 {
-	char *p1, *p2;
+	/* Remove the common prefix of both strings. */
+	while (*s1 && *s2 && *s1 == *s2) {
+		s1++;
+		s2++;
+	}
 
+	char *p1, *p2;
 	long long v1 = strtoll(s1, &p1, 10);
 	long long v2 = strtoll(s2, &p2, 10);
 


### PR DESCRIPTION
Currently, nnn sorts files like this:

![image](https://github.com/jarun/nnn/assets/51880422/83531b19-66a8-4559-8059-e34870375661)

After code change:

![image](https://github.com/jarun/nnn/assets/51880422/c24d140c-2fa3-441b-a277-d1508d995fe8)
