### PR TITLE
fix(quitcd.nu): specify signature in/out of command

### DIFF
--- a/misc/quitcd/quitcd.nu
+++ b/misc/quitcd/quitcd.nu
@@ -7,7 +7,7 @@
 export def --env n [
 	...args : string # Extra flags to launch nnn with.
 	--selective = false # Change directory only when exiting via ^G.
-] -> nothing {
+]: nothing -> nothing {
 
 	# The behaviour is set to cd on quit (nnn checks if $env.NNN_TMPFILE is set).
 	# Hard-coded to its respective behaviour in `nnn` source-code.


### PR DESCRIPTION
Nushell 0.10.1 introduces [stricter command signature parsing](https://www.nushell.sh/blog/2024-12-24-nushell_0_101_0.html#stricter-command-signature-parsing-toc), causing error upon importing this module.