### PR TITLE
feat: improve autojump

### DIFF
--- a/plugins/autojump
+++ b/plugins/autojump
@@ -15,7 +15,7 @@
 # to make z.lua work, you need to set $NNN_ZLUA to the path of script z.lua
 #
 # Shell: POSIX compliant
-# Authors: Marty Buchaus, Dave Snider, Tim Adler, Nick Waywood
+# Authors: Marty Buchaus, Dave Snider, Tim Adler, Nick Waywood, Markus Meier
 
 if [ ! -p "$NNN_PIPE" ]; then
     printf 'ERROR: NNN_PIPE is not set!'
@@ -24,13 +24,13 @@ if [ ! -p "$NNN_PIPE" ]; then
 fi
 
 if type jump >/dev/null 2>&1; then
-    printf "jump to : "
+    printf "Jump to: "
     IFS= read -r line
     # shellcheck disable=SC2086
     odir="$(jump cd ${line})"
     printf "%s" "0c$odir" > "$NNN_PIPE"
 elif type autojump >/dev/null 2>&1; then
-    printf "jump to : "
+    printf "Jump to: "
     read -r dir
     odir="$(autojump "$dir")"
     printf "%s" "0c$odir" > "$NNN_PIPE"
@@ -39,13 +39,13 @@ elif type zoxide >/dev/null 2>&1; then
     	odir="$(zoxide query -i --)"
     	printf "%s" "0c$odir" > "$NNN_PIPE"
     else
-	printf "jump to : "
+	printf "Jump to: "
     	read -r dir
     	odir="$(zoxide query -- "$dir")"
     	printf "%s" "0c$odir" > "$NNN_PIPE"
     fi
 elif type lua >/dev/null 2>&1 && [ -n "$NNN_ZLUA" ]; then
-    printf "jump to : "
+    printf "Jump to: "
     read -r line
     if type fzf >/dev/null 2>&1; then
         odir="$(lua "$NNN_ZLUA" -l "$line" | fzf --nth 2.. --reverse --inline-info --tac +s -e --height 35%)"

--- a/plugins/autojump
+++ b/plugins/autojump
@@ -9,11 +9,6 @@
 #   - OR z - https://github.com/rupa/z (z requires fzf)
 #   - OR z (fish) - https://github.com/jethrokuan/z (z requires fzf)
 #   - OR z.lua - https://github.com/skywind3000/z.lua (z.lua can enhanced with fzf)
-#
-# Additionally:
-#   - sed
-#   - awk
-#
 # Note: The dependencies STORE NAVIGATION PATTERNS
 #
 # to make z.lua work, you need to set $NNN_ZLUA to the path of script z.lua

--- a/plugins/autojump
+++ b/plugins/autojump
@@ -10,6 +10,10 @@
 #   - OR z (fish) - https://github.com/jethrokuan/z (z requires fzf)
 #   - OR z.lua - https://github.com/skywind3000/z.lua (z.lua can enhanced with fzf)
 #
+# Additionally:
+#   - sed
+#   - awk
+#
 # Note: The dependencies STORE NAVIGATION PATTERNS
 #
 # to make z.lua work, you need to set $NNN_ZLUA to the path of script z.lua
@@ -45,12 +49,12 @@ elif type zoxide >/dev/null 2>&1; then
         printf "%s" "0c$odir" > "$NNN_PIPE"
     fi
 elif type lua >/dev/null 2>&1 && [ -n "$NNN_ZLUA" ]; then
-    printf "Jump to: "
-    read -r line
     if type fzf >/dev/null 2>&1; then
-        odir="$(lua "$NNN_ZLUA" -l "$line" | fzf --nth 2.. --reverse --inline-info --tac +s -e --height 35%)"
-        printf "%s" "0c$(echo "$odir" | awk '{print $2}')" > "$NNN_PIPE"
+        odir="$(lua "$NNN_ZLUA" -l | awk '{print $2}' | fzf --nth -1 --delimiter=/ --reverse --inline-info --tac +s -e --height 35%)"
+        printf "0c%s" "$odir" > "$NNN_PIPE"
     else
+        printf "Jump to: "
+        read -r line
         odir="$(lua "$NNN_ZLUA" -e "$line")"
         printf "%s" "0c$odir" > "$NNN_PIPE"
     fi

--- a/plugins/autojump
+++ b/plugins/autojump
@@ -50,7 +50,9 @@ elif type zoxide >/dev/null 2>&1; then
     fi
 elif type lua >/dev/null 2>&1 && [ -n "$NNN_ZLUA" ]; then
     if type fzf >/dev/null 2>&1; then
-        odir="$(lua "$NNN_ZLUA" -l | awk '{print $2}' | fzf --nth -1 --delimiter=/ --reverse --inline-info --tac +s -e --height 35%)"
+        odir="$(lua "$NNN_ZLUA" -l \
+                    | awk '{print $2}' \
+                    | fzf --nth -1 --delimiter=/ --reverse --inline-info --tac +s -e --height 35%)"
         printf "0c%s" "$odir" > "$NNN_PIPE"
     else
         printf "Jump to: "

--- a/plugins/autojump
+++ b/plugins/autojump
@@ -36,13 +36,13 @@ elif type autojump >/dev/null 2>&1; then
     printf "%s" "0c$odir" > "$NNN_PIPE"
 elif type zoxide >/dev/null 2>&1; then
     if type fzf >/dev/null 2>&1; then
-    	odir="$(zoxide query -i --)"
-    	printf "%s" "0c$odir" > "$NNN_PIPE"
+        odir="$(zoxide query -i --)"
+        printf "%s" "0c$odir" > "$NNN_PIPE"
     else
-	printf "Jump to: "
-    	read -r dir
-    	odir="$(zoxide query -- "$dir")"
-    	printf "%s" "0c$odir" > "$NNN_PIPE"
+        printf "Jump to: "
+        read -r dir
+        odir="$(zoxide query -- "$dir")"
+        printf "%s" "0c$odir" > "$NNN_PIPE"
     fi
 elif type lua >/dev/null 2>&1 && [ -n "$NNN_ZLUA" ]; then
     printf "Jump to: "

--- a/plugins/autojump
+++ b/plugins/autojump
@@ -9,6 +9,7 @@
 #   - OR z - https://github.com/rupa/z (z requires fzf)
 #   - OR z (fish) - https://github.com/jethrokuan/z (z requires fzf)
 #   - OR z.lua - https://github.com/skywind3000/z.lua (z.lua can enhanced with fzf)
+#
 # Note: The dependencies STORE NAVIGATION PATTERNS
 #
 # to make z.lua work, you need to set $NNN_ZLUA to the path of script z.lua
@@ -23,13 +24,13 @@ if [ ! -p "$NNN_PIPE" ]; then
 fi
 
 if type jump >/dev/null 2>&1; then
-    printf "Jump to: "
+    printf "jump to: "
     IFS= read -r line
     # shellcheck disable=SC2086
     odir="$(jump cd ${line})"
     printf "%s" "0c$odir" > "$NNN_PIPE"
 elif type autojump >/dev/null 2>&1; then
-    printf "Jump to: "
+    printf "jump to: "
     read -r dir
     odir="$(autojump "$dir")"
     printf "%s" "0c$odir" > "$NNN_PIPE"
@@ -38,7 +39,7 @@ elif type zoxide >/dev/null 2>&1; then
         odir="$(zoxide query -i --)"
         printf "%s" "0c$odir" > "$NNN_PIPE"
     else
-        printf "Jump to: "
+        printf "jump to: "
         read -r dir
         odir="$(zoxide query -- "$dir")"
         printf "%s" "0c$odir" > "$NNN_PIPE"
@@ -50,7 +51,7 @@ elif type lua >/dev/null 2>&1 && [ -n "$NNN_ZLUA" ]; then
                     | fzf --nth -1 --delimiter=/ --reverse --inline-info --tac +s -e --height 35%)"
         printf "0c%s" "$odir" > "$NNN_PIPE"
     else
-        printf "Jump to: "
+        printf "jump to: "
         read -r line
         odir="$(lua "$NNN_ZLUA" -e "$line")"
         printf "%s" "0c$odir" > "$NNN_PIPE"


### PR DESCRIPTION
In case of z.lua with fzf, the experience can be improved: currently, we need to potentially input twice. First for the initial query, second for filtering. We can improve this in two ways:

1. Delegate the selection process completely to fzf: pipe all dirs into fzf and let it select the entry after the last slash
2. Remove the weightings - they are not needed while selecting.