### PR TITLE
fix/paste from wsl

### DIFF
--- a/plugins/x2sel
+++ b/plugins/x2sel
@@ -8,7 +8,7 @@
 #   - pbpaste (macOS)
 #   - termux-clipboard-get (Termux)
 #   - powershell (WSL)
-#   - cygwim's /dev/clipboard (Cygwin)
+#   - cygwin's /dev/clipboard (Cygwin)
 #   - wl-paste (Wayland)
 #   - clipboard (Haiku)
 #
@@ -26,6 +26,9 @@ getclip () {
 	if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
 		# Wayland
 		wl-paste
+	elif type powershell.exe >/dev/null 2>&1; then
+		# WSL
+		powershell.exe -noprofile -command Get-Clipboard | tr -d '\r'
 	elif type xsel >/dev/null 2>&1; then
 		# Linux
 		xsel -bo
@@ -38,9 +41,6 @@ getclip () {
 	elif type termux-clipboard-get >/dev/null 2>&1; then
 		# Termux
 		termux-clipboard-get
-	elif type powershell.exe >/dev/null 2>&1; then
-		# WSL
-		powershell.exe Get-Clipboard
 	elif [ -r /dev/clipboard ] ; then
 		# Cygwin
 		cat /dev/clipboard

--- a/plugins/x2sel
+++ b/plugins/x2sel
@@ -52,9 +52,15 @@ getclip () {
 
 CLIPBOARD=$(getclip)
 
+if [ -z "$CLIPBOARD" ]; then
+	echo "No content in clipboard"
+	exit 1
+fi
+
 # Check if clipboard actually contains a file list
 for file in $CLIPBOARD ; do
 	if [ ! -e "$file" ] ; then
+		echo "'$file' is not a file"
 		exit 1;
 	fi
 done


### PR DESCRIPTION
1. In Windows, lines are separated by CRLF. We need to remove the CR (carriage return) in order for IFS to work in all cases (i.e., unixoid and bsd like OS on one hand and Windows on the other hand).
2. When calling the script, we never get to know why something breaks. Therefore, we are adding error messages. This is of value if we call the script via fzplug which prints the error (or, wenn quitting from nnn).
3. I am honestly unsure what value this script provides. I see that it successfully writes to the selection file (reproducible), but nnn never seems to read from that file, it only writes into it. @jarun could you provide some insight about that?