### PR TITLE
Explicitly declare support for opening a path

### DIFF
--- a/misc/desktop/nnn.desktop
+++ b/misc/desktop/nnn.desktop
@@ -2,7 +2,7 @@
 Type=Application
 Name=nnn
 Comment=Terminal file manager
-Exec=nnn
+Exec=nnn %f
 Terminal=true
 Icon=nnn
 MimeType=inode/directory


### PR DESCRIPTION
While the nnn `.desktop` file has `MimeType=inode/directory`, it is missing a field code to specify how the command line should be constructed with the directory's path. This can cause application launchers to disregard nnn as a file manager candidate.

See <https://specifications.freedesktop.org/desktop-entry-spec/latest/exec-variables.html>.