### PR TITLE
Draft: Add mark plugin

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -41,6 +41,7 @@ Plugins extend the capabilities of `nnn`. They are _executable_ scripts (or bina
 | [ipinfo](ipinfo) | Fetch external IP address and whois information | sh | curl, whois |
 | [kdeconnect](kdeconnect) | Send selected files to an Android device [✓] | sh | kdeconnect-cli |
 | [launch](launch) | GUI application launcher | sh | fzf |
+| [mark](mark) | Mark and unmark files | sh | - |
 | [mimelist](mimelist) | List files by mime in subtree | sh | file/mimetype |
 | [moclyrics](moclyrics) | Show lyrics of the track playing in moc | sh | [ddgr](https://github.com/jarun/ddgr), [moc](http://moc.daper.net/) |
 | [mocq](mocq) | Queue/play selection/dir/file in moc [✓] | sh | [moc](http://moc.daper.net/) |

--- a/plugins/mark
+++ b/plugins/mark
@@ -1,0 +1,34 @@
+#!/usr/bin/env sh
+
+# Description: Mark and unmark files. Name of the files which are marked,
+#              starts with '* '.
+#
+# Shell: POSIX compliant
+# Author: Pooyan Khanjankhani
+
+. "$(dirname "$0")"/.nnn-plugin-helper
+
+selection=${NNN_SEL:-${XDG_CONFIG_HOME:-$HOME/.config}/nnn/.selection}
+if nnn_use_selection; then
+	files="$(tr '\0' '\n' <"$selection")"
+else
+	files="$(echo "$PWD/$1")"
+fi
+
+is_marked() { echo "$1" | grep '*$' >/dev/null 2>&1; }
+
+echo "$files" | while read -r file; do
+	name="$(basename "$file")"
+	dir="$(dirname "$file")"
+	if is_marked "$name"; then
+		new_name="${name%\*}"
+	else
+		new_name="$name"'*'
+	fi
+
+	mv "$file" "$dir"/"$new_name"
+done
+
+if [ -s "$selection" ] && [ -p "$NNN_PIPE" ]; then
+	printf "-" >"$NNN_PIPE"
+fi


### PR DESCRIPTION
It can be useful to mark certain files, such as when watching a TV show or a course, to keep track of where you left off. I couldn't find any other plugin that does this.

However, it's a bit annoying that each time this script changes a file name, the cursor jumps back to the first file. If there's a way to fix that, I'd be happy to know about it.