### PR TITLE
Use consistent language for disk mode in manual

### DIFF
--- a/nnn.1
+++ b/nnn.1
@@ -324,7 +324,7 @@ to list the selection file.
 .Nm
 can show the total size of non-filtered selected files listed in a
 directory. For directories, only the size of the directory is added by
-default. To add the size of the contents of a directory, switch to du mode.
+default. To add the size of the contents of a directory, sort by disk usage (aka du mode).
 .Sh FIND AND LIST
 There are two ways to search and list:
 .Pp


### PR DESCRIPTION
Was trying to see folder size and had difficulty moving from the mention of "du mode" to sorting by disk use. My suggestion makes a soft reference to sorting by disk use. Hopefully clearer for peeps.