### PR TITLE
Allow lowdown to use complete terminal width

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -302,7 +302,7 @@ handle_ext() {
         md) if exists glow; then
                 fifo_pager glow -s dark "$1"
             elif exists lowdown; then
-                fifo_pager lowdown -Tterm "$1"
+                fifo_pager lowdown -Tterm --term-width="$cols" --term-column="$cols" "$1"
             else
                 fifo_pager pager "$1"
             fi ;;


### PR DESCRIPTION
By default, lowdown uses:
* `--term-column`: 72 if running in a pipe
* `--term-width`: max(80, `--term-columns)`

See `man lowdown`.

This PR aims to use the full potential.