### PR TITLE
Check NULL from abspath()

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -8759,6 +8759,11 @@ int main(int argc, char *argv[])
 
 				close(fd);
 				selpath = abspath(optarg, NULL, NULL);
+				if (!selpath) {
+					xerror();
+					return EXIT_FAILURE;
+				}
+
 				unlink(selpath);
 			}
 			break;


### PR DESCRIPTION
abspath() returns NULL in some cases and its return value is always checked for NULL.