### PR TITLE
preview-tui: clear sixel graphics when switching previews

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -508,6 +508,10 @@ winch_handler() {
         pkill -f "tail --follow $FIFO_UEBERZUG"
         tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser json &
     fi
+    # Clear sixel graphics for external image previewers
+    case "${NNN_PREVIEWIMGPROG%% *}" in
+        img2sixel|chafa|timg) printf '\033[?8015l\033[?8015h' >/dev/tty 2>/dev/null ;;
+    esac
     preview_file "$(cat "$CURSEL")"
 }
 
@@ -517,6 +521,10 @@ preview_fifo() {
             pidkill "$PREVIEWPID"
             [ -p "$FIFO_UEBERZUG" ] && ueberzug_remove
             [ -n "$KITTY_LISTEN_ON" ] && kitty +kitten icat --clear --stdin=no >/dev/tty 2>/dev/null
+            # Clear sixel graphics for external image previewers (e.g. img2sixel, chafa)
+            case "${NNN_PREVIEWIMGPROG%% *}" in
+                img2sixel|chafa|timg) printf '\033[?8015l\033[?8015h' >/dev/tty 2>/dev/null ;;
+            esac
             [ "$selection" = "close" ] && break
             preview_file "$selection"
             printf "%s" "$selection" > "$CURSEL"


### PR DESCRIPTION
## Summary

- Clear sixel graphics layer when switching between file previews in `preview-tui`, fixing the issue where img2sixel/chafa/timg previews stack on top of each other in tmux

## Changes

| File | Change |
|------|--------|
| `plugins/preview-tui` | Added DECSDM reset (`\033[?8015l`/`\033[?8015h`) in `preview_fifo()` and `winch_handler()` to clear sixel graphics before rendering new previews |

## Root Cause

The existing cleanup in `preview_fifo()` handles kitty icat (`kitty +kitten icat --clear`) and ueberzug (`ueberzug_remove`), but has no equivalent for sixel-based image previewers. The terminal `clear` command only clears the text layer, leaving sixel graphics from the previous preview visible.

This follows the same pattern established in PR #2116 which added kitty graphics cleanup.

## Test Plan

- [x] `shellcheck` passes on modified plugin
- [ ] Manual: set `NNN_PREVIEWIMGPROG=img2sixel`, open nnn with `preview-tui` in tmux, navigate between image files and verify previous preview is cleared
- [ ] Manual: same test with `chafa` as previewer
- [ ] Manual: verify non-sixel previewers (kitty icat, ueberzug) are unaffected

Fixes #2134