### PR TITLE
nuke plugin - Faster handle files files by extension

### DIFF
--- a/plugins/nuke
+++ b/plugins/nuke
@@ -545,8 +545,8 @@ handle_bin() {
     esac
 }
 
-MIMETYPE="$( file -bL --mime-type -- "${FPATH}" )"
 handle_extension
+MIMETYPE="$( file -bL --mime-type -- "${FPATH}" )"
 handle_multimedia "${MIMETYPE}"
 handle_mime "${MIMETYPE}"
 [ "$BIN" -ne 0 ] && [ -x "${FPATH}" ] && handle_bin


### PR DESCRIPTION
Hello there,

If we're going to handle the file by extension : don't check mimetype first. The mimetype is not necessary in that use case, and may be costly in a slow connection and/or over wifi (or watever slow media you have)

If we don't handle by extension, mime type will be checked anyway (after handling by extension)