### PR TITLE
suedit plugin: prefer sudoedit over sudo and remove nonexistent -E flag for sudoedit

### DIFF
--- a/plugins/suedit
+++ b/plugins/suedit
@@ -7,10 +7,10 @@
 
 EDITOR="${EDITOR:-vim}"
 
-if type sudo >/dev/null 2>&1; then
+if type sudoedit >/dev/null 2>&1; then
+    sudoedit "$1"
+elif type sudo >/dev/null 2>&1; then
     sudo -E "$EDITOR" "$1"
-elif type sudoedit >/dev/null 2>&1; then
-    sudoedit -E "$1"
 elif type doas >/dev/null 2>&1; then
     doas "$EDITOR" "$1"
 fi


### PR DESCRIPTION
Security-wise it's preferable to use sudoedit over sudo, as the editor isn't opened with root permissions. This is better for security as, for example, editors like vim which can execute shell commands won't be able to do so with root permissions. Also, the PR removes the -E flag from sudoedit as no such option exists for that command.