### PR TITLE
fix crash under _FORTIFY_SOURCE

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -2834,15 +2834,16 @@ static char *get_archive_cmd(const char *archive)
 
 static void archive_selection(const char *cmd, const char *archive)
 {
-	char *buf = malloc((xstrlen(patterns[P_ARCHIVE_CMD]) + xstrlen(cmd) + xstrlen(archive)
-	                   + xstrlen(selpath)) * sizeof(char));
+	size_t len = xstrlen(patterns[P_ARCHIVE_CMD]) + xstrlen(cmd) + xstrlen(archive)
+	            + xstrlen(selpath) + 1;
+	char *buf = malloc(len);
 	if (!buf) {
 		DPRINTF_S(strerror(errno));
 		printwarn(NULL);
 		return;
 	}
 
-	snprintf(buf, CMD_LEN_MAX, patterns[P_ARCHIVE_CMD], cmd, archive, selpath);
+	snprintf(buf, len, patterns[P_ARCHIVE_CMD], cmd, archive, selpath);
 	spawn(utils[UTIL_SH_EXEC], buf, NULL, NULL, F_CLI | F_CONFIRM);
 	free(buf);
 }


### PR DESCRIPTION
when built with _FORTIFY_SOURCE it will check whether the buffer has as much space as the argument passed to snprintf: https://github.com/bminor/glibc/blob/7b544224f82d20019f9b28522ebf8114a372d1a2/debug/snprintf_chk.c#L28-L29

this results in some false positives when the snprintf provided len argument is bigger than the buffer size (but the result would have fit into the buffer anyways).

fix this by passing the proper size to snprintf as argument. (the +1 len isn't necessary, but add it just in case.)

Fixes: https://github.com/jarun/nnn/issues/1931