### PR TITLE
Document sort actions

### DIFF
--- a/misc/auto-completion/fish/nnn.fish
+++ b/misc/auto-completion/fish/nnn.fish
@@ -38,7 +38,7 @@ complete -c nnn -s R    -d 'disable rollover at edges'
 complete -c nnn -s s -r -d 'load session by name' -x -a '@\t"last session" (ls $sessions_dir)'
 complete -c nnn -s S    -d 'persistent session'
 complete -c nnn -s t -r -d 'timeout in seconds to lock'
-complete -c nnn -s T -r -d 'a d e r s t v'
+complete -c nnn -s T -r -d 'sort order' -x -a "a\t'apparent disk usage' d\t'disk usage' e\t'extension' r\t'reverse' s\t'size' t\t'time' v\t'version'"
 complete -c nnn -s u    -d 'use selection (no prompt)'
 complete -c nnn -s U    -d 'show user and group'
 complete -c nnn -s V    -d 'show program version and exit'

--- a/misc/auto-completion/zsh/_nnn
+++ b/misc/auto-completion/zsh/_nnn
@@ -37,7 +37,7 @@ args=(
     '(-s)-s[load session]:session name'
     '(-S)-S[persistent session]'
     '(-t)-t[timeout to lock]:seconds'
-    '(-T)-T[sort order]:key:(( a\:"apparent disk usasge" d\:"disk usage" e\:"extension" r\:"reverse" s\:"size" t\:"time" v\:"version" ))'
+    '(-T)-T[sort order]:key:(( a\:"apparent disk usage" d\:"disk usage" e\:"extension" r\:"reverse" s\:"size" t\:"time" v\:"version" ))'
     '(-u)-u[use selection (no prompt)]'
     '(-U)-U[show user and group]'
     '(-V)-V[show program version and exit]'

--- a/nnn.1
+++ b/nnn.1
@@ -1,4 +1,4 @@
-.Dd Aug 26, 2024
+.Dd February 22, 2025
 .Dt NNN 1
 .Os
 .Sh NAME
@@ -286,6 +286,55 @@ in \fBtype-to-nav\fR mode:
    ~   | Go HOME
 ------ + ------------------------
 .Ed
+.Sh SORT
+.Nm
+will always show the directories first, followed by the files.
+String order is always case-insensitive.
+.Pp
+The sort key can be set; either on start with the -T flag, or interactively
+using 't' or '^T'.
+The following options exist:
+.Bl -tag -width 2n
+.It Ic a
+apparent disk usage, how large the file appears to be, can be bigger than actual
+disk usage in sparse files.
+.It Ic d
+disk usage, amount of data taken on disk, a multiple of the block size.
+.It Ic e
+extension of the file.
+.It Ic r
+reverse the current order (not available for the -T flag).
+.It Ic s
+size of file, amount of data stored in the file.
+.It Ic t
+time, this depends on the currently selected time type which can be changed
+using the 'T' key.
+Options are:
+.Bl -tag -compact -width 1n
+.It Ic a
+access, last time the file was accessed.
+.It Ic c
+change, last time the metadata of the file was changed (e.g. permissions).
+.It Ic m
+modified, last time the content of the file was changed (default).
+.El
+.It Ic v
+version, sorts by filename while treating digit characters numerically.
+For example: j1.png, j02.png, j3.png.
+.It Ic c
+clear, revert to filename order (not available for the -T flag).
+.It Ic ^T
+cycle between filename/size/time order (not available for the -T flag).
+.El
+.Pp
+The uppercase version of the option can be used to specify the opposite of the
+default order.
+By default, time and size sort keys are ordered in descending order, and
+alphabetical fields are ordered in ascending order.
+For example, when using the 'e' option, the entries will be ordered by
+extension, in ascending order.
+Using 'E' would result in descending order of the extensions.
+This means that 'e' followed by 'r' is the same as 'E'.
 .Sh SELECTION
 .Nm
 allows file selection across directories and contexts!


### PR DESCRIPTION
The actions in the _Sort toggles_ (`t`) prompt were not very clear to me and lead to a lot of looking up with some confusion:
`'a'u/'d'u/'e'xt/'r'ev/'s'z/'t'm/'v'er/'c'lr/'^T'?`

So I dove into the source to find out what all the options do and added a help option.
Now, when responding to the prompt with `?`, the info of the options is displayed. This follows the _Don't memorize!_ approach taken by nnn.

The same approach as the general help is employed. I have looked into reusing the same code for both help functions but did not find a clean way to do it.

Regarding the order of the usage info, I debated between same order as the prompt, alphabetical, and grouped by type (e.g. all file size/disk usage together) and decided on alphabetical. If you would like prompt order, or any other order, let me know.

The binary size did not increase, to my surprise, it stayed at 126 440 B (compiled on x64 Arch Linux, gcc 14.2.1 20250207).