### PR TITLE
Indicate type-to-nav mode with symbol F

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -3238,6 +3238,9 @@ static int getorderstr(char *sort)
 {
 	int i = 0;
 
+	if (cfg.filtermode)
+		sort[i++] = 'F';
+
 	if (cfg.showhidden)
 		sort[i++] = 'H';
 


### PR DESCRIPTION
Notify the user the current context menu is in type-to-nav mode with symbol N after pressing `ESC` in type-to-nav mode.
After pressing `^N`, the symbol N disappear, indicate it is no longer in type-to-nav mode.

Feel free to reject it if it does not match nnn's design.