### PR TITLE
Do not default to `xterm`

### DIFF
--- a/plugins/preview-tabbed
+++ b/plugins/preview-tabbed
@@ -57,14 +57,14 @@ if [ -n "$WAYLAND_DISPLAY" ] ; then
     exit 1
 fi
 
-if type xterm >/dev/null 2>&1 ; then
-    TERMINAL="xterm -into"
-elif type urxvt >/dev/null 2>&1 ; then
-    TERMINAL="urxvt -embed"
+if type alacritty >/dev/null 2>&1 ; then
+    TERMINAL="alacritty --embed"
 elif type st >/dev/null 2>&1 ; then
     TERMINAL="st -w"
-elif type alacritty >/dev/null 2>&1 ; then
-    TERMINAL="alacritty --embed"
+elif type urxvt >/dev/null 2>&1 ; then
+    TERMINAL="urxvt -embed"
+elif type xterm >/dev/null 2>&1 ; then
+    TERMINAL="xterm -into"
 else
     echo "No xembed term found" >&2
 fi


### PR DESCRIPTION
It makes more sense to default to the terminals people are less likely to have. If a user has `xterm` installed, then that is, most probably, because it ships with X11. Whereas if a user has `st` or `alacritty` instlled, then that is because he/she chose to install it.