### PR TITLE
fix: escape archive name and selpath in archivefix: escape archive name and selpath in archive_selection() to prevent shell injection_selection() to preven…

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -2897,8 +2897,20 @@ static char *get_archive_cmd(const char *archive)
 
 static void archive_selection(const char *cmd, const char *archive)
 {
-	size_t len = xstrlen(patterns[P_ARCHIVE_CMD]) + xstrlen(cmd) + xstrlen(archive)
-	            + xstrlen(selpath) + 1;
+	char esc_archive[PATH_MAX * 4 + 2];
+	char esc_sel[PATH_MAX * 4 + 2];
+
+	if (shell_escape(esc_archive, sizeof(esc_archive), archive) < 0) {
+		printwarn(NULL);
+		return;
+	}
+
+	if (shell_escape(esc_sel, sizeof(esc_sel), selpath) < 0) {
+		printwarn(NULL);
+		return;
+	}
+
+	size_t len = xstrlen(cmd) + xstrlen(esc_archive) + xstrlen(esc_sel) + 20;
 	char *buf = malloc(len);
 	if (!buf) {
 		DPRINTF_S(strerror(errno));
@@ -2906,7 +2918,7 @@ static void archive_selection(const char *cmd, const char *archive)
 		return;
 	}
 
-	snprintf(buf, len, patterns[P_ARCHIVE_CMD], cmd, archive, selpath);
+	snprintf(buf, len, "xargs -0 %s %s < %s", cmd, esc_archive, esc_sel);
 	spawn(utils[UTIL_SH_EXEC], buf, NULL, NULL, F_CLI | F_CONFIRM);
 	free(buf);
 }


### PR DESCRIPTION
## Summary

`archive_selection()` builds a shell command string by embedding the user-supplied archive name unquoted:
```c
// patterns[P_ARCHIVE_CMD] = "xargs -0 %s %s < '%s'"
snprintf(buf, len, patterns[P_ARCHIVE_CMD], cmd, archive, selpath);
spawn(utils[UTIL_SH_EXEC], buf, NULL, NULL, F_CLI | F_CONFIRM);
```

Because the archive name is not escaped, shell metacharacters in the name are interpreted by `sh -c`, enabling arbitrary command execution. For example, typing `out`touch /tmp/PWNED`.tar` at the archive name prompt causes `touch /tmp/PWNED` to execute.

## Fix

Apply `shell_escape()` to both `archive` and `selpath` before embedding them in the command string. `shell_escape()` already exists in the codebase (added in commit 57882ffa) and is correctly used in `write_lastdir()`, it was simply not applied here.

## Testing

- Injection payload `out`touch /tmp/PWNED`.tar` → `/tmp/PWNED` **not created** (blocked)
- Normal archive name `test_archive.tar` → archive **created successfully** (no regression)

## Note

The single-file archive path (`c` key) is unaffected as it passes arguments via `execvp()` directly.