### PR TITLE
fix(xdgdefault): filter application list by current file's MIME type

### DIFF
--- a/plugins/xdgdefault
+++ b/plugins/xdgdefault
@@ -40,6 +40,8 @@ while [ -n "$dirs" ]; do
     dirs=${dirs#*:}
 done
 
+# see PR #2102
+# shellcheck disable=SC2038
 app=$(find "$@" -iname '*.desktop' -exec grep -l "MimeType=.*$ftype" {} + 2>/dev/null \
     | xargs -I {} grep '^Name=' {} /dev/null \
     | sort -u -t ':' -k 1,1 \


### PR DESCRIPTION
Currently this plugin lists all installed applications found in `$XDG_DATA_DIRS`, regardless of whether they can actually open the selected file. And I think there's no reason to list all of them.

I updated the `find` command pipeline to filter `.desktop` files based on the detected filetype. So now plugin displays only applications that explicitly support selected file's MIME type.