### PR TITLE
fix: enable flags for NNN_PREVIEWIMGPROG

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -453,7 +453,7 @@ image_preview() {
     elif exists ueberzug && [[ "$NNN_PREVIEWIMGPROG" == +(|ueberzug) ]]; then
         ueberzug_layer "$1" "$2" "$3" && return
     elif exists "${NNN_PREVIEWIMGPROG%% *}"; then # can include command flags; only check first word
-        "$NNN_PREVIEWIMGPROG" "$3" &
+        $NNN_PREVIEWIMGPROG "$3" &
     else
         fifo_pager print_bin_info "$3" && return
     fi


### PR DESCRIPTION
Following the [comment](https://github.com/jarun/nnn/blob/master/plugins/preview-tui#L455), we wanted to be able to include command flags.

One use case could be using `timg` inside of a sixel-enabled tmux which needs the flag `-ps`:
`export NNN_PREVIEWIMGPROG="timg -ps"`

With the current solution, we would get:
```
preview-tui: row 456: timg -ps: Command not found.
```

This PR aims to fix that.