### PR TITLE
The →  key acts like the “e” key. useful with preview-tui.

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -7473,6 +7473,11 @@ nochange:
 		if (presel)
 			presel = 0;
 
+		/* CUSTOM: treat right-arrow (SEL_NAV_IN) as edit when hovering a file,
+		 * but keep normal directory navigation when hovering a directory. */
+		if (sel == SEL_NAV_IN && ndents && !(pdents[cur].flags & DIR_OR_DIRLNK))
+			sel = SEL_EDIT;
+
 		switch (sel) {
 #ifndef NOMOUSE
 		case SEL_CLICK:


### PR DESCRIPTION
This small patch keeps the normal directory navigation with →
but when the cursor is on a regular file, → behaves like e (open in editor).

This improves UX while keeping backward compatibility and minimal changes.