### PR TITLE
filter function restore on session load

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -4385,6 +4385,7 @@ static void setcfg(settings newcfg)
 	/* Synchronize the global function pointers to match the new cfg. */
 	entrycmpfn = cfg.reverse ? &reventrycmp : &entrycmp;
 	namecmpfn = cfg.version ? &xstrverscasecmp : &xstricmp;
+	filterfn = cfg.regex ? &visible_re : &visible_str;
 }
 
 static void savecurctx(char *path, char *curname, int nextctx)
@@ -4542,10 +4543,9 @@ static bool load_session(const char *sname, char **path, char **lastdir, char **
 	*path = g_ctx[cfg.curctx].c_path;
 	*lastdir = g_ctx[cfg.curctx].c_last;
 	*lastname = g_ctx[cfg.curctx].c_name;
+	setcfg(cfg);
 	set_sort_flags('\0'); /* Set correct sort options */
 	xstrsncpy(curssn, sname ? sname : "@", NAME_MAX);
-	/* restore correct filter function */
-	filterfn = cfg.regex ? &visible_re : &visible_str;
 	status = TRUE;
 
 END:

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -4544,6 +4544,8 @@ static bool load_session(const char *sname, char **path, char **lastdir, char **
 	*lastname = g_ctx[cfg.curctx].c_name;
 	set_sort_flags('\0'); /* Set correct sort options */
 	xstrsncpy(curssn, sname ? sname : "@", NAME_MAX);
+	/* restore correct filter function */
+	filterfn = cfg.regex ? &visible_re : &visible_str;
 	status = TRUE;
 
 END:


### PR DESCRIPTION
loading a session or switching to a different context with a different filter mode setting (regex vs string) will not update the filter function and can lead to crashes
- **on session load, restore correct filter function**
- **also switch filterfn on ctx changes**
