### PR TITLE
add zellij as a supported multiplexer

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -5,12 +5,13 @@
 # Note: This plugin needs a "NNN_FIFO" to work. See man.
 #
 # Dependencies:
-#   - Supports 6 independent methods to preview with:
+#   - Supports 7 independent methods to preview with:
 #       - tmux (>=3.0), or
 #       - kitty with allow_remote_control and listen_on set in kitty.conf, or
 #       - wezterm (https://wezfurlong.org/wezterm), or
 #       - QuickLook on WSL (https://github.com/QL-Win/QuickLook), or
 #       - Windows Terminal (https://github.com/Microsoft/Terminal | https://aka.ms/terminal) with WSL, or
+#       - zellij (https://github.com/zellij-org/zellij) or
 #       - $NNN_TERMINAL set to a terminal (it's xterm by default).
 #   - less or $NNN_PAGER
 #   - tree or exa/eza or (GNU) ls
@@ -160,6 +161,8 @@ start_preview() {
         exists mpv && ENVVARS+=("NNN_PREVIEWVIDEO=sixel")
     elif [ -n "$WT_SESSION" ]; then
         NNN_TERMINAL=winterm
+    elif [ -n "$ZELLIJ" ]; then
+        NNN_TERMINAL=zellij
     else
         NNN_TERMINAL="${NNN_TERMINAL:-xterm}"
     fi
@@ -207,6 +210,17 @@ EOF
         winterm)
             if [ "$NNN_SPLIT" = "h" ]; then split="H"; else split="V"; fi
             wt -w 0 sp -$split -s"0.$NNN_SPLITSIZE" "$command" \; -w 0 mf previous 2>/dev/null ;;
+        zellij)
+            case "$NNN_SPLIT" in
+              h)
+                direction="down" ;;
+              *) 
+                direction=right ;;
+            esac
+            zellij run --name "nnn preview" --close-on-exit \
+              --direction "$direction" -- env "${ENVVARS[@]}" "$0" "$1" &
+            (sleep 0.2 && zellij action focus-previous-pane) &
+            ;;
         *)  if [ -n "$2" ]; then
                 env "${ENVVARS[@]}" QUICKLOOK=1 "$0" "$1" &
             else


### PR DESCRIPTION
Hi all,
this adds [zellij](https://github.com/zellij-org/zellij) as a supported multiplexer, creating a pane for the preview buffer which gets deconstructed when nnn is closed.
<img width="1900" height="1035" alt="image" src="https://github.com/user-attachments/assets/c24a8fc7-d138-4d29-9d72-bb25dcc9eaa6" />