### PR TITLE
Revert leaveok() optimization and left-half-block hover marker (restore screen reader / braille support)

### DIFF
--- a/src/nnn.c
+++ b/src/nnn.c
@@ -2439,7 +2439,6 @@ static bool initcurses(void *oldmask)
 	mouseinterval(0);
 #endif
 	curs_set(FALSE); /* Hide cursor */
-	leaveok(stdscr, TRUE); /* Skip precise cursor placement during normal redraws */
 
 	char *colors = getenv(env_cfg[NNN_COLORS]);
 
@@ -3872,7 +3871,6 @@ static int filterentries(char *path, char *lastname)
 
 	cleartimeout();
 	curs_set(TRUE);
-	leaveok(stdscr, FALSE);
 	showfilter(ln);
 
 	while ((r = get_wch(ch)) != ERR) {
@@ -4079,7 +4077,6 @@ end:
 	copycurname(lastname);
 
 	curs_set(FALSE);
-	leaveok(stdscr, TRUE);
 	settimeout();
 
 	/* Return keys for navigation etc. */
@@ -4198,7 +4195,6 @@ static char *xreadline(const char *prefill, const char *prompt)
 
 	x = getcurx(stdscr);
 	curs_set(TRUE);
-	leaveok(stdscr, FALSE);
 
 	while (1) {
 		buf[len] = ' ';
@@ -4422,7 +4418,6 @@ static char *xreadline(const char *prefill, const char *prompt)
 
 END:
 	curs_set(FALSE);
-	leaveok(stdscr, TRUE);
 	settimeout();
 	printmsg("");
 

--- a/src/nnn.c
+++ b/src/nnn.c
@@ -7980,11 +7980,7 @@ static inline void markhovered(void)
 {
 	if (cfg.showdetail && ndents) { /* Bold forward arrowhead */
 		tocursor();
-#ifdef ICONS_ENABLED
-		addstr("▌");
-#else
 		addch('>' | A_BOLD);
-#endif
 	}
 }
 


### PR DESCRIPTION
Reverts both changes discussed in #2161, as requested.

**1. `Revert "Use leaveok() to improve ncurses performance"` (99a6a2e)**

`leaveok(stdscr, TRUE)` lets ncurses leave the physical cursor wherever the last
write ended rather than moving it to the logical cursor position on refresh, which
turned the deliberate `tocursor()` calls in `statusbar()` and `markhovered()` into
no-ops for the real terminal cursor. Braille displays and terminal screen readers
follow the hardware cursor to know which row is current — the reverse-video
highlight conveys nothing to them — so `nnn` lost the "Basic support for screen
readers and braille displays" feature (#534) in v5.3.

**2. `Revert "Use left half block to mark hovered file"` (9de5bc8)**

In detail mode that marker is the only *textual* indication of the hovered row.
`>` is spoken by screen readers; U+258C LEFT HALF BLOCK is announced as "left half
block" or dropped entirely, depending on the reader's symbol table. This one is
unreleased, so no released version is affected.

### Testing

Driving `nnn -d` in a pty and dumping the raw byte stream for one `j` keypress.

Before (v5.3 / master) — the redraw ends on the status bar and the cursor stays there:

```
... \r ESC[24d ... 2 ESC[39m ESC(B ESC[m
```

After this PR — a trailing `ESC[4d BS` puts the cursor on column 1 of the hovered row:

```
... \r ESC[24d ... 2 ESC[4d BS ESC[39m ESC(B ESC[m
                     ^^^^^^^^^ lands on hovered entry
```

Builds clean with `make O_NORL=0` and `make O_NERD=1 O_NORL=0` (`-Wall -Wextra
-Wshadow`, no new warnings).

If you would rather keep the optimization and gate the cursor placement behind an
option or an environment variable instead, I am happy to rework this — just say
which you prefer.

## AI Usage Disclosure

This change was developed with assistance from Claude (Anthropic). All code was
reviewed and tested by the author before submission.
