### PR TITLE
docs: add link to a live browser demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Runs on the Pi, [Termux](https://www.youtube.com/embed/AbaauM7gUJw) (Android), L
 
 [_(more use cases)_](https://github.com/jarun/nnn/wiki/Basic-use-cases#the_nnn-magic)
 
+Online demo: <a href="https://build.demoshell.com/launch?snapshot=demoshell%2Ftui%3Annn"><img src="https://build.demoshell.com/v1/embed/badge.svg" alt="Live demo by Demoshell" align="absmiddle"></a>
+
 ## Features
 
 - Quality


### PR DESCRIPTION
Adds a "Online demo" link to the README, pointing to nnn running in the browser: https://gallery.demoshell.com/app/nnn/

It's the actual nnn binary inside an emulated Linux VM (WebAssembly), with the stock config and no plugins. The image rebuilds automatically when a new release is published.

Disclosure: I run the service behind this (Demoshell). The demo and hosting are free for open-source projects (the badge carries a small attribution).

The demo page also allows the maintainer to claim that VM if you'd like to support it. Otherwise I'll keep taking care of it.