### PR TITLE
rework SEL_OPENWITH, add example plugin openwith

### DIFF
--- a/nnn.1
+++ b/nnn.1
@@ -454,6 +454,11 @@ used. A single combination of arguments is supported for SHELL and PAGER.
     NOTE: \fBnuke\fR is a file opener available in the plugin repository.
 .Ed
 .Pp
+\fBNNN_OPENWITH:\fR specify a custom script for opening files with 'o' key.
+.Bd -literal
+    export NNN_OPENWITH=$HOME/.config/nnn/plugins/openwith
+.Ed
+.Pp
 \fBNNN_BMS:\fR bookmark string as \fIkey_char:location\fR pairs
 separated by \fB;\fR:
 .Bd -literal

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -53,6 +53,7 @@ Plugins extend the capabilities of `nnn`. They are _executable_ scripts (or bina
 | [nuke](nuke) | Sample file opener (CLI-only by default) | sh | _see in-file docs_ |
 | [oldbigfile](oldbigfile) | List large files by access time | sh | find, sort |
 | [openall](openall) | Open selected files together or one by one [✓] | bash | - |
+| [openwith](openwith) | Open selected files and/or exec arbitrary commands over selection | bash | - |
 | [organize](organize) | Auto-organize files in directories by file type [✓] | sh | file |
 | [pdfread](pdfread) | Read a PDF or text file aloud | sh | pdftotext, mpv,<br>pico2wave |
 | [preview-tabbed](preview-tabbed) | Preview files with Tabbed/xembed | bash | _see in-file docs_ |

--- a/plugins/openwith
+++ b/plugins/openwith
@@ -1,0 +1,80 @@
+#!/usr/bin/env sh
+
+# Description: do operations over file selection
+#
+# After pressing enter \`$EDITOR\` will be opened, so you can edit command. wq to continue.
+# DONT FORGET in place of files you want add \`{}\` instead!!!"
+# Files will be parsed one by one instead of all at once
+#
+# Dependencies: fzf, xargs
+# Shell: sh
+# Author: Arun Prakash Jana, Darukutsu
+
+# setting this to 1 will result in using history as additional source of runners
+# it's recommended to enable editor as well
+history=0
+# setting this to 1 will result in opening editor to further edit command
+editor=0
+selection=${NNN_SEL:-${XDG_CONFIG_HOME:-$HOME/.config}/nnn/.selection}
+
+if [ $editor -eq 0 ]; then
+  header="Choose command to run over your file/selection"
+else
+  header="After pressing enter \`$EDITOR\` will be opened, so you can edit command. Add \`{}\` in place of files!!! If \`{}\` are omitted file/selection will be appended at the end of command-string"
+fi
+
+if type fzf >/dev/null 2>&1; then
+  fuzzy=fzf
+# TODO: more examples with rofi etc
+#if type rofi >/dev/null 2>&1; then
+#  fuzzy=rofi
+else
+  exit 1
+fi
+
+shellname="$(basename "$SHELL")"
+
+tmpfile=$(mktemp)
+echo "$PATH" | xargs -d':' -I{} find {} -type f -perm -1 >>"$tmpfile"
+if [ $history -eq 1 ]; then
+  if [ "$shellname" = "bash" ]; then
+    hist_file=${HISTFILE:-$HOME/.bash_history}
+    cat "$hist_file" >>"$tmpfile"
+  elif [ "$shellname" = "fish" ]; then
+    hist_file="$HOME/.local/share/fish/fish_history"
+    grep "\- cmd: " "$hist_file" | cut -c 8- >>"$tmpfile"
+  fi
+fi
+entry="$("$fuzzy" --header="$header" --tac <"$tmpfile")"
+rm "$tmpfile"
+
+if [ -n "$entry" ]; then
+  tmpfile=$(mktemp)
+  echo "$entry" >>"$tmpfile"
+  if [ $editor -eq 1 ]; then
+    $EDITOR "$tmpfile"
+  fi
+
+  if ! grep '{}' "$tmpfile"; then
+    sed -i '$ s/^.*$/& {}/' "$tmpfile"
+  fi
+
+  if [ -s "$tmpfile" ]; then
+    command="$(cat "$tmpfile")"
+    if [ $history -eq 1 ]; then
+      echo "$command" >>"$hist_file"
+    fi
+
+    if ! [ -s "$selection" ]; then
+      printf "%s/%s" "$2" "$1" >"$selection"
+    fi
+
+    xargs -0 -I{} $command <"$selection"
+    # Clear selection
+    printf "-" >"$NNN_PIPE"
+  fi
+  rm "$tmpfile"
+
+  printf "Press any key to exit"
+  read -r _
+fi

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -7826,8 +7826,16 @@ nochange:
 			cd = FALSE;
 			goto begin;
 		}
+		case SEL_OPENWITH:
+		{
+			char *open_with = getenv("NNN_OPENWITH");
+			if (open_with != NULL) {
+				spawn(open_with, pdents[cur].name, path, NULL, F_CLI | F_TTY);
+				goto nochange;
+			}
+			__attribute__ ((fallthrough));
+		}
 		case SEL_ARCHIVE: // fallthrough
-		case SEL_OPENWITH: // fallthrough
 		case SEL_NEW: // fallthrough
 		case SEL_RENAME:
 		{


### PR DESCRIPTION
This solves 3 problems which user might have upon pressing 'o' key:
1) forgot name or typo of gui/cli program, can use fzf, rofi... instead
2) exec arbitrary commands over selection let's say `git add` or anything more complicated
3) no more need for custom patch https://github.com/jarun/nnn/issues/1350

Script `openwith` doesn't clear `.selection` because I was not sure if I should give it `$NNN_SEL`.

What do you think?