### PR TITLE
Fix implicit function declaration strcasecmp

### DIFF
--- a/src/icons-hash.c
+++ b/src/icons-hash.c
@@ -23,6 +23,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <strings.h>
 #include <stdlib.h>
 #include <limits.h>
 #include "icons.h"


### PR DESCRIPTION
`icons-hash.c` uses `strcasecmp` from `strings.h`, but does not include it. At least when building against musl with gcc 15, this is a fatal error.

See https://bugs.gentoo.org/939164