### PR TITLE
dirs in context color fix

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -2284,8 +2284,10 @@ static bool initcurses(void *oldmask)
 						msg(env_cfg[NNN_COLORS]);
 						return FALSE;
 					}
-				} else
+				} else {
 					*pcode = (*colors < '0' || *colors > '7') ? 4 : *colors - '0';
+					fcolors[i + 1] = *pcode;
+				}
 				++colors;
 			} else
 				*pcode = 4;


### PR DESCRIPTION
When you launch `nnn -D` , directories use some default color instead of context color

I made some investigation and found out that this check `if (color_pair && fcolors[color_pair])` is always false for context colors, as it's values in `fcolors` are always `0`.
<img width="527" alt="dbg" src="https://github.com/jarun/nnn/assets/45429288/64f69061-8f9d-4a34-ac1b-23b0f781a82e">

I added it's initialization in `initcurses` to fix this. Now it looks like this
<img width="384" alt="col1" src="https://github.com/jarun/nnn/assets/45429288/733ac838-0a2f-4664-b19f-f7e32bb877f4">
<img width="390" alt="col2" src="https://github.com/jarun/nnn/assets/45429288/d18e442e-9113-4c14-92cf-0d1dfcd2a70b">
