### PR TITLE
preview-tui: clear stale kitty graphics placements when switching away from video previews

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -516,6 +516,7 @@ preview_fifo() {
         if [ -n "$selection" ]; then
             pidkill "$PREVIEWPID"
             [ -p "$FIFO_UEBERZUG" ] && ueberzug_remove
+            [ -n "$KITTY_LISTEN_ON" ] && kitty +kitten icat --clear --stdin=no >/dev/tty 2>/dev/null
             [ "$selection" = "close" ] && break
             preview_file "$selection"
             printf "%s" "$selection" > "$CURSEL"


### PR DESCRIPTION
When using Kitty with mpv video previews, switching away from a video preview causes the preview pane to freeze. The stale video frame remains rendered on screen, and subsequent previews fail to display until another non-video graphics file is reselected (images, PDFs, etc.), at which point the stale frame is cleared but the other file still isn't shown, requiring one more switch to another file (this time of any type) for previews to show up again.

The root cause is that `pidkill "$PREVIEWPID"` kills the mpv process but does not clear the Kitty graphics protocol placement it created. Unlike terminal text content, Kitty graphics placements are not removed by `clear`. The existing cleanup logic handles ueberzug by calling `ueberzug_remove` but has no equivalent path for Kitty graphics. This patch adds an explicit `icat --clear` call in `preview_fifo()` after killing the preview process, matching the existing pattern used for ueberzug cleanup.