### PR TITLE
Fix eza in preview-tui

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -389,9 +389,9 @@ preview_file() {
         elif exists tree; then
             fifo_pager tree --filelimit "$(find . -maxdepth 1 | wc -l)" -L 3 -C -F --dirsfirst --noreport
         elif exists exa; then
-            fifo_pager exa -T --group-directories-first --colour=always -L 3
+            fifo_pager exa -T --group-directories-first --colour=always -L 3 .
         elif exists eza; then # eza is a community fork of exa (exa is unmaintained)
-            fifo_pager eza -T --group-directories-first --colour=always -L 3
+            fifo_pager eza -T --group-directories-first --colour=always -L 3 .
         else
             fifo_pager ls -F --group-directories-first --color=always
         fi


### PR DESCRIPTION
For some reason eza outputs nothing when run inside preview-tui and only behaved weirder when I tried to debug it. Simply specifying the path as suggested in the eza issue seems to completely fix it.
https://github.com/eza-community/eza/issues/1567
this guy probably also had the same problem https://github.com/jarun/nnn/issues/2076