### PR TITLE
Add opn plugin

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -52,6 +52,7 @@ Plugins extend the capabilities of `nnn`. They are _executable_ scripts (or bina
 | [nmount](nmount) | Toggle mount status of a device as normal user | sh | pmount (optional), udisks2 |
 | [nuke](nuke) | Sample file opener (CLI-only by default) | sh | _see in-file docs_ |
 | [oldbigfile](oldbigfile) | List large files by access time | sh | find, sort |
+| [opn](opn) | Open selected file with the associated application, application picker | bash | [opn](https://github.com/MatthiasKunnen/opn) |
 | [openall](openall) | Open selected files together or one by one [✓] | bash | - |
 | [organize](organize) | Auto-organize files in directories by file type [✓] | sh | file |
 | [pdfread](pdfread) | Read a PDF or text file aloud | sh | pdftotext, mpv,<br>pico2wave |

--- a/plugins/opn
+++ b/plugins/opn
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Use the CLI file opener program "opn" which allows selecting the application to open the
+# file with based on the XDG Desktop and MimeApps Specification.
+# See https://github.com/MatthiasKunnen/opn
+#
+# Integration with nnn:
+#   1. Export the required config (change the path if necessary):
+#         export NNN_OPENER=/usr/share/nnn/plugins/opn
+#   2. Run nnn with the program option to indicate a CLI opener
+#         nnn -c
+#      The -c program option overrides option -e
+#
+# Required configuration of opn:
+#   1. Install opn, see https://github.com/MatthiasKunnen/opn/blob/master/Install.md
+#   2. Set OPN_TERM_CMD to configure your preferred terminal.
+#      E.g. "foot" or "gnome-terminal --".
+#      See https://github.com/MatthiasKunnen/opn?tab=readme-ov-file#terminal-applications
+
+set -uo pipefail
+
+FPATH="$1"
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+	clear -x
+fi
+
+opn file "${FPATH}"
+status=$?
+
+if [ $status -eq 0 ]; then
+	exit 0
+fi
+
+# Show any error message to the user
+read -rsn1 -p"Press any key to return to nnn";echo


### PR DESCRIPTION
I would like to add a plugin that integrates with a tool I made called [`opn`](https://github.com/MatthiasKunnen/opn).

![example_open_pdf](https://github.com/user-attachments/assets/701fa624-089e-441e-94de-337ca4f18896)

It is a terminal application picker that works using the [XDG desktop spec](https://specifications.freedesktop.org/desktop-entry-spec/latest/). It can be seen as an alternative to the `nuke` plugin provided by nnn that is out-of-the-box customized to what the user has installed.

One question I had while making the plugin is the name, do users often add the plugin dir to their path? If they do, this will cause an infinite loop where the opn script will call itself. I can change the name to `opn_nnn` or similar should this be desired.

If you have any questions, or even feature ideas, I'll happily answer them