### PR TITLE
Toggle type-to-nav (^N) like global switch

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -4330,6 +4330,7 @@ static void savecurctx(char *path, char *curname, int nextctx)
 {
 	settings tmpcfg = cfg;
 	context *ctxr = &g_ctx[nextctx];
+	uint_t r = cfg.filtermode;
 
 	/* Save current context */
 	if (curname)
@@ -4358,6 +4359,7 @@ static void savecurctx(char *path, char *curname, int nextctx)
 
 	tmpcfg.curctx = nextctx;
 	setcfg(tmpcfg);
+	cfg.filtermode = r;
 }
 
 #ifndef NOSSN


### PR DESCRIPTION
This commit bring the current type-to-nav mode state to next context while changing to the next context, making toggling the type-to-nav (^N) like a global switch, instead of the original behavior which store each type-to-nav mode state per context.

I think it is much easier to control the workflow because I no longer need to remember which context is in type-to-nav mode or not.

Feel free to reject it if it does not match nnn's design.