### PR TITLE
Follow symlink in fzplug plugin.

### DIFF
--- a/plugins/fzplug
+++ b/plugins/fzplug
@@ -34,7 +34,7 @@ if type bat >/dev/null; then
     BAT="bat --terminal-width='$(tput cols)' --decorations=always --color=always --style='${BAT_STYLE:-header,numbers}'"
 fi
 
-plugin=$(find "$nnnpluginsdir" "$CUSTOMDIR1" "$CUSTOMDIR2" \
+plugin=$(find -L "$nnnpluginsdir" "$CUSTOMDIR1" "$CUSTOMDIR2" \
 -maxdepth 3 -perm -111 -type f 2>/dev/null | fzf --ansi --preview \
     "${BAT:-cat} {}" --preview-window="right:66%:wrap" --delimiter / \
     --with-nth -1 --bind="?:toggle-preview")


### PR DESCRIPTION
Hi,
my `~/.config/nnn/plugins` folder is symlinked from this repo that I use it as a submodule of my dotfiles.
This make it so that the `find` command in the fzplug plugin follows symlinks.