### PR TITLE
plugins/upload: remove inactive services

### DIFF
--- a/plugins/upload
+++ b/plugins/upload
@@ -1,12 +1,11 @@
 #!/usr/bin/env sh
 
-# Description: Selections are uploaded using Firefox Send
+# Description: Selections are archived into a tar file (uncompressed) and uploaded to file.io
 #              For single files:
-#              Upload to Firefox Send if ffsend is found, else
-#              Paste contents of a text a file http://ix.io
+#              Paste contents of a text file to http://ix.io
 #              Upload a binary file to file.io
 #
-# Dependencies: ffsend (https://github.com/timvisee/ffsend), curl, jq, tr
+# Dependencies: curl, jq, tar, file with `--mime-type` support
 #
 # Note: Binary file set to expire after a week
 #
@@ -15,30 +14,24 @@
 
 selection=${NNN_SEL:-${XDG_CONFIG_HOME:-$HOME/.config}/nnn/.selection}
 if [ -s "$selection" ]; then
-    if type ffsend >/dev/null 2>&1; then
-      # File name will be randomized foo.tar
-      xargs -0 < "$selection" ffsend u
-    else
-      printf "ffsend is required to upload selection."
-    fi
+    xargs -0 tar -c < "$selection" | \
+        curl -s -F "file=@/dev/stdin;filename=selection.tar" 'https://file.io/?expires=1w' | \
+        jq '.link' | tr -d '"'
 
     # Clear selection
     printf "-" > "$NNN_PIPE"
 else
     if [ -n "$1" ] && [ -s "$1" ]; then
-	if type ffsend >/dev/null 2>&1; then
-	    ffsend -fiq u "$1"
-	elif [ "$(mimetype --output-format %m "$1" | awk -F '/' '{print $1}')" = "text" ]; then
-	    curl -F "f:1=@$1" ix.io
-	else
-	    # Upload the file, show the download link and wait till user presses any key
-	    curl -s -F "file=@$1" https://file.io/?expires=1w | jq '.link' | tr -d '"'
-
-	    # To write download link to "$1".loc and exit
-	    # curl -s -F "file=@$1" https://file.io/?expires=1w -o `basename "$1"`.loc
-	fi
+        if file --mime-type "$1" | grep -q -F "text/"; then
+            curl -F "file=@$1" https://0x0.st
+        else
+            # Upload the file, show the download link and wait till user presses any key
+            curl -s -F "file=@$1" https://file.io/?expires=1w | jq '.link' | tr -d '"'
+            # To write download link to "$1".loc and exit
+            # curl -s -F "file=@$1" https://file.io/?expires=1w -o `basename "$1"`.loc
+        fi
     else
-	printf "empty file!"
+        printf "empty file!"
     fi
 fi
 


### PR DESCRIPTION
this removes ix.io and ffsend since they are no longer active.

binary files are uploaded to file.io as before. selections are now tar-balled and uploaded to file.io.

text files are uploaded to 0x0.st

Closes: https://github.com/jarun/nnn/pull/1900