### PR TITLE
fix: handle backslashes in fish quitcd paths

### DIFF
--- a/misc/quitcd/quitcd.fish
+++ b/misc/quitcd/quitcd.fish
@@ -29,8 +29,13 @@ function n --wraps nnn --description 'support nnn quit and change directory'
     # making an infinitely recursive alias
     command nnn $argv
 
-    if test -e $NNN_TMPFILE
-        source $NNN_TMPFILE
-        rm -- $NNN_TMPFILE
+    if test -e "$NNN_TMPFILE"
+        # nnn writes POSIX shell syntax, whose quoting differs from fish.
+        # NUL separation preserves paths containing (or ending in) newlines.
+        set -l lastdir (command sh -c '. "$1" && printf "%s\000" "$PWD"' sh "$NNN_TMPFILE" | string split0)
+        if set -q lastdir[1]
+            cd -- "$lastdir"
+        end
+        rm -- "$NNN_TMPFILE"
     end
 end

--- a/misc/test/test-quitcd-fish.py
+++ b/misc/test/test-quitcd-fish.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Run with python3 misc/test/test-quitcd-fish.py (requires fish on PATH)."""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+FISH = shutil.which(os.environ.get("FISH", "fish"))
+WRAPPER = Path(__file__).resolve().parents[1] / "quitcd" / "quitcd.fish"
+
+
+@unittest.skipUnless(FISH, "fish is required")
+class QuitcdFishTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.home = self.root / "home"
+        self.home.mkdir()
+        self.config = self.root / "config space\\"
+        (self.config / "nnn").mkdir(parents=True)
+        self.lastd = self.config / "nnn" / ".lastd"
+        self.fixture = self.root / "lastd-fixture"
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        stub = self.bin / "nnn"
+        stub.write_text('#!/bin/sh\n'
+                        'if test -e "$NNN_TEST_LASTD"; then\n'
+                        '    cp -- "$NNN_TEST_LASTD" "$NNN_TMPFILE"\n'
+                        'fi\n')
+        stub.chmod(0o755)
+        self.env = {"PATH": str(self.bin) + os.pathsep + os.defpath,
+                    "HOME": str(self.home), "XDG_CONFIG_HOME": str(self.config),
+                    "NNN_TEST_LASTD": str(self.fixture), "LC_ALL": "C.UTF-8"}
+        # Preserve a caller's library path when testing an isolated fish build.
+        if "LD_LIBRARY_PATH" in os.environ:
+            self.env["LD_LIBRARY_PATH"] = os.environ["LD_LIBRARY_PATH"]
+
+    def run_wrapper(self):
+        result = subprocess.run(
+            [FISH, "--no-config", "-c",
+             'source "$argv[1]"; n; printf "%s\\0" "$PWD"', str(WRAPPER)],
+            cwd=self.root, env=self.env, capture_output=True, timeout=10)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(self.lastd.exists())
+        return result
+
+    def write_lastd(self, target):
+        # write_lastdir() emits a POSIX single-quoted cd command, without newline.
+        self.fixture.write_text("cd '" + str(target).replace("'", "'\\''") + "'")
+
+    def test_paths(self):
+        for name in ("plain", "with spaces", "trailing\\", "double\\\\slash",
+                     "quote'", "slash\\'quote", "tab\there", "中文",
+                     "line\nbreak", "trailing\n", "trailing\n\n", "$dollar;*()"):
+            with self.subTest(name=name):
+                target = self.root / name
+                target.mkdir()
+                self.write_lastd(target)
+                result = self.run_wrapper()
+                self.assertEqual(result.stdout, os.fsencode(target) + b"\0")
+                self.assertEqual(result.stderr, b"")
+
+    def test_missing_directory_does_not_change_directory(self):
+        self.write_lastd(self.root / "missing")
+        result = self.run_wrapper()
+        self.assertEqual(result.stdout, os.fsencode(self.root) + b"\0")
+        self.assertNotEqual(result.stderr, b"")
+
+    def test_no_lastd_does_not_change_directory(self):
+        result = self.run_wrapper()
+        self.assertEqual(result.stdout, os.fsencode(self.root) + b"\0")
+        self.assertEqual(result.stderr, b"")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The fish quitcd wrapper currently sources the POSIX shell command written by nnn directly in fish. Backslashes have different meanings inside single quotes in the two shells: a directory ending in a backslash produces an unbalanced-quote error, while repeated backslashes can change the target path.

Read the existing command with POSIX sh and pass its resulting directory back to fish using a NUL separator. This preserves embedded and trailing newlines, and a guard keeps the current directory unchanged if the target is unavailable. The nnn output format and other shell wrappers are unchanged.

Validation on Linux with fish 3.6.0:
- The regression script covers 12 path cases plus missing-directory and missing-file handling; three backslash cases fail before the fix and all cases pass after it.
- Seven real nnn/PTY exit scenarios pass, including HOME and XDG_CONFIG_HOME configurations; the unchanged wrapper fails four of them.
- All 15 combinations in `make checkpatches` build successfully; default build with `-Werror`, fish syntax validation and Python syntax validation pass.

Run the regression with `python3 misc/test/test-quitcd-fish.py` (fish required). macOS, other fish versions and the complete upstream CI matrix were not exercised.

Refs #1957 and the corresponding item in #1546.
