### PR TITLE
quitcd: fix range limits for new nushell version

### DIFF
--- a/misc/quitcd/quitcd.nu
+++ b/misc/quitcd/quitcd.nu
@@ -29,8 +29,7 @@ export def --env n [
 		# Remove <cd '> from the first part of the string and the last single quote <'>.
 		# Fix post-processing of nnn's given path that escapes its single quotes with POSIX syntax.
 		let path = open $nnn_tmpfile
-			| str substring 3..
-			| str trim --char "'"
+			| str replace --all --regex `^cd '|'$` ``
 			| str replace --all `'\''` `'`
 
 		^rm -- $nnn_tmpfile

--- a/misc/quitcd/quitcd.nu
+++ b/misc/quitcd/quitcd.nu
@@ -28,7 +28,10 @@ export def --env n [
 	if ($nnn_tmpfile | path exists) {
 		# Remove <cd '> from the first part of the string and the last single quote <'>.
 		# Fix post-processing of nnn's given path that escapes its single quotes with POSIX syntax.
-		let path = open $nnn_tmpfile | str substring 4..-1 | str replace --all `'\''` `'`
+		let path = open $nnn_tmpfile
+			| str substring 3..
+			| str trim --char "'"
+			| str replace --all `'\''` `'`
 
 		^rm -- $nnn_tmpfile
 


### PR DESCRIPTION
[Last version of nushell](https://www.nushell.sh/blog/2024-04-30-nushell_0_93_0.html) changed the way ranges work, so the command `str substring 4..-1` isn't behaving the way it was anymore.