### PR TITLE
bugfix/directory-preview-doesnt-work-on-mac-os

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -373,7 +373,7 @@ preview_file() {
         elif exists eza; then # eza is a community fork of exa (exa is unmaintained)
             fifo_pager eza -T --group-directories-first --colour=always -L 3
         else
-            fifo_pager ls -F --group-directories-first --color=always
+            fifo_pager ls -1 --color=always | sort
         fi
         cd ..
     elif [ "${encoding#*)}" = "binary" ]; then


### PR DESCRIPTION
On macOS, without additional utilities, the directory preview feature was not working due to the --group-directories-first flag, which is not supported by the BSD version of ls.

To resolve this, an alternative method was implemented and tested.