### PR TITLE
stop recommending allow_remote_control yes

### DIFF
--- a/plugins/preview-tui
+++ b/plugins/preview-tui
@@ -68,7 +68,7 @@
 #   different terminal window will be used ($NNN_TERMINAL).
 #
 #   Kitty users need something similar to the following in their kitty.conf:
-#   - `allow_remote_control yes`
+#   - `allow_remote_control socket-only`
 #   - `listen_on unix:$TMPDIR/kitty`
 #   - `enabled_layouts splits` (optional)
 #   With ImageMagick installed, this terminal can use the icat kitten to display images.


### PR DESCRIPTION
`allow_remote_control yes` allows kitty to be controlled by any command that prints escape codes, including `cat`ing a file, which is a major security problem and that functionality is not used by preview-tui.

Relevant documentation: https://sw.kovidgoyal.net/kitty/conf/#opt-kitty.allow_remote_control

The [wiki page](https://github.com/jarun/nnn/wiki/Live-previews) doesn't specifically say to use `yes` but it should also be updated to recommend using `socket-only`