### PR TITLE
Use jq to preview json if installed

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -323,6 +323,12 @@ handle_ext() {
             elif exists bsdtar; then
                 fifo_pager bsdtar -tvf "$1"
             fi ;;
+        json)
+            if exists jq; then
+                fifo_pager jq --color-output '.' "$1"
+            else
+                fifo_pager pager "$1"
+            fi ;;
         *) if [ "$3" = "bin" ]; then
                fifo_pager print_bin_info "$1"
            else


### PR DESCRIPTION
Currently, we're using bat to preview json (if bat is available). Bat is providing a language for json, but the support is rather poor.
`jq` instead does the job better if it exists.

In comparison, we do something similar in [nuke](https://github.com/jarun/nnn/blob/master/plugins/nuke#L251).