### PR TITLE
feat: Improve UX for dragdrop plugin

### DIFF
--- a/plugins/dragdrop
+++ b/plugins/dragdrop
@@ -66,11 +66,18 @@ elif [ "$resp" = "r" ]; then
     "$dnd" --print-path --target 2>/dev/null | while read -r f
     do
         if printf "%s" "$f" | grep -q '^\(https\?\|ftps\?\|s\?ftp\)://' ; then
-            if curl -fsLJOS "$f"; then
+            output=$(curl -fsLJOS "$f" 2>&1)
+            if [ $? = 0 ]; then
                 filename="$(basename "${f%%\?*}")"
                 add_file "$PWD/$filename"
                 if [ $notify = 1 ]; then
                     notify-send "Download Complete" "Finished downloading $filename"
+                fi
+            else
+                if [ $notify = 1 ]; then
+                    notify-send "Download Failed" "$output"
+                else
+                    echo "Download Failed: $output"
                 fi
             fi
         elif [ -e "$f" ]; then

--- a/plugins/dragdrop
+++ b/plugins/dragdrop
@@ -66,8 +66,7 @@ elif [ "$resp" = "r" ]; then
     "$dnd" --print-path --target 2>/dev/null | while read -r f
     do
         if printf "%s" "$f" | grep -q '^\(https\?\|ftps\?\|s\?ftp\)://' ; then
-            output=$(curl -fsLJOS "$f" 2>&1)
-            if [ $? = 0 ]; then
+            if output=$(curl -fsLJOS "$f" 2>&1); then
                 filename="$(basename "${f%%\?*}")"
                 add_file "$PWD/$filename"
                 if [ $notify = 1 ]; then

--- a/plugins/dragdrop
+++ b/plugins/dragdrop
@@ -14,6 +14,9 @@
 # Shell: POSIX compliant
 # Author: 0xACE
 
+# If you want system notification, put this equal to 1
+notify=0
+
 selection=${NNN_SEL:-${XDG_CONFIG_HOME:-$HOME/.config}/nnn/.selection}
 resp=f
 all=
@@ -54,24 +57,29 @@ fi
 
 if [ "$resp" = "s" ]; then
     use_all
-    sed -z 's|'"$PWD/"'||g' < "$selection" | xargs -0 "$dnd" "$all" &
+    sed -z 's|'"$PWD/"'||g' < "$selection" | xargs -0 "$dnd" "$all" 2>/dev/null &
 elif [ "$resp" = "d" ]; then
     use_all
-    "$dnd" "$all" "$PWD/"* &
+    "$dnd" "$all" "$PWD/"* 2>/dev/null &
 elif [ "$resp" = "r" ]; then
     true > "$selection"
-    "$dnd" --print-path --target | while read -r f
+    "$dnd" --print-path --target 2>/dev/null | while read -r f
     do
-            if printf "%s" "$f" | grep '^\(https\?\|ftps\?\|s\?ftp\):\/\/' ; then
-                    curl -LJO "$f"
-                    add_file "$PWD/$(basename "$f")"
-            elif [ -e "$f" ]; then
-                    add_file "$f"
+        if printf "%s" "$f" | grep -q '^\(https\?\|ftps\?\|s\?ftp\)://' ; then
+            if curl -fsLJO "$f"; then
+                filename="$(basename "${f%%\?*}")"
+                add_file "$PWD/$filename"
+                if [ $notify = 1 ]; then
+                    notify-send "Download Complete" "Finished downloading $filename"
+                fi
             fi
+        elif [ -e "$f" ]; then
+            add_file "$f"
+        fi
     done &
 else
     if [ -n "$1" ] && [ -e "$1" ]; then
-        "$dnd" "$1" &
+        "$dnd" "$1" 2>/dev/null &
     fi
 fi
 

--- a/plugins/dragdrop
+++ b/plugins/dragdrop
@@ -66,7 +66,7 @@ elif [ "$resp" = "r" ]; then
     "$dnd" --print-path --target 2>/dev/null | while read -r f
     do
         if printf "%s" "$f" | grep -q '^\(https\?\|ftps\?\|s\?ftp\)://' ; then
-            if curl -fsLJO "$f"; then
+            if curl -fsLJOS "$f"; then
                 filename="$(basename "${f%%\?*}")"
                 add_file "$PWD/$filename"
                 if [ $notify = 1 ]; then


### PR DESCRIPTION
This pull request introduces some quality-of-life improvements for the dragdrop plugin.

- Similarly to the kdeconnect plugin, there is a new option for system notifications when downloading files from a URL. This is useful when downloading larger files. It is disabled by default.
- With newer fontconfig versions, dragon now gives a warning. I also get some GTK warnings that interfere with the nnn UI. Sending dragon's stderr to /dev/null will prevent that issue.
- Remove unneeded backslashes from regular expression to prevent "stray \ before /" warnings.
- Use quiet flag with grep and silent flag with curl to prevent their outputs and avoid clashing with nnn's UI.
- Some small modifications to the way curl is called inside the script to better handle failed downloads. Errors will still be shown, but adding the file to the selection and the success notification will be skipped on failure.
- Strip query parameters from filenames so they are correctly added to selection.

### Before:
Dragon:
<img width="440" height="482" alt="dragon-warnings" src="https://github.com/user-attachments/assets/db8ced0e-fc3d-4f63-9d95-2e5cfb8db712" />

Curl:
<img width="457" height="490" alt="curl-before" src="https://github.com/user-attachments/assets/3d140099-627e-40c3-be51-f9b53ab57871" />

Pasting file with URL parameters:
<img width="462" height="494" alt="url-parameters-before" src="https://github.com/user-attachments/assets/f6644356-34f4-4fdb-a3ae-84b9b13cbedc" />


### After:
Dragon:
<img width="550" height="490" alt="no-warnings" src="https://github.com/user-attachments/assets/975e8d6b-d9fe-4f27-a6fe-f74ba9d8c9ff" />

Curl:
<img width="453" height="486" alt="curl-after" src="https://github.com/user-attachments/assets/4cf322a9-eb33-4545-8346-3e298f050f7a" />

Pasting file with URL parameters:
<img width="460" height="488" alt="url-parameters-after" src="https://github.com/user-attachments/assets/0b973d13-ccfa-465e-855a-9506b16f61aa" />




