### PR TITLE
Allow lowdown to use complete terminal width

### DIFF
--- a/plugins/nuke
+++ b/plugins/nuke
@@ -226,7 +226,8 @@ handle_extension() {
                 glow -sdark "${FPATH}" | eval "$PAGER"
                 exit 0
             elif type lowdown >/dev/null 2>&1; then
-                lowdown -Tterm "${FPATH}" | eval "$PAGER"
+                cols=$(tput cols)
+                lowdown -Tterm --term-width="$cols" --term-column="$cols" "${FPATH}" | eval "$PAGER"
                 exit 0
             fi
             ;;


### PR DESCRIPTION
In accordance with 48bc670cac104266395d389f1ddecbd5945be37d, we can maximize lowdown in plugin nuke aswell.