### PR TITLE
Disable large file support on old glibc

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -35,7 +35,7 @@
 #endif
 #include <features.h>		/* __GLIBC__ etc */
 /* large file support on 32-bit glibc >= 2.23 where fts.h supports it */
-#if !defined(__GLIBC__) || __GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 23)
+#if __GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 23)
 #define _FILE_OFFSET_BITS 64
 #endif
 #if defined(__linux__)

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -28,12 +28,15 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#define _FILE_OFFSET_BITS 64 /* Support large files on 32-bit glibc */
-
 #if defined(__linux__) || defined(MINGW) || defined(__MINGW32__) \
 	|| defined(__MINGW64__) || defined(__CYGWIN__)
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
+#include <features.h>		/* __GLIBC__ etc */
+/* large file support on 32-bit glibc >= 2.23 where fts.h supports it */
+#if !defined(__GLIBC__) || __GLIBC__ > 2 || __GLIBC_MINOR__ >= 23
+#define _FILE_OFFSET_BITS 64
 #endif
 #if defined(__linux__)
 #include <sys/inotify.h>

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -35,7 +35,7 @@
 #endif
 #include <features.h>		/* __GLIBC__ etc */
 /* large file support on 32-bit glibc >= 2.23 where fts.h supports it */
-#if !defined(__GLIBC__) || __GLIBC__ > 2 || __GLIBC_MINOR__ >= 23
+#if !defined(__GLIBC__) || __GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 23)
 #define _FILE_OFFSET_BITS 64
 #endif
 #if defined(__linux__)


### PR DESCRIPTION
On glibc <2.23 fts.h doesn't support the feature:

https://sourceware.org/bugzilla/show_bug.cgi?id=11460

```
In file included from src/nnn.c:78:0:
/usr/include/fts.h:41:3: error: #error "<fts.h> cannot be used with -D_FILE_OFFSET_BITS==64"
 # error "<fts.h> cannot be used with -D_FILE_OFFSET_BITS==64"
```